### PR TITLE
Kaya ref year

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '35098000'
+ValidationKey: '35290600'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.84.0",
+  "version": "1.85.0",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.84.0
-Date: 2022-03-24
+Version: 1.85.0
+Date: 2022-03-25
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/R/compareScenarios2.R
+++ b/R/compareScenarios2.R
@@ -47,6 +47,10 @@
 #'     \code{numeric(n)}.
 #'     Default: \code{c(2010, 2030, 2050, 2100)}.
 #'     Years to show in bar plots of scenario data.}
+#'   \item{\code{yearRef}}{
+#'     \code{numeric(1)}.
+#'     Default: \code{2005}.
+#'     A reference year used to show relative values in Kaya decomposition.}
 #'   \item{\code{reg}}{
 #'     \code{NULL} or \code{character(n)}.
 #'     Default: \code{NULL}.

--- a/R/compareScenarios2.R
+++ b/R/compareScenarios2.R
@@ -49,7 +49,7 @@
 #'     Years to show in bar plots of scenario data.}
 #'   \item{\code{yearRef}}{
 #'     \code{numeric(1)}.
-#'     Default: \code{2005}.
+#'     Default: \code{2020}.
 #'     A reference year used to show relative values in Kaya decomposition.}
 #'   \item{\code{reg}}{
 #'     \code{NULL} or \code{character(n)}.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.84.0**
+R package **remind2**, version **1.85.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.84.0, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.85.0, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.84.0},
+  note = {R package version 1.85.0},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/inst/markdown/compareScenarios2/cs2_02_macro.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_02_macro.Rmd
@@ -57,11 +57,11 @@ showLinePlots(data, "Interest Rate (t+1)/(t-1)|Real")
 
 ```{r}
 # Local (this subsection) preprocessing for all price variables.
-data %>% 
+data %>%
   filter(scenario != "historical") %>%
-  filter(str_starts(variable, "Price")) %>% 
+  filter(str_starts(variable, "Price")) %>%
   filter(period >= 2010) %>% # 2005 values are invalid
-  droplevels() -> 
+  droplevels() ->
   dPrice
 ```
 
