### PR TITLE
Adding further emissions variables (demand-side, industry CCS, non-energy use)

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '25012152'
+ValidationKey: '25190660'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.33.1",
+  "version": "1.34.0",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.33.1
-Date: 2021-06-14
+Version: 1.34.0
+Date: 2021-06-21
 Authors@R: as.person(c(
 	   "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/R/compareScenarios.R
+++ b/R/compareScenarios.R
@@ -315,7 +315,7 @@ compareScenarios <- function(mif, hist,
              "Emi|GHG|Gross|Energy|Supply|Non-electric (Mt CO2eq/yr)",
              "Emi|GHG|Energy|Demand|Transport (Mt CO2eq/yr)",
              "Emi|GHG|Energy|Demand|Buildings (Mt CO2eq/yr)",
-             "Emi|GHG|Energy|Demand|Industry (Mt CO2eq/yr)",
+             "Emi|GHG|Gross|Energy|Demand|Industry (Mt CO2eq/yr)",
              "Emi|GHG|Industrial Processes (Mt CO2eq/yr)",
              "Emi|GHG|Agriculture (Mt CO2eq/yr)",
              "Emi|GHG|Land-Use Change (Mt CO2eq/yr)",
@@ -356,7 +356,7 @@ compareScenarios <- function(mif, hist,
              "Emi|CO2|Land-Use Change (Mt CO2/yr)",
              "Emi|CO2|Industrial Processes (Mt CO2/yr)",
              "Emi|CO2|Energy|Demand|Transport (Mt CO2/yr)",
-             "Emi|CO2|Energy|Demand|Industry (Mt CO2/yr)",
+             "Emi|CO2|Gross|Energy|Demand|Industry (Mt CO2/yr)",
              "Emi|CO2|Energy|Demand|Buildings (Mt CO2/yr)",
              "Emi|CO2|Gross|Energy|Supply|Non-electric (Mt CO2/yr)",
              "Emi|CO2|Gross|Energy|Supply|Electricity (Mt CO2/yr)",
@@ -1694,6 +1694,14 @@ hlines=if(all(names(targets) %in% getNames(histData, dim=3) & !is.na(histData[ma
   swfigure(sw,print,p,sw_option="height=8,width=8")
   p <- mipLineHistorical(data[,,"Emi|CO2|Energy|Demand|Industry (Mt CO2/yr)"][mainReg,,,invert=TRUE],x_hist=histData[,,"Emi|CO2|Industry|Direct (Mt CO2/yr)"][mainReg,,,invert=TRUE],
                          ylab='Emi|CO2|Energy|Demand|Industry [Mt CO2/yr]',scales="free_y",plot.priority=c("x_hist","x","x_proj"),facet.ncol=3)
+  swfigure(sw,print,p,sw_option="height=9,width=8")
+  
+  
+  p <- mipLineHistorical(data[mainReg,,"Emi|CO2|Gross|Energy|Demand|Industry (Mt CO2/yr)"],x_hist=histData[mainReg,,"Emi|CO2|Industry|Direct (Mt CO2/yr)"],
+                         ylab='Emi|CO2|Gross|Energy|Demand|Industry [Mt CO2/yr]',scales="free_y",plot.priority=c("x_hist","x","x_proj"))
+  swfigure(sw,print,p,sw_option="height=8,width=8")
+  p <- mipLineHistorical(data[,,"Emi|CO2|Gross|Energy|Demand|Industry (Mt CO2/yr)"][mainReg,,,invert=TRUE],x_hist=histData[,,"Emi|CO2|Industry|Direct (Mt CO2/yr)"][mainReg,,,invert=TRUE],
+                         ylab='Emi|CO2|Gross|Energy|Demand|Industry [Mt CO2/yr]',scales="free_y",plot.priority=c("x_hist","x","x_proj"),facet.ncol=3)
   swfigure(sw,print,p,sw_option="height=9,width=8")
   
   swlatex(sw,"\\subsubsection{Transport}")

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -1042,10 +1042,10 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL,t=c(seq(2005,2060,
   
   # split into electric and non-electric energy supply emissions
   out <- mbind(out,
-               setNames(out[,,"Emi|CO2|Energy|Supply|+|Electricity w/ couple prod (Mt CO2/yr)"],
+               setNames(out[,,"Emi|CO2|Gross|Energy|Supply|+|Electricity (Mt CO2/yr)"],
                         "Emi|GHG|Gross|Energy|Supply|Electricity (Mt CO2eq/yr)"),              
-               setNames(out[,,"Emi|GHG|Energy|+|Supply (Mt CO2eq/yr)"]
-                        - out[,,"Emi|CO2|Energy|Supply|+|Electricity w/ couple prod (Mt CO2/yr)"],
+               setNames(out[,,"Emi|GHG|Gross|Energy|+|Supply (Mt CO2eq/yr)"]
+                        - out[,,"Emi|CO2|Gross|Energy|Supply|+|Electricity (Mt CO2/yr)"],
                         "Emi|GHG|Gross|Energy|Supply|Non-electric (Mt CO2eq/yr)"))
   
   

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -34,7 +34,7 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL,t=c(seq(2005,2060,
   }
   
   # intialize varibles used in dplyr operations
-  all_enty2 <- all_te <- all_enty <- all_enty1 <- emi_sectors <- all_emiMkt <- NULL
+  all_enty2 <- all_te <- all_enty <- all_enty1 <- emi_sectors <- all_emiMkt <- all_in <- NULL
   
   # Read Data from GDX ----
   

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -1268,9 +1268,14 @@ reportFE <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2070,211
       out.nechem <- suppressWarnings(as.magpie(df.out.nechem, spatial=1, temporal=2, datacol=4))
       out.nechem <- out.nechem[getRegions(out), getYears(out),]
       
-  
+      # set NAs to zero
+      out.nechem[is.na( out.nechem)] <- 0
+      
+      
       # bind FE non-energy use to output object
       out <- mbind(out, out.nechem)
+      
+
       
       # add further FE variables needed in ARIADNE
       out <- mbind(out,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.33.1**
+R package **remind2**, version **1.34.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)    
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R package version 1.33.1.
+Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R package version 1.34.0.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2021},
-  note = {R package version 1.33.1},
+  note = {R package version 1.34.0},
 }
 ```
 


### PR DESCRIPTION
This PR contains:

* addition demand-side emissions by FE carrier
* addition of variables for industry captured carbon differentiating between fossil, biomass, synfuel origin
* addition of gross variables excl. industry BECCS
* addition of sets of emissions variables excl. non-energy use/feedstocks from industry (e.g. ``Emi|CO2|w/o Non-energy Use|...``)

It is added due to current project demands and to be refined later. 

Although not very urgent, I list some points below that we should jointly tackle at some point.

On the gross emissions:

@amerfort and @strefler:

I realized that given our current definition of "gross" (net emissions + BECCS), some sectoral gross emissions variables can actually become negative due to the presence of synfuel CO2. 

This can happen due to two reasons:

We currently use the convention of attributing synfuel CO2 emissions to the synfuel producer (``Emi|CO2|Energy|Supply|Liquids/Gases``), while considering CO2 capture as CO2 negative for the CO2 provider and synfuels as CO2-neutral to the user on the demand-side. So if

1.) CO2 is captured e.g. from biomass to hydrogen to be used for liquid synfuels, these emissions are deduced from ``Emi|CO2|Energy|Supply|Hydrogen`` and  added to ``Emi|CO2|Energy|Supply|Liquids``. The supply variable here becomes negative without the presence of biomass. 

2.) Synfuels used in industry are considered CO2-neutral there, so if industry captures these emissions, this is counted as negative emissions for industry. 

Even with a different attribution convention of synfuel CO2, I think, it can always happen that gross emissions variables can be negative. We might want to have a meeting at some point to discuss this in depth, 

On the industry CC(S):

@amerfort and @silviamade

In general, the above variable additions all depend on the reporting of industry CC(S). It would be good to go through this again at some point with you guys in a reporting task force. It might actually also make sense to eventually calculate industry CC(S) variables in the REMIND code itself because they are also needed there to define emissions targets in the regipol module. 

On the non-energy use emissions:

@silviamade 

For now the whole non-energy use reporting is  a rough estimation which only works for REMIND-EU with industry fixed_shares. However, the structure is set to work with all realizations/setups once we have a common formulation/reporting of feedstocks for all realizations. This would be another point worth tackling in the reporting task force. 