### PR TITLE
Remove knitr == 1.36

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '33722932'
+ValidationKey: '33745509'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.77.2",
+  "version": "1.77.3",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     ggplot2,
     highcharter,
     iamc,
-    knitr(== 1.36),
+    knitr,
     lubridate,
     lucode2,
     luplot,
@@ -45,6 +45,7 @@ Imports:
     withr,
     yaml,
     ymlthis
+Remotes: chroetz/knitr@fix-Sweave2knitr
 Encoding: UTF-8
 License: LGPL-3
 RoxygenNote: 7.1.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.77.2
-Date: 2022-02-08
+Version: 1.77.3
+Date: 2022-02-10
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.
@@ -45,7 +45,6 @@ Imports:
     withr,
     yaml,
     ymlthis
-Remotes: chroetz/knitr@fix-Sweave2knitr
 Encoding: UTF-8
 License: LGPL-3
 RoxygenNote: 7.1.2

--- a/R/compareScenarios.R
+++ b/R/compareScenarios.R
@@ -36,7 +36,6 @@ compareScenarios <- function(mif, hist,
                              y_bar=c(2010,2030,2050,2100),
                              reg=NULL, mainReg="GLO", fileName="CompareScenarios.pdf",
                              sr15marker_RCP=NULL) {
-
   lineplots_perCap <- function(data, vars, percap_factor, ylabstr,
                                global=FALSE, mainReg_plot=mainReg, per_gdp=FALSE, histdata_plot=NULL){
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.77.2**
+R package **remind2**, version **1.77.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.77.2, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.77.3, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.77.2},
+  note = {R package version 1.77.3},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
Requiring knitr 1.36 explicitly leads to check failures during GitHub actions, also installing remind2 with dependencies will never install knitr 1.36. So this PR removes the knitr == 1.36 dependency and instead with this [PR](https://github.com/pik-piam/lusweave/pull/3) `lusweave` will check if the incompatible knitr 1.37 is used and throw a warning.