@@ -69,59 +69,59 @@ data %>%
 ### PE Prices
 
 ```{r PE Prices}
-levels(dPrice$variable) %>% 
-  str_subset("^Price\\|Primary Energy\\|") %>% 
-  str_subset("\\|Moving Avg$", negate=TRUE) ->
+levels(dPrice$variable) %>%
+  str_subset("^Price\\|Primary Energy\\|") %>%
+  str_subset("\\|Moving Avg$", negate = TRUE) ->
   vars
-walk(vars, showLinePlots, data=dPrice, scale="fixed")
+walk(vars, showLinePlots, data = dPrice, scale = "fixed")
 ```
 
 ### SE Prices
 
 
 ```{r SE Prices}
-levels(dPrice$variable) %>% 
-  str_subset("^Price\\|Secondary Energy\\|") %>% 
-  str_subset("\\|Moving Avg$", negate=TRUE) ->
+levels(dPrice$variable) %>%
+  str_subset("^Price\\|Secondary Energy\\|") %>%
+  str_subset("\\|Moving Avg$", negate = TRUE) ->
   vars
-walk(vars, showLinePlots, data=dPrice, scale="fixed")
+walk(vars, showLinePlots, data = dPrice, scale = "fixed")
 ```
 
 ### FE Prices
 
 ```{r FE Prices}
-levels(dPrice$variable) %>% 
-  str_subset("^Price\\|Final Energy\\|") %>% 
-  str_subset("\\|Moving Avg$", negate=TRUE) ->
+levels(dPrice$variable) %>%
+  str_subset("^Price\\|Final Energy\\|") %>%
+  str_subset("\\|Moving Avg$", negate = TRUE) ->
   vars
 
-vars %>% 
-  str_subset("Liquids") %>% 
-  walk(showLinePlots, data=dPrice, scale="fixed")
-vars %>% 
-  str_subset("Gases") %>% 
-  walk(showLinePlots, data=dPrice, scale="fixed")
-vars %>% 
-  str_subset("Solids") %>% 
-  walk(showLinePlots, data=dPrice, scale="fixed")
-vars %>% 
-  str_subset("Electricity") %>% 
-  walk(showLinePlots, data=dPrice, scale="fixed")
-vars %>% 
-  str_subset("Hydrogen") %>% 
-  walk(showLinePlots, data=dPrice, scale="fixed")
-vars %>% 
-  str_subset("Heat") %>% 
-  walk(showLinePlots, data=dPrice, scale="fixed")
+vars %>%
+  str_subset("Liquids") %>%
+  walk(showLinePlots, data = dPrice, scale = "fixed")
+vars %>%
+  str_subset("Gases") %>%
+  walk(showLinePlots, data = dPrice, scale = "fixed")
+vars %>%
+  str_subset("Solids") %>%
+  walk(showLinePlots, data = dPrice, scale = "fixed")
+vars %>%
+  str_subset("Electricity") %>%
+  walk(showLinePlots, data = dPrice, scale = "fixed")
+vars %>%
+  str_subset("Hydrogen") %>%
+  walk(showLinePlots, data = dPrice, scale = "fixed")
+vars %>%
+  str_subset("Heat") %>%
+  walk(showLinePlots, data = dPrice, scale = "fixed")
 ``` 
 
 ## Trade
 
 ```{r Trade}
-levels(data$variable) %>% 
+levels(data$variable) %>%
   str_subset("^Trade\\|[^|]*$") ->
   vars
-walk(vars, showLinePlots, data=data)
+walk(vars, showLinePlots, data = data)
 ```
 
 ## FE intensity of GDP
@@ -137,41 +137,41 @@ showAreaAndBarPlots(data, items)
 ## FE intensity of GDP, linegraph (by GDP)
 
 ```{r FE intensity of GDP-linegraph}
-data %>% 
+data %>%
   # To make the plots less crowded, show only IEA historical data.
-  filter(scenario != "historical" | model == "IEA") -> 
+  filter(scenario != "historical" | model == "IEA") ->
   dIea
 items <- c(
   "FE|Transport pGDP",
   "FE|Buildings pGDP",
   "FE|Industry pGDP")
-showMultiLinePlots(dIea, items, scales="fixed")
-showMultiLinePlotsByVariable(dIea, items, "GDP|PPP pCap", scales="fixed")
+showMultiLinePlots(dIea, items, scales = "fixed")
+showMultiLinePlotsByVariable(dIea, items, "GDP|PPP pCap", scales = "fixed")
 ```
 
 ## Kaya-Decomposition
 
 ```{r kaya calc}
-data %>% 
-  filter(variable %in% c("Emi|CO2|Energy", "FE", "GDP|MER", "Population")) %>% 
-  filter(scenario != "historical") %>% 
+data %>%
+  filter(variable %in% c("Emi|CO2|Energy", "FE", "GDP|MER", "Population")) %>%
+  filter(scenario != "historical") %>%
   select(model, scenario, region, variable, unit, period, value) ->
   d
-d %>% 
+d %>%
   distinct(variable, unit) ->
   old_units
-d %>% 
-  select(-unit) %>% 
-  pivot_wider(names_from=variable, values_from=value) %>% 
+d %>%
+  select(-unit) %>%
+  pivot_wider(names_from = variable, values_from = value) %>%
   mutate(
-    emiCO2_by_FE = `Emi|CO2|Energy`/FE,
-    FE_by_GDP = FE/`GDP|MER`,
-    GDP_by_Pop = `GDP|MER`/Population,
-    `Emi|CO2|Energy` = NULL, FE = NULL, `GDP|MER` = NULL) %>% 
+    emiCO2_by_FE = `Emi|CO2|Energy` / FE,
+    FE_by_GDP = FE / `GDP|MER`,
+    GDP_by_Pop = `GDP|MER` / Population,
+    `Emi|CO2|Energy` = NULL, FE = NULL, `GDP|MER` = NULL) %>%
   pivot_longer(
-    c(emiCO2_by_FE, FE_by_GDP, GDP_by_Pop, Population), 
-    names_to="variable",
-    values_to="value") -> kaya
+    c(emiCO2_by_FE, FE_by_GDP, GDP_by_Pop, Population),
+    names_to = "variable",
+    values_to = "value") -> kaya
 kaya_units <- tribble(
   ~variable, ~unit,
   "Population", "million",
@@ -180,22 +180,22 @@ kaya_units <- tribble(
   "emiCO2_by_FE", "EJ/Mt CO2")
 kaya_vars <- kaya_units$variable
 kaya %>%
-  left_join(kaya_units) %>% 
+  left_join(kaya_units) %>%
   as.quitte() ->
   kaya
 
-ref_year <- 2005
-kaya %>% 
-  filter(period==ref_year) %>% 
-  select(-period) %>% 
-  rename(ref_value=value) -> 
+ref_year <- getOption("kaya.refYear")
+kaya %>%
+  filter(period == ref_year) %>%
+  select(-period) %>%
+  rename(ref_value = value) ->
   kaya_ref
-kaya %>% 
-  left_join(kaya_ref) %>% 
+kaya %>%
+  left_join(kaya_ref) %>%
   mutate(
     value = value / ref_value,
     unit = paste0("relative to ", ref_year),
-    ref_value = NULL) %>% 
+    ref_value = NULL) %>%
   as.quitte() ->
   kaya_rel
 ```
