### PR TITLE
add ES|Transport and FE|Industry plots

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '26865184'
+ValidationKey: '26888325'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.42.4",
+  "version": "1.42.5",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.42.4
-Date: 2021-08-27
+Version: 1.42.5
+Date: 2021-08-30
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/R/compareScenarios.R
+++ b/R/compareScenarios.R
@@ -3144,6 +3144,64 @@ hlines=if(all(names(targets) %in% getNames(histData, dim=3) & !is.na(histData[ma
 
   }
   
+  # Biomass and Fossil (add historical data when available)
+  
+  items <- c("FE|Industry|Liquids|Biomass (EJ/yr)",
+             "FE|Industry|Solids|Biomass (EJ/yr)",
+             "FE|Industry|Gases|Biomass (EJ/yr)",
+             "FE|Industry|Liquids|Fossil (EJ/yr)",
+             "FE|Industry|Solids|Fossil (EJ/yr)",
+             "FE|Industry|Gases|Fossil (EJ/yr)"
+  )
+  
+  if(all(c(items) %in% magclass::getNames(data,dim=3))){
+
+    p <- mipLineHistorical(data[mainReg,,"FE|Industry|Liquids|Biomass (EJ/yr)"],
+                           ylab='FE|Industry|Liquids|Biomass [EJ/yr]',scales="free_y",plot.priority=c("x_hist","x","x_proj"))
+    swfigure(sw,print,p,sw_option="height=8,width=8")
+    p <- mipLineHistorical(data[,,"FE|Industry|Liquids|Biomass (EJ/yr)"][mainReg,,,invert=TRUE],
+                           ylab='FE|Industry|Liquids|Biomass [EJ/yr]',scales="free_y",plot.priority=c("x_hist","x","x_proj"),facet.ncol=3)
+    swfigure(sw,print,p,sw_option="height=9,width=8")
+    
+    p <- mipLineHistorical(data[mainReg,,"FE|Industry|Gases|Biomass (EJ/yr)"],
+                           ylab='FE|Industry|Gases|Biomass [EJ/yr]',scales="free_y",plot.priority=c("x_hist","x","x_proj"))
+    swfigure(sw,print,p,sw_option="height=8,width=8")
+    p <- mipLineHistorical(data[,,"FE|Industry|Gases|Biomass (EJ/yr)"][mainReg,,,invert=TRUE],
+                           ylab='FE|Industry|Gases|Biomass [EJ/yr]',scales="free_y",plot.priority=c("x_hist","x","x_proj"),facet.ncol=3)
+    swfigure(sw,print,p,sw_option="height=9,width=8")
+    
+    p <- mipLineHistorical(data[mainReg,,"FE|Industry|Solids|Biomass (EJ/yr)"],
+                           ylab='FE|Industry|Solids|Biomass [EJ/yr]',scales="free_y",plot.priority=c("x_hist","x","x_proj"))
+    swfigure(sw,print,p,sw_option="height=8,width=8")
+    p <- mipLineHistorical(data[,,"FE|Industry|Solids|Biomass (EJ/yr)"][mainReg,,,invert=TRUE],
+                           ylab='FE|Industry|Solids|Biomass [EJ/yr]',scales="free_y",plot.priority=c("x_hist","x","x_proj"),facet.ncol=3)
+    swfigure(sw,print,p,sw_option="height=9,width=8")
+    
+    
+    p <- mipLineHistorical(data[mainReg,,"FE|Industry|Liquids|Fossil (EJ/yr)"],
+                           ylab='FE|Industry|Liquids|Fossil [EJ/yr]',scales="free_y",plot.priority=c("x_hist","x","x_proj"))
+    swfigure(sw,print,p,sw_option="height=8,width=8")
+    p <- mipLineHistorical(data[,,"FE|Industry|Liquids|Fossil (EJ/yr)"][mainReg,,,invert=TRUE],
+                           ylab='FE|Industry|Liquids|Fossil [EJ/yr]',scales="free_y",plot.priority=c("x_hist","x","x_proj"),facet.ncol=3)
+    swfigure(sw,print,p,sw_option="height=9,width=8")
+    
+    p <- mipLineHistorical(data[mainReg,,"FE|Industry|Gases|Fossil (EJ/yr)"],
+                           ylab='FE|Industry|Gases|Fossil [EJ/yr]',scales="free_y",plot.priority=c("x_hist","x","x_proj"))
+    swfigure(sw,print,p,sw_option="height=8,width=8")
+    p <- mipLineHistorical(data[,,"FE|Industry|Gases|Fossil (EJ/yr)"][mainReg,,,invert=TRUE],
+                           ylab='FE|Industry|Gases|Fossil [EJ/yr]',scales="free_y",plot.priority=c("x_hist","x","x_proj"),facet.ncol=3)
+    swfigure(sw,print,p,sw_option="height=9,width=8")
+    
+    p <- mipLineHistorical(data[mainReg,,"FE|Industry|Solids|Fossil (EJ/yr)"],
+                           ylab='FE|Industry|Solids|Fossil [EJ/yr]',scales="free_y",plot.priority=c("x_hist","x","x_proj"))
+    swfigure(sw,print,p,sw_option="height=8,width=8")
+    p <- mipLineHistorical(data[,,"FE|Industry|Solids|Fossil (EJ/yr)"][mainReg,,,invert=TRUE],
+                           ylab='FE|Industry|Solids|Fossil [EJ/yr]',scales="free_y",plot.priority=c("x_hist","x","x_proj"),facet.ncol=3)
+    swfigure(sw,print,p,sw_option="height=9,width=8")
+
+  }
+
+  
   # Industry subsectors
   
   items <- c("FE|Industry|Steel (EJ/yr)",
@@ -3402,11 +3460,11 @@ hlines=if(all(names(targets) %in% getNames(histData, dim=3) & !is.na(histData[ma
       "ES|Transport|Pass|non-LDV (bn pkm/yr)"
     )
     
-    p <- lineplots_perCap(data, items, 1e3, "Mobility Demand per Cap. (km/yr)",
+    p <- lineplots_perCap(data, items, 1e3, "Mobility Demand per Cap. [km/yr]",
                           global = T, per_gdp = F)
     swfigure(sw,print,p,sw_option="height=9,width=16")
     
-    p <- lineplots_perCap(data, items, 1e3, "Mobility Demand per Cap. (km/yr)",
+    p <- lineplots_perCap(data, items, 1e3, "Mobility Demand per Cap. [km/yr]",
                           global = F, per_gdp = F)
     swfigure(sw,print,p,sw_option="height=9,width=16")
     
@@ -3415,11 +3473,11 @@ hlines=if(all(names(targets) %in% getNames(histData, dim=3) & !is.na(histData[ma
     
     swlatex(sw,"\\subsubsection{Energy Services for Passanger Transport (per Capita, GDP)}")
     
-    p <- lineplots_perCap(data, items, 1e3, "Mobility Demand per Cap. (km/yr)",
+    p <- lineplots_perCap(data, items, 1e3, "Mobility Demand per Cap. [km/yr]",
                           global = T, per_gdp = T)
     swfigure(sw,print,p,sw_option="height=9,width=16")
     
-    p <- lineplots_perCap(data, items, 1e3, "Mobility Demand per Cap. (km/yr)",
+    p <- lineplots_perCap(data, items, 1e3, "Mobility Demand per Cap. [km/yr]",
                           global = F, per_gdp = T)
     swfigure(sw,print,p,sw_option="height=9,width=16")
     
@@ -3442,12 +3500,12 @@ hlines=if(all(names(targets) %in% getNames(histData, dim=3) & !is.na(histData[ma
       swlatex(sw,"\\twocolumn")
       
       p <- mipBarYearData(var_cap[mainReg,y_bar,], 
-                          ylab = "Mobility Demand for LDV per Capita (km/yr)")
+                          ylab = "Mobility Demand for LDV per Capita [km/yr]")
       p <- p + theme(legend.position="none")
       swfigure(sw,print,p,sw_option="height=4.5,width=7")
       
       p <- mipBarYearData(var_cap[,y_bar,][mainReg,,,invert=TRUE], 
-                          ylab = "Mobility Demand for LDV per Capita (km/yr)") +
+                          ylab = "Mobility Demand for LDV per Capita [km/yr]") +
         guides(fill=guide_legend(ncol=3))
       swfigure(sw,print,p,sw_option="height=9,width=8")
       
@@ -3709,10 +3767,10 @@ hlines=if(all(names(targets) %in% getNames(histData, dim=3) & !is.na(histData[ma
     swfigure(sw,print,p,sw_option="height=9,width=8")
     
     p <- mipLineHistorical(data[mainReg,,"Value Added|Industry|Chemicals (billion US$2005/yr)"],x_hist=histData_NA[mainReg,,"Value Added|Industry|Chemicals (billion US$2005/yr)"],
-                           ylab="Value Added|Industry|Chemicals (billion US$2005/yr)",scales="free_y",plot.priority=c("x_hist","x","x_proj"))
+                           ylab="Value Added|Industry|Chemicals [billion US$2005/yr]",scales="free_y",plot.priority=c("x_hist","x","x_proj"))
     swfigure(sw,print,p,sw_option="height=8,width=8")
     p <- mipLineHistorical(data[,,"Value Added|Industry|Chemicals (billion US$2005/yr)"][mainReg,,,invert=TRUE],x_hist=histData_NA[,,"Value Added|Industry|Chemicals (billion US$2005/yr)"][c(mainReg, "GLO"),,,invert=TRUE],
-                           ylab="Value Added|Industry|Chemicals (billion US$2005/yr)",scales="free_y",plot.priority=c("x_hist","x","x_proj"),facet.ncol=3)
+                           ylab="Value Added|Industry|Chemicals [billion US$2005/yr]",scales="free_y",plot.priority=c("x_hist","x","x_proj"),facet.ncol=3)
     swfigure(sw,print,p,sw_option="height=9,width=8")
   }
   

--- a/R/compareScenarios.R
+++ b/R/compareScenarios.R
@@ -29,16 +29,6 @@
 #' @importFrom utils installed.packages
 #' @importFrom rmndt magpie2dt
 
-# library(magclass)
-# library(lusweave)
-# library(mip)
-# library(luplot)
-# library(ggplot2)
-# library(quitte)
-# library(data.table)
-# library(utils)
-# library(rmndt)
-
 
 compareScenarios <- function(mif, hist,
                              y=c(seq(2005,2060,5),seq(2070,2100,10)),

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.42.4**
+R package **remind2**, version **1.42.5**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)   [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/remind2)
+[![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)    
 
 ## Purpose and Functionality
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R package version 1.42.4, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R package version 1.42.5, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2021},
-  note = {R package version 1.42.4},
+  note = {R package version 1.42.5},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
A new set of bar plots is added for passenger and freight transport per capita.

The structure of the conditionals is changed, so that available transport variables are always plotted for either realization of the transportation model.

Another set of plots is added for the variables FE|Industry|Solids/Liquids/Gases|Biomass/Fossil.