### PR TITLE
cs2: automatic line break in long words with underscore, dash, ... 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '34939904'
+ValidationKey: '34958976'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.83.2",
+  "version": "1.83.3",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.83.2
+Version: 1.83.3
 Date: 2022-03-21
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.83.2**
+R package **remind2**, version **1.83.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.83.2, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.83.3, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.83.2},
+  note = {R package version 1.83.3},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/inst/markdown/compareScenarios2/cs2_00_info.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_00_info.Rmd
@@ -14,9 +14,16 @@ fileReference %>%
   kable_styling(
     bootstrap_options = c("condensed"),
     latex_options = c("hold_position")) %>%
-  column_spec(2:3, width = "5cm") %>%
-  column_spec(4, width = "15cm") %>%
-  column_spec(1:4, background = bkgndColors)
+  column_spec(1:4, background = bkgndColors) %>% 
+  column_spec(2:3, width = "5.5cm") %>%
+  column_spec(4, width = "15.5cm")
+```
+
+```{r results='asis'}
+cat(
+  "\"Historical\" data is taken from ", 
+  str_replace_all(params$mifHist, fixed("\\"), "/"),
+  ".\n\n")
 ```
 
 

--- a/inst/markdown/compareScenarios2/cs2_99_further_info.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_99_further_info.Rmd
@@ -120,7 +120,11 @@ if (exists("cfgDefault") && !is.null(cfgDefault) &&
   cat(
     "Following GAMS settings are the same in all scenarios and not present in the default file:\n\n")
 
-  showInTables(cfgGmsWideSame[setdiff(names(cfgGmsWideSame), names(cfgDefault$gms))])
+  bind_cols(
+    Source = "Scenarios",
+    cfgGmsWideSame[setdiff(names(cfgGmsWideSame), names(cfgDefault$gms))]
+  ) %>%
+  showInTables()
 }
 ```
 

--- a/inst/markdown/compareScenarios2/cs2_99_further_info.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_99_further_info.Rmd
@@ -75,6 +75,7 @@ if (exists("cfgGms") && !is.null(cfgGms)) {
     left_join(select(fileReference, fileid, newScenarioName), by = "fileid") %>%
     select(-path, -fileid) %>%
     rename(scenario = newScenarioName) %>%
+    filter(! name %in% c("c_expname" , "c_description")) %>% 
     pivot_wider(names_from = name, values_from = value) %>%
     mutate(across(-scenario, unlist)) ->
     cfgGmsWide
@@ -108,7 +109,7 @@ if (exists("cfgDefault") && !is.null(cfgDefault) &&
 
   cat("## GAMS Config Non-Default\n\n")
 
-  cat("Following GAMS settings are the same in all sceanrios but different from the default settings.\n\n")
+  cat("Following GAMS settings are the same in all scenarios but different from the default settings.\n\n")
 
   bind_cols(
     Source = c("Scenarios", "Default"),
@@ -117,7 +118,7 @@ if (exists("cfgDefault") && !is.null(cfgDefault) &&
     showInTables()
 
   cat(
-    "Following GAMS settings are the same in all sceanrios and not present in the default file:\n\n")
+    "Following GAMS settings are the same in all scenarios and not present in the default file:\n\n")
 
   showInTables(cfgGmsWideSame[setdiff(names(cfgGmsWideSame), names(cfgDefault$gms))])
 }

--- a/inst/markdown/compareScenarios2/cs2_main.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_main.Rmd
@@ -129,7 +129,8 @@ tibble(path = unname(params$mifScen)) %>%
     path,
     read.quitte,
     factors = TRUE,
-    na.strings = c("", "NA", "N/A", "Inf", "-Inf"))) %>%
+    # read.quitte() default NA-strings and Inf, -Inf
+    na.strings = c("UNDF", "NA", "N/A", "n_a", "Inf", "-Inf"))) %>%
   unnest(data) %>%
   nest(data = -c(fileid, path, scenario)) ->
   dataScenNested

--- a/inst/markdown/compareScenarios2/cs2_pdf_header_include.tex
+++ b/inst/markdown/compareScenarios2/cs2_pdf_header_include.tex
@@ -9,4 +9,4 @@
    {\thesubparagraph\ }
    {0pt}
    {}
-   
+\usepackage{hyphenat} % allow for automatic line breaks in words with - and _


### PR DESCRIPTION
Added `\usepackage{hyphenat}` to LaTeX inculdes to allow for line breaks in long words with underscore, dash, ... , in particular in the path column of the file reference table. See https://github.com/pik-piam/remind2/issues/204
Furthermore, `c_expname` and `c_description` are not shown in the Further Info section anymore as this is redundant.