@@ -204,18 +204,20 @@ kaya %>%
 
 ```{r kaya plot abs}
 showMultiLinePlots(kaya, kaya_vars)
-walk(kaya_vars, showRegiLinePlots, data=kaya)
+walk(kaya_vars, showRegiLinePlots, data = kaya)
 ```
 
-### Relative to 2005
+```{r results='asis'}
+cat("### Relative to ", ref_year, "\n")
+```
 
 ```{r kaya plot rel}
 showMultiLinePlots(kaya_rel, kaya_vars)
-walk(kaya_vars, showRegiLinePlots, data=kaya)
+walk(kaya_vars, showRegiLinePlots, data = kaya)
 ```
 
 ### Components
 
 ```{r kaya_vars plot}
-walk(kaya_vars, showLinePlots, data=kaya_rel)
+walk(kaya_vars, showLinePlots, data = kaya_rel)
 ```

--- a/inst/markdown/compareScenarios2/cs2_02_macro.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_02_macro.Rmd
@@ -219,5 +219,5 @@ walk(kaya_vars, showRegiLinePlots, data = kaya_rel)
 ### Components
 
 ```{r kaya_vars plot}
-walk(kaya_vars, showLinePlots, data = kaya_rel)
+walk(kaya_vars, showLinePlots, data = kaya)
 ```

--- a/inst/markdown/compareScenarios2/cs2_02_macro.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_02_macro.Rmd
@@ -213,7 +213,7 @@ cat("### Relative to ", ref_year, "\n")
 
 ```{r kaya plot rel}
 showMultiLinePlots(kaya_rel, kaya_vars)
-walk(kaya_vars, showRegiLinePlots, data = kaya)
+walk(kaya_vars, showRegiLinePlots, data = kaya_rel)
 ```
 
 ### Components

--- a/inst/markdown/compareScenarios2/cs2_main.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_main.Rmd
@@ -25,7 +25,7 @@ params:
   yearsScen: !r c(seq(2005, 2060, 5), seq(2070, 2100, 10))
   yearsHist: !r c(seq(1960, 2020, 1), seq(2025, 2100, 5))
   yearsBarPlot: !r c(2010, 2030, 2050, 2100)
