### PR TITLE
Renamed p_PEPrice to pm_PEPrice.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,4 @@
 ^.*\.zenodo.json$
 ^\.github$
 ^codecov\.yml$
+^\.pre-commit-config\.yaml$

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '28478844'
+ValidationKey: '28611480'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+    -   id: check-case-conflict
+    -   id: check-json
+    -   id: check-yaml
+    -   id: check-merge-conflict
+    -   id: fix-byte-order-marker
+    -   id: end-of-file-fixer
+ci:
+    autoupdate_schedule: quarterly

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.50.3",
+  "version": "1.51.0",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.50.3
+Version: 1.51.0
 Date: 2021-11-17
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))

--- a/R/reportPrices.R
+++ b/R/reportPrices.R
@@ -100,7 +100,7 @@ reportPrices <- function(gdx, output=NULL, regionSubsetList=NULL,
 
   pm_FEPrice <- readGDX(gdx, "pm_FEPrice", restore_zeros = FALSE)
   pm_SEPrice <- readGDX(gdx, "pm_SEPrice", restore_zeros = FALSE)
-  p_PEPrice <- readGDX(gdx, "p_PEPrice", restore_zeros = FALSE)
+  pm_PEPrice <- readGDX(gdx, c("p_PEPrice","pm_PEPrice"), restore_zeros = FALSE)
   vm_demFeSector <- readGDX(gdx, "vm_demFeSector", field = "l", restore_zeros = FALSE)[,t,]
   prodSe         <- readGDX(gdx, "vm_prodSe", field = "l", restore_zeros = FALSE)[,t,]
   try(seAgg <- readGDX(gdx, name="seAgg", type="set"))
@@ -225,20 +225,20 @@ reportPrices <- function(gdx, output=NULL, regionSubsetList=NULL,
 
   ## PE Prices
   out <- mbind(out,
-               setNames(mselect(p_PEPrice, all_enty="peoil")*tdptwyr2dpgj,
+               setNames(mselect(pm_PEPrice, all_enty="peoil")*tdptwyr2dpgj,
                         "Price|Primary Energy|Oil (US$2005/GJ)"),
-               setNames(mselect(p_PEPrice, all_enty="pegas")*tdptwyr2dpgj,
+               setNames(mselect(pm_PEPrice, all_enty="pegas")*tdptwyr2dpgj,
                         "Price|Primary Energy|Gas (US$2005/GJ)"),
-               setNames(mselect(p_PEPrice, all_enty="pecoal")*tdptwyr2dpgj,
+               setNames(mselect(pm_PEPrice, all_enty="pecoal")*tdptwyr2dpgj,
                         "Price|Primary Energy|Coal (US$2005/GJ)"),
-               setNames(mselect(p_PEPrice, all_enty="peur")*tdptwyr2dpgj,
+               setNames(mselect(pm_PEPrice, all_enty="peur")*tdptwyr2dpgj,
                         "Price|Primary Energy|Nuclear (US$2005/GJ)"),
                ## only modern (ligno-cellulosic) biomass reported
-               setNames(mselect(p_PEPrice, all_enty="pebiolc")*tdptwyr2dpgj,
+               setNames(mselect(pm_PEPrice, all_enty="pebiolc")*tdptwyr2dpgj,
                         "Price|Primary Energy|Biomass|Modern (US$2005/GJ)"),
-               setNames(mselect(p_PEPrice, all_enty="pebios")*tdptwyr2dpgj,
+               setNames(mselect(pm_PEPrice, all_enty="pebios")*tdptwyr2dpgj,
                         "Price|Primary Energy|Biomass|1st Generation|Sugar and Starch (US$2005/GJ)"),
-               setNames(mselect(p_PEPrice, all_enty="pebios")*tdptwyr2dpgj,
+               setNames(mselect(pm_PEPrice, all_enty="pebios")*tdptwyr2dpgj,
                         "Price|Primary Energy|Biomass|1st Generation|Oil-based (US$2005/GJ)")
                )
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.50.3**
+R package **remind2**, version **1.51.0**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)    [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
 ## Purpose and Functionality
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R package version 1.50.3, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R package version 1.51.0, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2021},
-  note = {R package version 1.50.3},
+  note = {R package version 1.51.0},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
This is in accordance with the changes made in [this commit](https://github.com/remindmodel/remind/pull/485/commits/204794eade58d98c06e5eed84a36de3595237eac) inside [this PR](https://github.com/remindmodel/remind/pull/485/).