### PR TITLE
cs2: duplicated scen name bugfix

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '34680100'
+ValidationKey: '34704618'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.82.0",
+  "version": "1.82.1",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.82.0
-Date: 2022-03-04
+Version: 1.82.1
+Date: 2022-03-07
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.82.0**
+R package **remind2**, version **1.82.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 

--- a/inst/markdown/compareScenarios2/cs2_main.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_main.Rmd
@@ -121,7 +121,7 @@ dataScenNested %>%
 
 # Apply renaming of scenario, unnest, and select only relevant columns.
 dataScenNested %>%
-  mutate(scenario = factor(newScenarioName, levels=newScenarioName)) %>%
+  mutate(scenario = factor(newScenarioName, levels = newScenarioName)) %>%
   unnest(data) %>%
   select(model, scenario, region, variable, unit, period, value) ->
   dataScen
@@ -332,6 +332,7 @@ if (length(params$sections) == 1 && params$sections == "all") {
 
 
 ```{r include sections, child = sectionPaths}
+
 ```
 
 

--- a/inst/markdown/compareScenarios2/cs2_main.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_main.Rmd
@@ -92,10 +92,11 @@ tibble(path = unname(params$mifScen)) %>%
   unnest(data) %>%
   nest(data = -c(fileid, path, scenario)) ->
   dataScenNested
-# Add column newScenarioName either with contents of params$mifScenNames or copy names from column scenario.
+# Add column character column "newScenarioName",
+# either with contents of params$mifScenNames or copy names from column scenario.
 if (is.null(params$mifScenNames)) {
   dataScenNested %>%
-    mutate(newScenarioName = scenario) ->
+    mutate(newScenarioName = as.character(scenario)) ->
     dataScenNested
 } else {
   dataScenNested %>%
@@ -120,7 +121,7 @@ dataScenNested %>%
 
 # Apply renaming of scenario, unnest, and select only relevant columns.
 dataScenNested %>%
-  mutate(scenario = newScenarioName) %>%
+  mutate(scenario = factor(newScenarioName, levels=newScenarioName)) %>%
   unnest(data) %>%
   select(model, scenario, region, variable, unit, period, value) ->
   dataScen


### PR DESCRIPTION
fixes a bug when scenario names are duplicated and `make.unique()` fails because `newScenarioName` may be a factor. See also #207 