### PR TITLE
Removed filtering of EU only regions in reportEDGET.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '23448708'
+ValidationKey: '23471196'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.25.2",
+  "version": "1.25.3",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.25.2
-Date: 2021-04-12
+Version: 1.25.3
+Date: 2021-04-15
 Authors@R: as.person(c(
 	   "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/R/reportEDGETransport.R
+++ b/R/reportEDGETransport.R
@@ -27,7 +27,6 @@ reportEDGETransport <- function(output_folder=".",
   }
   gdx <- file.path(output_folder, "fulldata.gdx")
 
-  regionSubsetList <- toolRegionSubsets(gdx)
   sub_folder = "EDGE-T/"
 
   ## NULL Definitons for codeCheck compliance
@@ -428,12 +427,6 @@ reportEDGETransport <- function(output_folder=".",
             unit="EJ/yr", value=sum(value)),
           by=c("model", "scenario", "region", "period")]), use.names = TRUE)
 
-
-
-  if(!is.null(regionSubsetList)){
-    regions2report = c(regionSubsetList$EUR, regionSubsetList$NEU)
-    toMIF <- toMIF[region %in% regions2report]
-  }
 
   ## Make sure there are no duplicates!
   idx <- anyDuplicated(toMIF, by = c("region", "variable", "period"))


### PR DESCRIPTION
Probably at some point it was required to include EU-only regions in the mif file. This PR removes the now deprecated filtering.