### PR TITLE
Annual milege added to EDGE-T reporting.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '25644845'
+ValidationKey: '25663660'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.36.3",
+  "version": "1.36.4",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.36.3
+Version: 1.36.4
 Date: 2021-07-07
 Authors@R: as.person(c(
 	   "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -1102,11 +1102,6 @@ reportFE <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2070,211
     
     vm_demFeForEs_trnsp = vm_demFeForEs[fe2es_dyn35]
     
-    if(tran_mod == "edge_esm"){
-      p35_pass_FE_share_transp <- dimSums(vm_demFeForEs_trnsp[,,"esdie_pass_",pmatch=TRUE], dim=3,na.rm=T) /
-        dimSums(vm_demFeForEs_trnsp[,,"esdie_",pmatch=TRUE], dim=3,na.rm=T)
-    }
-    
     out <- mbind(out,
       setNames(dimSums(vm_demFeForEs_trnsp[,,"eselt_frgt_",pmatch=TRUE],dim=3,na.rm=T),"FE|Transport|Freight|Electricity (EJ/yr)"),
       setNames(dimSums(vm_demFeForEs_trnsp[,,"eselt_pass_",pmatch=TRUE],dim=3,na.rm=T),"FE|Transport|Pass|Electricity (EJ/yr)"),


### PR DESCRIPTION
this PR contains:

- annual mileage loaded from input data instead of using estimate
- removed useless lines in `reportFE` in `edge_esm` realization