### PR TITLE
report floor space also with simple buildings

### DIFF
--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -617,10 +617,6 @@ reportFE <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2070,211
                                             "FE|Buildings|Space Heating|Hydrogen (EJ/yr)")],dim=3,na.rm=T),        "FE|Buildings|Space Heating (EJ/yr)")
                   
     )
-    
-    out <-  mbind(out,
-                   setNames(p36_floorspace,        "Energy Service|Buildings|Floor Space (bn m2/yr)")
-                   )
   }
   
   # ---- Industry Module ----

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -489,6 +489,11 @@ reportFE <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2070,211
   
   # ---- Buildings Module ----
   
+  p36_floorspace <- readGDX(gdx, "p36_floorspace")[, t, ]
+  if (!is.null(p36_floorspace)) {
+    out <- mbind(out, setNames(p36_floorspace, "Energy Service|Buildings|Floor Space (bn m2/yr)"))
+  }
+
   if (buil_mod %in% c("simple")){
     
     if("feelhpb" %in% getNames(vm_cesIO)){
@@ -510,9 +515,6 @@ reportFE <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2070,211
     # sets
     ppfen_build <- readGDX(gdx,c("ppfen_buildings_dyn36","ppfen_buildings_dyn28","ppfen_buildings"),format="first_found", react = "silent")
     esty_build <-  readGDX(gdx,c("esty_dyn36"),format="first_found", react = "silent")
-    
-    # parameter
-    p36_floorspace <- readGDX(gdx,"p36_floorspace")[,t,]
     
     #var
     v_prodEs <- readGDX(gdx,name = c("v_prodEs"), field="l",restore_zeros = F, format = "first_found", react = "silent")[,t,]* TWa_2_EJ


### PR DESCRIPTION
If the parameter p36_floorspace exists, it will no be reported independent of the buildings realisation. Simple buildings will soon also have this parameter.