### PR TITLE
Fix EW sign

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '35341716'
+ValidationKey: '35366358'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.85.2",
+  "version": "1.85.3",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.85.2
-Date: 2022-04-01
+Version: 1.85.3
+Date: 2022-04-04
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/R/convGDX2MIF.R
+++ b/R/convGDX2MIF.R
@@ -100,7 +100,7 @@ convGDX2MIF <- function(gdx, gdx_ref = NULL, file = NULL, scenario = "default",
   
   # reporting of SDP variables
   message("running reportSDPVariables...")
-  tmp <- try(reportSDPVariables(gdx,output))  # test whether reportSDPVariables works
+  tmp <- try(reportSDPVariables(gdx,output,t))  # test whether reportSDPVariables works
   if(class(tmp)!="try-error") {
     if(!is.null(tmp)) output <- tmp
   } else {

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -1178,7 +1178,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
                         "Emi|CO2|CDR|DACCS (Mt CO2/yr)"),
                # total EW
                # total co2 captured by EW
-               setNames(-v33_emiEW * GtC_2_MtCO2,
+               setNames(v33_emiEW * GtC_2_MtCO2,
                         "Emi|CO2|CDR|EW (Mt CO2/yr)"))
   
   out <- mbind(out,

--- a/R/reportSDPVariables.R
+++ b/R/reportSDPVariables.R
@@ -20,7 +20,11 @@
 
 
 
-reportSDPVariables <- function(gdx,output=NULL) {
+reportSDPVariables <- function(
+  gdx, 
+  output=NULL, 
+  t = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150)
+) {
   
   # Define current realisation for the different modules
   module2realisation <- readGDX(gdx, "module2realisation")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.85.2**
+R package **remind2**, version **1.85.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.85.2, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.85.3, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.85.2},
+  note = {R package version 1.85.3},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/inst/markdown/compareScenarios2/cs2_99_further_info.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_99_further_info.Rmd
@@ -140,4 +140,3 @@ if (exists("cfgGmsWideDiff") && !is.null(cfgGmsWideDiff)) {
 }
 ```
 
-\newpage

--- a/inst/markdown/compareScenarios2/cs2_main.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_main.Rmd
@@ -205,7 +205,7 @@ rm(dataScen, dataScenNested, dataHist)
 # In the variable names, replace |+|, |++|, |+++|, ... by |.
 data %>%
   mutate(
-    varplus = variable,
+    varplus = as.character(variable),
     variable = remind2::deletePlus(variable)) ->
   data
 

--- a/inst/markdown/compareScenarios2/cs2_pdf_header_include.tex
+++ b/inst/markdown/compareScenarios2/cs2_pdf_header_include.tex
@@ -1,4 +1,10 @@
 \usepackage{titlesec}
+\titleformat{\section}
+    {\normalfont\Large\bfseries}
+    {\thesection}
+    {1em}
+    {}
+    [\newpage]
 \titleformat{\paragraph}
    {\normalfont\bfseries}
    {\theparagraph\ }


### PR DESCRIPTION
`"Emi|CO2|CDR|EW (Mt CO2/yr)"` now has the correct sign