### PR TITLE
Carbon price aggregation weight. Set default to FE and add gross emissions alternative to the report   

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '30380800'
+ValidationKey: '30570680'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.60.0",
+  "version": "1.61.0",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.60.0
+Version: 1.61.0
 Date: 2021-12-27
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))

--- a/man/reportPrices.Rd
+++ b/man/reportPrices.Rd
@@ -39,5 +39,5 @@ for the reporting
 \code{\link{convGDX2MIF}}
 }
 \author{
-Alois Dirnaichner, Felix Schreyer, David Klein
+Alois Dirnaichner, Felix Schreyer, David Klein, Renato Rodrigues
 }


### PR DESCRIPTION
* changing default carbon price aggregation to use final energy as weight.  
* adding carbon price variables aggregated by Emi|GHG|Gross|Energy with suffix "AggregatedByGrossCO2".