### PR TITLE
Disable tests when interactively checking the package in RStudio

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '20924960'
+ValidationKey: '20943643'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.12.0
+Version: 1.12.1
 Date: 2021-02-25
 Authors@R: as.person(c(
 	   "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.12.0**
+R package **remind2**, version **1.12.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)    
 
@@ -46,8 +46,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R
-package version 1.12.0.
+Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R package version 1.12.1.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2021},
-  note = {R package version 1.12.0},
+  note = {R package version 1.12.1},
 }
 ```
 

--- a/remind2.Rproj
+++ b/remind2.Rproj
@@ -15,3 +15,4 @@ LaTeX: pdfLaTeX
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageCheckArgs: --no-tests


### PR DESCRIPTION
 They still run with lucode2::buildlibrary(). Users who don't use RStudio can disable the tests with the `args="no-tests"` argument in `devtools::check`