### PR TITLE
update compareScenarios2() to accept relative paths for mifScen, mifHist, and userSectionPath

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '31573949'
+ValidationKey: '31748370'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.66.1",
+  "version": "1.67.0",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.66.1
-Date: 2022-01-17
+Version: 1.67.0
+Date: 2022-01-19
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/R/compareScenarios2.R
+++ b/R/compareScenarios2.R
@@ -83,9 +83,9 @@ compareScenarios2 <- function(
   ) {
   yamlParams <- c(
     list(
-      mifScen = unname(mifScen),
+      mifScen = normalizePath(mifScen, mustWork = TRUE),
       mifScenNames = names(mifScen),
-      mifHist = mifHist),
+      mifHist = normalizePath(mifHist, mustWork = TRUE)),
     list(...))
   outputFormat <- tolower(outputFormat)
   if (outputFormat == "pdf") outputFormat <- "pdf_document"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.66.1**
+R package **remind2**, version **1.67.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.66.1, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.67.0, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.66.1},
+  note = {R package version 1.67.0},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/inst/markdown/compareScenarios2/cs2_main.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_main.Rmd
@@ -286,5 +286,5 @@ if (length(params$sections) == 1 && params$sections == "all") {
 ```
 
 
-```{r include user section, child = params$userSectionPath}
+```{r include user section, child = normalizePath(params$userSectionPath, mustWork = TRUE)}
 ```


### PR DESCRIPTION
So far, `knitr` is looking for files relative to wherever under `.libPaths()` it is installed.

(I will add the `lucode2::buildLibrary()` hubbub after approval to avoid additional conflicts.)