### PR TITLE
Add CES price and CES markup cost as "internal" (diagnostic) variables in reporting

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '28686480'
+ValidationKey: '28825280'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.51.3",
+  "version": "1.52.0",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.51.3
-Date: 2021-11-29
+Version: 1.52.0
+Date: 2021-12-03
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/R/reportPrices.R
+++ b/R/reportPrices.R
@@ -70,7 +70,7 @@ reportPrices <- function(gdx, output=NULL, regionSubsetList=NULL,
   budget.m       <- readGDX(gdx,name='qm_budget',types = "equations",field = "m",format = "first_found")[, t,] # Alternative: calcPrice
   balcapture.m   <- readGDX(gdx,name=c("q_balcapture", "q12_balcapture"), field = "m", restore_zeros = F)[, t,]
 
-  esm2macro.m    <- readGDX(gdx,name='q35_esm2macro',types="equations",field="m",format="first_found")[, t,]
+  esm2macro.m    <- readGDX(gdx,name='q35_esm2macro',types="equations",field="m",format="first_found", react = "silent")[, t,]
 
   cm_emiscen     <- readGDX(gdx,name='cm_emiscen',format="first_found")
 
@@ -461,7 +461,7 @@ reportPrices <- function(gdx, output=NULL, regionSubsetList=NULL,
   
   
   
-  o01_CESderivatives <- readGDX(gdx, "o01_CESderivatives", restore_zeros = T)
+  o01_CESderivatives <- readGDX(gdx, "o01_CESderivatives", restore_zeros = T, react = "silent")
   
   if (!is.null(o01_CESderivatives)) {
   
@@ -481,7 +481,7 @@ reportPrices <- function(gdx, output=NULL, regionSubsetList=NULL,
   # CES Prices
   
   # choose derivative of GDP (inco) with respect to input
-  ces_price <- collapseDim(mselect(o01_CESderivatives, all_in = "inco", all_in1 = ppfEn))
+  ces_price <- collapseDim(mselect(o01_CESderivatives, all_in = "inco", all_in1 = ppfen))
   # variable names
   ces_price <- setNames(ces_price, paste0("Internal|Price|CES|",getNames(ces_price)," (tr US$2005/input unit)"))
   

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.51.3**
+R package **remind2**, version **1.52.0**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)    [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
 ## Purpose and Functionality
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R package version 1.51.3, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R package version 1.52.0, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2021},
-  note = {R package version 1.51.3},
+  note = {R package version 1.52.0},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
CES price and markup cost added only for industry and buildings bottom-most CES nodes as they are needed here. 