### PR TITLE
bug fix for issue 89

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '26805744'
+ValidationKey: '26824608'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.42.1",
+  "version": "1.42.2",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.42.1
+Version: 1.42.2
 Date: 2021-08-25
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))

--- a/R/compareScenarios.R
+++ b/R/compareScenarios.R
@@ -175,23 +175,22 @@ compareScenarios <- function(mif, hist,
     warning(paste0("There are repeated scenario names in comparison! Appending numerical value to repeated names"))
   }
   
-  # append numerical value to repeated names
-  mifScenarios_new <- c()
-  for(i in 1:length(uniqueScenarioName)){
-    unique_element = uniqueScenarioName[[i]]
-    k = 1
-    for(j in 1:length(mifScenarios)){
-      if (mifScenarios[[j]] == unique_element){
-        mifScenarios_new <-c(mifScenarios_new, paste0(unique_element, "_", k))
-        k = k + 1
-      }
-    }
+  #get duplicated names
+  dup_names = mifScenarios[duplicated(mifScenarios)]
+  
+  #append a numerical value to the repeated names
+  for (i in 1:length(dup_names)){
+    dup_name = dup_names[[i]]
+    #number of duplicates
+    dupnum <- seq(1,length(mifScenarios[mifScenarios == dup_name]))
+    mifScenarios[mifScenarios == dup_name] <- paste0(mifScenarios[mifScenarios == dup_name], "_", dupnum)  
   }
   
+  mifScenarios_new <- mifScenarios
+  #rename scenario names
   for(i in 1:length(mifScenarios)){
     magclass::getNames(mifData[[i]],dim=1) <- mifScenarios_new[[i]]
   }
-  
   
   # get regions present all mif files
   for(i in 1:length(mifData)){ 

--- a/R/compareScenarios.R
+++ b/R/compareScenarios.R
@@ -171,25 +171,26 @@ compareScenarios <- function(mif, hist,
   
   # print a warning message on repeated names
   uniqueScenarioName = unique(unlist(mifScenarios, use.names = FALSE))
+  
   if (length(uniqueScenarioName) < length(mifScenarios)){
     warning(paste0("There are repeated scenario names in comparison! Appending numerical value to repeated names"))
-  }
-  
-  #get duplicated names
-  dup_names = mifScenarios[duplicated(mifScenarios)]
-  
-  #append a numerical value to the repeated names
-  for (i in 1:length(dup_names)){
-    dup_name = dup_names[[i]]
-    #number of duplicates
-    dupnum <- seq(1,length(mifScenarios[mifScenarios == dup_name]))
-    mifScenarios[mifScenarios == dup_name] <- paste0(mifScenarios[mifScenarios == dup_name], "_", dupnum)  
-  }
-  
-  mifScenarios_new <- mifScenarios
-  #rename scenario names
-  for(i in 1:length(mifScenarios)){
-    magclass::getNames(mifData[[i]],dim=1) <- mifScenarios_new[[i]]
+ 
+    #get duplicated names
+    dup_names = mifScenarios[duplicated(mifScenarios)]
+    
+    #append a numerical value to the repeated names
+    for (i in 1:length(dup_names)){
+      dup_name = dup_names[[i]]
+      #number of duplicates
+      dupnum <- seq(1,length(mifScenarios[mifScenarios == dup_name]))
+      mifScenarios[mifScenarios == dup_name] <- paste0(mifScenarios[mifScenarios == dup_name], "_", dupnum)  
+    }
+    
+    mifScenarios_new <- mifScenarios
+    #rename scenario names
+    for(i in 1:length(mifScenarios)){
+      magclass::getNames(mifData[[i]],dim=1) <- mifScenarios_new[[i]]
+    }
   }
   
   # get regions present all mif files

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.42.1**
+R package **remind2**, version **1.42.2**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)   [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/remind2)
+[![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)    
 
 ## Purpose and Functionality
 
@@ -46,7 +46,10 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R package version 1.42.1, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2021). _remind2: The REMIND R
+package (2nd generation)_. R package version
+1.42.2, <URL:
+https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2021},
-  note = {R package version 1.42.1},
+  note = {R package version 1.42.2},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
now repeated scenario names are not swapped
i.e. original names = (A,B,A)
new names = (A1,B,A2)
(before [bugged version](https://github.com/pik-piam/remind2/issues/89) was A1, A2, B1)