-  yearRef: 2005
+  yearRef: 2020
   reg: null
   sections: "all"
   userSectionPath: null

--- a/inst/markdown/compareScenarios2/cs2_main.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_main.Rmd
@@ -25,6 +25,7 @@ params:
   yearsScen: !r c(seq(2005, 2060, 5), seq(2070, 2100, 10))
   yearsHist: !r c(seq(1960, 2020, 1), seq(2025, 2100, 5))
   yearsBarPlot: !r c(2010, 2030, 2050, 2100)
+  yearRef: 2005
   reg: null
   sections: "all"
   userSectionPath: null
@@ -223,7 +224,7 @@ if (!is.null(params$reg)) {
 # Change unit million US$2005/yr to billion US$2005/yr.
 # Relevant for ARIADNE historical EUR GDP|PPP.
 bind_rows(
-  data %>% filter(! unit %in% c("million US$2005/yr")),
+  data %>% filter(!unit %in% c("million US$2005/yr")),
   data %>%
     filter(unit == "million US$2005/yr") %>%
     mutate(
@@ -347,6 +348,9 @@ data <- as.quitte(data)
 options(mip.mainReg = params$mainReg)
 options(mip.yearsBarPlot = params$yearsBarPlot)
 options(mip.histRefModel = histRefModel)
+
+# Reference year for Kaya decomposition is params$yearRef or the first available year therafter.
+options(kaya.refYear = min(params$yearsScen[params$yearsScen >= params$yearRef]))
 ```
 
 
@@ -385,8 +389,10 @@ if (length(params$sections) == 1 && params$sections == "all") {
 
 
 ```{r include sections, child = sectionPaths}
+
 ```
 
 
 ```{r include user section, child = params$userSectionPath}
+
 ```

--- a/man/compareScenarios2.Rd
+++ b/man/compareScenarios2.Rd
@@ -73,6 +73,10 @@ choose Rmd as output format and obtain a copy of the *.Rmd-files.
     \code{numeric(n)}.
     Default: \code{c(2010, 2030, 2050, 2100)}.
     Years to show in bar plots of scenario data.}
+  \item{\code{yearRef}}{
+    \code{numeric(1)}.
+    Default: \code{2005}.
+    A reference year used to show relative values in Kaya decomposition.}
   \item{\code{reg}}{
     \code{NULL} or \code{character(n)}.
     Default: \code{NULL}.

--- a/man/compareScenarios2.Rd
+++ b/man/compareScenarios2.Rd
@@ -75,7 +75,7 @@ choose Rmd as output format and obtain a copy of the *.Rmd-files.
     Years to show in bar plots of scenario data.}
   \item{\code{yearRef}}{
     \code{numeric(1)}.
-    Default: \code{2005}.
+    Default: \code{2020}.
     A reference year used to show relative values in Kaya decomposition.}
   \item{\code{reg}}{
     \code{NULL} or \code{character(n)}.


### PR DESCRIPTION
Adds `yearRef` as YAML parameter with default `2020` to `compareScenarios2()`. It is used to show values in the Kaya decomposition relative to  a reference year. Before, this year was hard coded as `2005`, which would cause the respective code for the Kaya plot to show an error message instead of the plot. See also #8.

Now the smallest available year greater or equal to `yearRef` is used as reference year in the relative Kaya plots.

Examples:

* If neither `yearsScen` (the years shown for scenario data) nor `yearRef` is specified, nothing changes, i.e. `2020` is the reference.
* If `yearsScen = seq(2025, 2055, 5)`, then `2025` is automatically chosen as reference year.
* If `yearRef=2005`, then `2005` is used as reference year.
* If `yearsScen = seq(2010, 2055, 5)` and `yearRef = 2013`, then `2015` is chosen as reference year.
