### PR TITLE
Hotfix to make earlier commit compatible with industry subsectors

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '25230942'
+ValidationKey: '25251086'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.34.2",
+  "version": "1.34.3",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.34.2
-Date: 2021-06-23
+Version: 1.34.3
+Date: 2021-06-24
 Authors@R: as.person(c(
 	   "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -1485,9 +1485,6 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL,t=c(seq(2005,2060,
                          "Emi|CO2|Energy and Industrial Processes (Mt CO2/yr)",
                          "Emi|CO2|Energy|+|Demand (Mt CO2/yr)",
                          "Emi|CO2|Energy|Demand|+|Transport (Mt CO2/yr)",
-                         "Emi|CO2|Energy|Demand|++|Liquids (Mt CO2/yr)",
-                         # Note: this assumes that all bunker fuels are liquids
-                         "Emi|CO2|Energy|Demand|Transport|+|Liquids (Mt CO2/yr)", 
                          "Emi|CO2|++|Outside ETS and ESR (Mt CO2/yr)",
                          
                          # Gross CO2 Emissions
@@ -1495,6 +1492,13 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL,t=c(seq(2005,2060,
                          "Emi|CO2|Gross|Energy (Mt CO2/yr)",
                          "Emi|CO2|Gross|Energy and Industrial Processes (Mt CO2/yr)",
                          "Emi|CO2|Gross|Energy|Demand|+|Transport (Mt CO2/yr)")
+  
+  # TODO: remove this if clause once the below variable are there for industry subsectors, too
+  if (module2realisation["industry",2] == "fixed_shares") {
+    # Note: this assumes that all bunker fuels are liquids
+    emi.vars.wBunkers <- c( emi.vars.wBunkers,     "Emi|CO2|Energy|Demand|Transport|+|Liquids (Mt CO2/yr)",  "Emi|CO2|Energy|Demand|++|Liquids (Mt CO2/yr)")
+    
+  }
   
   
   

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.34.2**
+R package **remind2**, version **1.34.3**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)   [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/remind2)
+[![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)    
 
 ## Purpose and Functionality
 
@@ -46,9 +46,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2021). _remind2: The REMIND R
-package (2nd generation)_. R package version
-1.34.2.
+Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R package version 1.34.3.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2021},
-  note = {R package version 1.34.2},
+  note = {R package version 1.34.3},
 }
 ```
 


### PR DESCRIPTION
This is a hotfix to make [this commit](https://github.com/pik-piam/remind2/commit/c4a519e5ba9b951e23e068e554fe6d09220c7864) compatible with GDXs of the industry subsectors realization. 