### PR TITLE
Make sure to download GDX files for tests in binary mode.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3548250'
+ValidationKey: '3567116'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.9.0
-Date: 2021-02-17
+Version: 1.9.1
+Date: 2021-02-18
 Authors@R: as.person(c(
 	   "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.9.0**
+R package **remind2**, version **1.9.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)    
 
@@ -54,7 +54,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 To cite package **remind2** in publications use:
 
 Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R
-package version 1.9.0.
+package version 1.9.1.
 
 A BibTeX entry for LaTeX users is
 
@@ -63,7 +63,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2021},
-  note = {R package version 1.9.0},
+  note = {R package version 1.9.1},
 }
 ```
 

--- a/tests/testthat/test-convGDX2mif.R
+++ b/tests/testthat/test-convGDX2mif.R
@@ -42,9 +42,10 @@ test_that("Test if REMIND reporting is produced as it should and check data inte
   if(length(my_gdxs) == 0){
     dir.create(testgdx_folder, showWarnings = FALSE)
     download.file("https://rse.pik-potsdam.de/data/example/fulldata_REMIND21.gdx",
-                  file.path(testgdx_folder, "fulldata.gdx"))
-    expect_equal(md5sum(file.path(testgdx_folder, "fulldata.gdx")),
-                 "8ce7127ec26cb8bb36cecee3f4fa97f1")
+                  file.path(testgdx_folder, "fulldata.gdx"), mode="wb")
+    if(md5sum(file.path(testgdx_folder, "fulldata.gdx")) != "8ce7127ec26cb8bb36cecee3f4fa97f1"){
+      fail("MD5 hash not correct. Downloading GDX failed.")
+    }
   }
   my_gdxs <- list.files("../testgdxs/", "*.gdx", full.names = TRUE)
 


### PR DESCRIPTION
@Renato-Rodrigues experienced problems with the MD5 hash checking (on windows, I suppose). I forced *binary-mode* for the download, so that silently replaced line-endings should not come in the way.