### PR TITLE
Add a test for compareScenarios.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '20623824'
+ValidationKey: '20737020'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '20737020'
+ValidationKey: '20924960'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.10.4",
+  "version": "1.11.0",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.11.0
-Date: 2021-02-24
+Version: 1.12.0
+Date: 2021-02-25
 Authors@R: as.person(c(
 	   "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.10.4
-Date: 2021-02-23
+Version: 1.11.0
+Date: 2021-02-24
 Authors@R: as.person(c(
 	   "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.
@@ -44,6 +44,6 @@ License: LGPL-3
 RoxygenNote: 7.1.1
 Suggests:
 	testthat,
-	doParallel,
+	stringi,
 	sr15data
 VignetteBuilder: knitr

--- a/R/compareScenarios.R
+++ b/R/compareScenarios.R
@@ -361,7 +361,7 @@ compareScenarios <- function(mif, hist,
   swfigure(sw,print,p,sw_option="height=9,width=8")
 
   p <- mipBarYearData(var[,y_bar,][mainReg,,,invert=TRUE]) +
-        guides(fill=guide_legend(ncol=3))
+    guides(fill=guide_legend(ncol=3))
 
   swfigure(sw,print,p,sw_option="height=9,width=8")
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.10.4**
+R package **remind2**, version **1.11.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)    
 
@@ -46,7 +46,8 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R package version 1.10.4.
+Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R
+package version 1.11.0.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2021},
-  note = {R package version 1.10.4},
+  note = {R package version 1.11.0},
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.11.0**
+R package **remind2**, version **1.12.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)    
 
@@ -46,7 +46,8 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R package version 1.11.0.
+Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R
+package version 1.12.0.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2021},
-  note = {R package version 1.11.0},
+  note = {R package version 1.12.0},
 }
 ```
 


### PR DESCRIPTION
this test runs atop the GDX test, to avoid having to produce the
reporting twice. Runtime of the build is now **9m 40s** which is substantial. I wonder what to do about this, since I think it is important to have a (rudimentary) test on `compareScenarios`. One possibility would be to perform this check only in the CI on github actions. Would require some "skip_if" clause.