### PR TITLE
Adapt non-energy use emissions, add waste emissions and minor fixes to capacity variables

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '26031352'
+ValidationKey: '26057103'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.38.2",
+  "version": "1.38.3",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.38.2
-Date: 2021-07-28
+Version: 1.38.3
+Date: 2021-08-02
 Authors@R: as.person(c(
 	   "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/R/reportCapacity.R
+++ b/R/reportCapacity.R
@@ -118,9 +118,9 @@ reportCapacity <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5
   tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("h22ch4")], dim = 3), "Cap|Gases|Hydrogen (GW)"))
 
   # liquids
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("refliq", "bioftrec", "bioftcrec", "coalftrec", "coalftcrec", "MeOH")], dim = 3), "Cap|Liquids (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("refliq", "bioftrec", "bioftcrec", "coalftrec", "coalftcrec", "MeOH","biodiesel", "bioeths", "bioethl")], dim = 3), "Cap|Liquids (GW)"))
   tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("refliq")], dim = 3), "Cap|Liquids|Oil (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("bioftrec", "bioftcrec")], dim = 3), "Cap|Liquids|Biomass (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("bioftrec", "bioftcrec","biodiesel", "bioeths", "bioethl")], dim = 3), "Cap|Liquids|Biomass (GW)"))
   tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("coalftrec", "coalftcrec")], dim = 3), "Cap|Liquids|Coal (GW)"))
   tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("MeOH")], dim = 3), "Cap|Liquids|Hydrogen (GW)"))
 

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -1458,7 +1458,8 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL,t=c(seq(2005,2060,
     
     
     # variable names, insert w/o non-energy use
-    names.wNonEn <- c(emi.vars.wNonEn.inclWaste,emi.vars.wNonEn.exclWaste) 
+    emi.vars.wNonEn <- c(emi.vars.wNonEn.inclWaste,emi.vars.wNonEn.exclWaste) 
+    names.wNonEn <- emi.vars.wNonEn
     names.wNonEn <- gsub("Emi\\|CO2","Emi|CO2|w/o Non-energy Use",names.wNonEn)
     names.wNonEn <- gsub("Emi\\|GHG","Emi|GHG|w/o Non-energy Use",names.wNonEn)
     
@@ -1467,7 +1468,7 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL,t=c(seq(2005,2060,
     names.wNonEn <- gsub("\\|\\++\\|","\\|",names.wNonEn)
     
     # calulate emissions variables with non-energy use
-    out.wNonEn <- out[,,c(emi.vars.wNonEn.inclWaste,emi.vars.wNonEn.exclWaste)]
+    out.wNonEn <- out[,,emi.vars.wNonEn]
     # for aggregate emissions: substract non-energy use carbon and add waste incineration emissions  
     out.wNonEn[,,emi.vars.wNonEn.inclWaste] <- out.wNonEn[,,emi.vars.wNonEn.inclWaste] - out[,,"Emi|CO2|Non-energy Use|Energy|Demand|Industry (Mt CO2/yr)"] + out[,,"Emi|CO2|w/o Non-energy Use|Waste Incineration (Mt CO2/yr)"]  
     # for energy related emissions: substract non-energy use carbon
@@ -1476,7 +1477,7 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL,t=c(seq(2005,2060,
     
     
     # insert "w/o Non-energy Use" label in variable names
-    out.wNonEn <- setNames(out.wNonEn[,,c(emi.vars.wNonEn.inclWaste,emi.vars.wNonEn.exclWaste)], names.wNonEn)
+    out.wNonEn <- setNames(out.wNonEn[,,emi.vars.wNonEn], names.wNonEn)
 
 
     out <- mbind(out,out.wNonEn)

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -1376,18 +1376,22 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL,t=c(seq(2005,2060,
   # (Note: The non-energy use variables are so far only available for REMIND-EU runs and industry fixed_shares)
   # TODO: add non-energy use variables for all regionmappings and sector realizations
 
-  # Note: Non-energy use emissions should not be confused with process emissions. Non-energy use emissions are emissions/CO2 content from/of FE carriers which are used as feedstocks in industry.
+  # Note: Non-energy use emissions should not be confused with process emissions. Non-energy use emissions are emissions/carbon flow of FE carriers which are used as feedstocks in industry.
   if ("FE|Non-energy Use|Industry (EJ/yr)" %in% getNames(output)) {
 
+    
+    # calculate non-energy use emissions (= feedstock carbon content) as industry emissions before CCS per energy carrier * share of feedstocks in final energy
+    # take industry emissions before CCS as feedstocks cannot be used for CCS
+    # this is a temporary approximation in the reporting, but should eventually be adapted in REMIND by having a seperate feedstock FE of which the carbon cannot be captured
     out <- mbind(out,
                  # liquids
-                 setNames(out[,,"Emi|CO2|Energy|Demand|Industry|+|Liquids (Mt CO2/yr)"]*output[getRegions(out),,"FE|Non-energy Use|Industry|+|Liquids (EJ/yr)"]/output[getRegions(out),,"FE|Industry|+|Liquids (EJ/yr)"],
+                 setNames( dimSums(mselect(EmiFeCarrier, all_enty1 = c("fehos"), emi_sectors = "indst"), dim = 3)*GtC_2_MtCO2*output[getRegions(out),,"FE|Non-energy Use|Industry|+|Liquids (EJ/yr)"]/output[getRegions(out),,"FE|Industry|+|Liquids (EJ/yr)"],
                           "Emi|CO2|Non-energy Use|Energy|Demand|Industry|Liquids (Mt CO2/yr)"),
                  # gases
-                 setNames(out[,,"Emi|CO2|Energy|Demand|Industry|+|Gases (Mt CO2/yr)"]*output[getRegions(out),,"FE|Non-energy Use|Industry|+|Gases (EJ/yr)"]/output[getRegions(out),,"FE|Industry|+|Gases (EJ/yr)"],
+                 setNames(dimSums(mselect(EmiFeCarrier, all_enty1 = c("fegas"), emi_sectors = "indst"), dim = 3)*GtC_2_MtCO2*output[getRegions(out),,"FE|Non-energy Use|Industry|+|Gases (EJ/yr)"]/output[getRegions(out),,"FE|Industry|+|Gases (EJ/yr)"],
                           "Emi|CO2|Non-energy Use|Energy|Demand|Industry|Gases (Mt CO2/yr)"),
                  # solids
-                 setNames(out[,,"Emi|CO2|Energy|Demand|Industry|+|Solids (Mt CO2/yr)"]*output[getRegions(out),,"FE|Non-energy Use|Industry|+|Solids (EJ/yr)"]/output[getRegions(out),,"FE|Industry|+|Solids (EJ/yr)"],
+                 setNames(dimSums(mselect(EmiFeCarrier, all_enty1 = c("fesos"), emi_sectors = "indst"), dim = 3)*GtC_2_MtCO2*output[getRegions(out),,"FE|Non-energy Use|Industry|+|Solids (EJ/yr)"]/output[getRegions(out),,"FE|Industry|+|Solids (EJ/yr)"],
                           "Emi|CO2|Non-energy Use|Energy|Demand|Industry|Solids (Mt CO2/yr)"))
     
     # total non-energy use emissions

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.38.2**
+R package **remind2**, version **1.38.3**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)   [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/remind2)
+[![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)   [![R build status](https://github.com/fschreyer/remind2/workflows/check/badge.svg)](https://github.com/fschreyer/remind2/actions) [![codecov](https://codecov.io/gh/fschreyer/remind2/branch/master/graph/badge.svg)](https://codecov.io/gh/fschreyer/remind2)
 
 ## Purpose and Functionality
 
@@ -46,9 +46,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2021). _remind2: The REMIND R
-package (2nd generation)_. R package version
-1.38.2.
+Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R package version 1.38.3.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2021},
-  note = {R package version 1.38.2},
+  note = {R package version 1.38.3},
 }
 ```
 


### PR DESCRIPTION
This
* corrects some capacity variables for some bio-technologies which had not been included before
* adapts calculation of non-energy use emissions (= carbon content of industry feedstocks) to avoid negative non-energy use emissions
* adds half of non-energy use emissions as waste incineration emissions

However, the non-energy use part in the reporting is a temporary solution and should be removed once feedstocks are properly in REMIND. 