### PR TITLE
Cleaned up tests

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '20563377'
+ValidationKey: '20586462'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.10.1
-Date: 2021-02-19
+Version: 1.10.2
+Date: 2021-02-23
 Authors@R: as.person(c(
 	   "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.
@@ -44,5 +44,6 @@ License: LGPL-3
 RoxygenNote: 7.1.1
 Suggests:
 	testthat,
+	doParallel,
 	sr15data
 VignetteBuilder: knitr

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.10.1**
+R package **remind2**, version **1.10.2**
 
-  
+[![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)    
 
 ## Purpose and Functionality
 
@@ -46,8 +46,8 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2021). _remind2: The REMIND R package (2nd
-generation)_. R package version 1.10.1.
+Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R
+package version 1.10.2.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2021},
-  note = {R package version 1.10.1},
+  note = {R package version 1.10.2},
 }
 ```
 

--- a/tests/testthat/test-convGDX2mif.R
+++ b/tests/testthat/test-convGDX2mif.R
@@ -2,6 +2,7 @@ context("REMIND reporting")
 
 library(gdx)
 library(data.table)
+library(doParallel)
 
 ## Check REMIND output. dt is a data.table in *wide* format,
 ## i.e., variables are columns. `eqs` is a list of equations of the form
@@ -43,9 +44,6 @@ test_that("Test if REMIND reporting is produced as it should and check data inte
     dir.create(testgdx_folder, showWarnings = FALSE)
     download.file("https://rse.pik-potsdam.de/data/example/fulldata_REMIND21.gdx",
                   file.path(testgdx_folder, "fulldata.gdx"), mode="wb")
-    if(md5sum(file.path(testgdx_folder, "fulldata.gdx")) != "8ce7127ec26cb8bb36cecee3f4fa97f1"){
-      fail("MD5 hash not correct. Downloading GDX failed.")
-    }
   }
   my_gdxs <- list.files("../testgdxs/", "*.gdx", full.names = TRUE)
 
@@ -63,44 +61,11 @@ test_that("Test if REMIND reporting is produced as it should and check data inte
 
   }
 
-  runParallelTests <- function(gdxs=NULL,cores=0,par=FALSE){
-
-    new_gdxs <- NULL
-    if (is.null(gdxs) & file.exists("/p/projects/")) {
-      gdxs <- system2("find","/p/projects/remind/runs/r* -name fulldata.gdx",stdout=T,stderr = FALSE)
-      gdxs <- grep("magpie",gdxs,v=T,invert=T,ignore.case = T)
-      gd <- length(gdxs)
-      gdxs <- gdxs[c(gd)] # floor(gd/2),floor(3*gd/4),
-      gdxs <- c(gdxs,"/p/projects/remind/runs/0AA_DONTDELETEME_MO/fulldata.gdx")
-      brnam <- unlist(strsplit(gdxs,split="/"))
-      new_gdxs <- paste0(brnam[grep("fulldata.gdx",brnam)-1],".gdx")
-      file.copy(gdxs,new_gdxs,overwrite = TRUE)
-      gdxs <- new_gdxs
-    }
-    i <- NULL
-    # if (Sys.info()["sysname"]=="Linux") {
-    #   par <- TRUE
-    #   library(foreach)
-    #   doMC::registerDoMC(cores = 2)
-    # }
-    if (par) {
-      foreach (i = gdxs) %dopar% {
-        cat(paste0(i,"\n"))
-        a <- convGDX2MIF(i)
-        check_integrity(a)
-        cat("\n")
-      }
-    } else {
-      for (i in gdxs) {
-        cat(paste0(i,"\n"))
-        a <- convGDX2MIF(i)
-        check_integrity(a)
-        cat("\n")
-      }
-    }
-    unlink(new_gdxs)
+  foreach (i = my_gdxs) %dopar% {
+    cat(paste0(i,"\n"))
+    a <- convGDX2MIF(i)
+    check_integrity(a)
+    cat("\n")
   }
-
-  runParallelTests(my_gdxs)
 
 })


### PR DESCRIPTION
- removed cluster specific GDX setup, 
- removed MD5 check (now that we load from RSE anyways). This makes updating the GDX easier.
- using `doParallel` by default and adding it to *Suggests*