### PR TITLE
Automated testing for the new REMIND Library

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,6 +1,5 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.git$
-^tests/testgdxs/.*\.gdx$
 ^\.buildlibrary$
 ^.*\.zenodo.json$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,6 +1,6 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.git$
-^inst/extdata/old\.gdx$
+^tests/testgdxs/.*\.gdx$
 ^\.buildlibrary$
 ^.*\.zenodo.json$

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3361140'
+ValidationKey: '3548250'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3174410'
+ValidationKey: '3361140'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.8.0
-Date: 2021-02-15
+Version: 1.9.0
+Date: 2021-02-17
 Authors@R: as.person(c(
 	   "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.7.0
+Version: 1.8.0
 Date: 2021-02-15
 Authors@R: as.person(c(
 	   "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.8.0**
+R package **remind2**, version **1.9.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)    
 
@@ -38,6 +38,10 @@ The package comes with a vignette describing the basic functionality of the pack
 vignette("remind_summary") # Adding plots to the REMIND_summary.pdf
 ```
 
+## Automated Tests
+
+When building the library, GDXs are downloaded to test the creation of the reporting. For requests to update the test specimen, please file an issue or contact the package maintainer. Note that you can also manually place one or multiple GDX files in the `tests/testgdxs` folder to have them tested instead of the default ones.
+
 ## Questions / Problems
 
 In case of questions / problems please contact Renato Rodrigues <renato.rodrigues@pik-potsdam.de>.
@@ -47,7 +51,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 To cite package **remind2** in publications use:
 
 Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R
-package version 1.8.0.
+package version 1.9.0.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +60,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2021},
-  note = {R package version 1.8.0},
+  note = {R package version 1.9.0},
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.7.0**
+R package **remind2**, version **1.8.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)    
 
@@ -46,7 +46,8 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R package version 1.7.0.
+Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R
+package version 1.8.0.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2021},
-  note = {R package version 1.7.0},
+  note = {R package version 1.8.0},
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ vignette("remind_summary") # Adding plots to the REMIND_summary.pdf
 
 When building the library, GDXs are downloaded to test the creation of the reporting. For requests to update the test specimen, please file an issue or contact the package maintainer. Note that you can also manually place one or multiple GDX files in the `tests/testgdxs` folder to have them tested instead of the default ones.
 
+
+If you want to disable the GDX test, please uncomment the line following the comment `## uncomment to skip test` in `tests/testthat/test-convGDX2mif.R`.
+
 ## Questions / Problems
 
 In case of questions / problems please contact Renato Rodrigues <renato.rodrigues@pik-potsdam.de>.

--- a/tests/testthat/test-convGDX2mif.R
+++ b/tests/testthat/test-convGDX2mif.R
@@ -32,11 +32,19 @@ check_eqs <- function(dt, eqs, scope="all", sens=1e-10){
 
 test_that("Test if REMIND reporting is produced as it should and check data integrity", {
 
+  testgdx_folder <- "../testgdxs/"
+
   ## add GDXs for comparison here:
   my_gdxs <- list.files("../testgdxs/", "*.gdx", full.names = TRUE)
   if(length(my_gdxs) == 0){
-    succeed("No GDXs found to test.")
+    dir.create(testgdx_folder, showWarnings = FALSE)
+    download.file("https://rse.pik-potsdam.de/data/example/fulldata_REMIND21.gdx",
+                  file.path(testgdx_folder, "fulldata.gdx"))
+    if(md5sum(file.path(testgdx_folder, "fulldata.gdx")) != "8ce7127ec26cb8bb36cecee3f4fa97f1"){
+      fail("Checksum for downloaded GDX not correct.")
+    }
   }
+  my_gdxs <- list.files("../testgdxs/", "*.gdx", full.names = TRUE)
 
   ## please add variable tests below
   check_integrity <- function(out){
@@ -47,7 +55,7 @@ test_that("Test if REMIND reporting is produced as it should and check data inte
     check_eqs(
       dt_wide,
       list(
-        `FE|Transport|Liquids (EJ/yr)` = "`FE|Transport|Liquids|Oil (EJ/yr)` + `FE|Transport|Liquids|Biomass (EJ/yr)` + `FE|Transport|Liquids|Hydrogen (EJ/yr)` + `FE|Transport|Liquids|Coal (EJ/yr)`"
+        `FE|Transport|+|Liquids (EJ/yr)` = "`FE|Transport|Liquids|+|Biomass (EJ/yr)` + `FE|Transport|Liquids|+|Fossil (EJ/yr)`"
       ))
 
   }
@@ -76,7 +84,6 @@ test_that("Test if REMIND reporting is produced as it should and check data inte
       foreach (i = gdxs) %dopar% {
         cat(paste0(i,"\n"))
         a <- convGDX2MIF(i)
-        ## run integrity test only on fulldata
         check_integrity(a)
         cat("\n")
       }
@@ -84,8 +91,7 @@ test_that("Test if REMIND reporting is produced as it should and check data inte
       for (i in gdxs) {
         cat(paste0(i,"\n"))
         a <- convGDX2MIF(i)
-        if("fulldata.gdx" == basename(i))
-          check_integrity(a)
+        check_integrity(a)
         cat("\n")
       }
     }

--- a/tests/testthat/test-convGDX2mif.R
+++ b/tests/testthat/test-convGDX2mif.R
@@ -1,13 +1,56 @@
 context("REMIND reporting")
 
-test_that("Test if REMIND reporting is produced as it should", {
+library(gdx)
+library(data.table)
 
-  library(gdx)
+## Check REMIND output. dt is a data.table in *wide* format,
+## i.e., variables are columns. `eqs` is a list of equations of the form
+## list(LHS = "RHS", ...). The scope determines if the equations
+## should be checked for regions ("regional"), only globally ("world") or
+## both ("all"). Sensitivity determines the allowed offset when comparing
+## LHS to RHS
+check_eqs <- function(dt, eqs, scope="all", sens=1e-10){
+  if(scope == "regional"){
+    dt <- dt[all_regi != "World"]
+  }else if(scope == "world"){
+    dt <- dt[all_regi == "World"]
+  }
+
+  for(LHS in names(eqs)){
+    exp <- parse(text=eqs[[LHS]])
+    dt[, total := eval(exp), by=.(all_regi, ttot, scenario, model)]
+
+    dt[, diff := total - get(LHS)]
+    if(nrow(dt[abs(diff) > sens]) > 0){
+      fail(
+        sprintf("Check on data integrity failed for %s", LHS))
+    }
+    ## expect_equal(dt[["total"]], dt[[LHS]], tolerance = sens)
+  }
+
+}
+
+test_that("Test if REMIND reporting is produced as it should and check data integrity", {
 
   ## add GDXs for comparison here:
-  my_gdxs <- c(
-    # system.file('extdata/old.gdx', package = 'remind'),
-    NULL)
+  my_gdxs <- list.files("../testgdxs/", "*.gdx", full.names = TRUE)
+  if(length(my_gdxs) == 0){
+    succeed("No GDXs found to test.")
+  }
+
+  ## please add variable tests below
+  check_integrity <- function(out){
+    dt <- rmndt::magpie2dt(out)
+    stopifnot(!(c("total", "diff") %in% unique(dt[["variable"]])))
+    dt_wide <- data.table::dcast(dt, ... ~ variable)
+
+    check_eqs(
+      dt_wide,
+      list(
+        `FE|Transport|Liquids (EJ/yr)` = "`FE|Transport|Liquids|Oil (EJ/yr)` + `FE|Transport|Liquids|Biomass (EJ/yr)` + `FE|Transport|Liquids|Hydrogen (EJ/yr)` + `FE|Transport|Liquids|Coal (EJ/yr)`"
+      ))
+
+  }
 
   runParallelTests <- function(gdxs=NULL,cores=0,par=FALSE){
 
@@ -33,18 +76,22 @@ test_that("Test if REMIND reporting is produced as it should", {
       foreach (i = gdxs) %dopar% {
         cat(paste0(i,"\n"))
         a <- convGDX2MIF(i)
+        ## run integrity test only on fulldata
+        check_integrity(a)
         cat("\n")
       }
     } else {
       for (i in gdxs) {
         cat(paste0(i,"\n"))
         a <- convGDX2MIF(i)
+        if("fulldata.gdx" == basename(i))
+          check_integrity(a)
         cat("\n")
       }
     }
     unlink(new_gdxs)
   }
 
-  expect_error(runParallelTests(my_gdxs),regexp = NA)
+  runParallelTests(my_gdxs)
 
 })

--- a/tests/testthat/test-convGDX2mif.R
+++ b/tests/testthat/test-convGDX2mif.R
@@ -32,6 +32,9 @@ check_eqs <- function(dt, eqs, scope="all", sens=1e-10){
 
 test_that("Test if REMIND reporting is produced as it should and check data integrity", {
 
+  ## uncomment to skip test
+  ## success("Skip GDX test")
+
   testgdx_folder <- "../testgdxs/"
 
   ## add GDXs for comparison here:
@@ -40,9 +43,8 @@ test_that("Test if REMIND reporting is produced as it should and check data inte
     dir.create(testgdx_folder, showWarnings = FALSE)
     download.file("https://rse.pik-potsdam.de/data/example/fulldata_REMIND21.gdx",
                   file.path(testgdx_folder, "fulldata.gdx"))
-    if(md5sum(file.path(testgdx_folder, "fulldata.gdx")) != "8ce7127ec26cb8bb36cecee3f4fa97f1"){
-      fail("Checksum for downloaded GDX not correct.")
-    }
+    expect_equal(md5sum(file.path(testgdx_folder, "fulldata.gdx")),
+                 "8ce7127ec26cb8bb36cecee3f4fa97f1")
   }
   my_gdxs <- list.files("../testgdxs/", "*.gdx", full.names = TRUE)
 


### PR DESCRIPTION
The test tries to create a reporting for a GDX from here: `/p/projects/remind/users/renatoro/REMIND-EU_Calibration/v12_2021_02_10_mergeVersion/output/SSP2-Base_2021-02-10_15.40.32/fulldata.gdx`. The GDX is hosted [by RSE](https://rse.pik-potsdam.de/data/example/) and downloaded from there for the test.

- If a GDX is placed in `tests/testgdxs`, no download takes place in the provided GDX is used.
- README is updated.
- A template is provided for summation tests on the reporting output.

A test on correct summation of |+| variables is in preparation by @giannou .