### PR TITLE
bugfix in buildings UE reporting

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '29601000'
+ValidationKey: '29624658'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -11,7 +11,7 @@ on:
 env:
   USE_BSPM: "true"
   _R_CHECK_FORCE_SUGGESTS_: "false"
-  NO_BINARY_INSTALL_R_PACKAGES: 'c("madrat", "magclass", "citation", "gms", "goxygen")'
+  NO_BINARY_INSTALL_R_PACKAGES: 'c("madrat", "magclass", "citation", "gms", "goxygen", "raster")'
 
 jobs:
   lucode2-check:
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          ./run.sh install_aptget libhdf5-dev
+          ./run.sh install_aptget libgdal-dev
           ./run.sh install_all
           ./run.sh install_r lucode2 covr
 

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.56.0",
+  "version": "1.56.1",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.56.0
-Date: 2021-12-14
+Version: 1.56.1
+Date: 2021-12-17
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -567,8 +567,9 @@ reportFE <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2070,211
       pm_fedemand <- readGDX(gdx, "pm_fedemand")[, t, ]
       feUeEff_build <- p36_uedemand_build[,, names(carrierBuild)] /
         pm_fedemand[,, names(carrierBuild)]
-      feUeEff_build <- mbind(feUeEff_build,
-        setNames(feUeEff_build[,, "fegab"], "feh2b")) 
+      # assume efficiency for all gases also for H2
+      feUeEff_build[,, "feh2b"] <- setNames(feUeEff_build[,, "fegab"], "feh2b")
+      # apply efficiency to get UE levels
       uedemand_build <- vm_cesIO[,, names(carrierBuild)] * feUeEff_build
       getItems(uedemand_build, 3) <-
         gsub("^FE", "UE", carrierBuild)[getItems(uedemand_build, 3)]
@@ -579,6 +580,12 @@ reportFE <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2070,211
         setNames(dimSums(out[,, gsub("^FE", "UE", carrierBuildHeating)],
                          dim = 3, na.rm = TRUE),
                  "UE|Buildings|Heating (EJ/yr)"))
+      
+      # sum of buildings UE demand
+      out <- mbind(out,
+                   setNames(dimSums(out[,, gsub("^FE", "UE", carrierBuild)],
+                                    dim = 3, na.rm = TRUE),
+                            "UE|Buildings (EJ/yr)"))
     }
   } else if (buil_mod %in% c("services_putty", "services_with_capital")){
     

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.56.0**
+R package **remind2**, version **1.56.1**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)    [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
 ## Purpose and Functionality
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R package version 1.56.0, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2021). _remind2: The REMIND R package (2nd generation)_. R package version 1.56.1, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2021},
-  note = {R package version 1.56.0},
+  note = {R package version 1.56.1},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
- fixes a bug in the UE demand reporting for buildings ([issue#138](https://github.com/pik-piam/remind2/issues/138))
- expands commenting
- adds total useful energy demand in buildings as reporting variable

mind: Right now, useful conventional electricity demand in buildings is always zero due to missing values in the gdx that demand changes in mrremind. Until then, total useful energy in buildings will miss this (significant) fraction.