### PR TITLE
suppress 'Joining, by' messages that clutter the logs

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '35495232'
+ValidationKey: '35514336'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.85.8",
+  "version": "1.85.9",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.85.8
+Version: 1.85.9
 Date: 2022-04-22
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))

--- a/R/calc_CES_marginals.R
+++ b/R/calc_CES_marginals.R
@@ -50,7 +50,7 @@ calc_CES_marginals <- function(gdxName, id = 'file') {
     
     # ---- calculate marginals ----
     marginals <- cesOut2cesIn %>% 
-      left_join(
+      left_join_silent(
         pm_cesdata %>% 
           filter(!!sym('param') %in% c('xi', 'eff')) %>% 
           pivot_wider(names_from = 'param') %>% 
@@ -58,25 +58,25 @@ calc_CES_marginals <- function(gdxName, id = 'file') {
         
         c('pf.in' = 'pf')
       ) %>% 
-      left_join(
+      left_join_silent(
         pm_cesdata %>% 
           filter('rho' == !!sym('param')) %>% 
           select(-'param', 'rho' = 'value'),
         
         c('t', 'regi', 'pf.out' = 'pf')
       ) %>% 
-      left_join(
+      left_join_silent(
         vm_effGr,
         
         c('t', 'regi', 'pf.in' = 'pf')
       ) %>% 
-      left_join(
+      left_join_silent(
         vm_cesIO %>% 
           rename('value.in' = 'value'), 
         
         c('t', 'regi', 'pf.in' = 'pf')
       ) %>% 
-      left_join(
+      left_join_silent(
         vm_cesIO %>% 
           rename('value.out' = 'value'),
         
@@ -107,8 +107,8 @@ calc_CES_marginals <- function(gdxName, id = 'file') {
         marginals %>% 
           filter(!!sym('pf.out') %in% CES_root) %>% 
           select('pf' = 'pf.in', 't', 'regi', 'price' = 'marginal') %>% 
-          left_join(cesOut2cesIn, c('pf' = 'pf.in')) %>% 
-          left_join(
+          left_join_silent(cesOut2cesIn, c('pf' = 'pf.in')) %>% 
+          left_join_silent(
             prices %>% 
               rename('price.out' = 'price'), 
             

--- a/R/compareScenarios.R
+++ b/R/compareScenarios.R
@@ -36,6 +36,8 @@ compareScenarios <- function(mif, hist,
                              y_bar=c(2010,2030,2050,2100),
                              reg=NULL, mainReg="GLO", fileName="CompareScenarios.pdf",
                              sr15marker_RCP=NULL) {
+  message("compareScenarios is outdated and may break - use compareScenarios2 instead!")
+
   lineplots_perCap <- function(data, vars, percap_factor, ylabstr,
                                global=FALSE, mainReg_plot=mainReg, per_gdp=FALSE, histdata_plot=NULL){
 

--- a/R/get_total_efficiencies.R
+++ b/R/get_total_efficiencies.R
@@ -22,8 +22,8 @@ get_total_efficiencies <- function(gdxName) {
   pf_mapping <- read.gdx(gdxName, 'cesOut2cesIn', factors = FALSE, 
                          colNames = c('pf.out', 'pf.in'))
   
-  full_join(
-    inner_join(
+  full_join_silent(
+    inner_join_silent(
       pf_mapping,
       
       pm_cesdata %>% 
@@ -33,7 +33,7 @@ get_total_efficiencies <- function(gdxName) {
       c('pf.in' = 'pf')
     ),
     
-    inner_join(
+    inner_join_silent(
       pf_mapping,
       
       pm_cesdata %>% 

--- a/R/plotLCOE.R
+++ b/R/plotLCOE.R
@@ -233,8 +233,8 @@ plotLCOE <- function(LCOEfile, gdx, y=c(2015,2020,2030,2040,2050,2060),reg="all_
                       filter( type == "marginal") %>% 
                       revalue.levels(output = relabel.outputs) %>% 
                       rename(LCOE = value) %>%
-                      left_join(df.dC) %>% 
-                      left_join(df.SePrice) %>% 
+                      left_join_silent(df.dC) %>% 
+                      left_join_silent(df.SePrice) %>% 
                       gather(variable, value, LCOE, vm_deltaCap, Price) %>%   
                       # do away with cost dimension for non LCOE variables
                       filter( cost == "Investment Cost" | variable == "LCOE",

--- a/R/reportCharts.R
+++ b/R/reportCharts.R
@@ -545,7 +545,7 @@ reportCharts <- function(gdx=NULL, regionMapping=NULL, hist=NULL, reportfile=NUL
         scale_y_continuous(labels = scales::percent) +
         scale_x_continuous(limits = c(2005, NA)) )
     #per capita chart
-    df <- suppressWarnings(left_join(df, pop, by=c("region", "period")))
+    df <- suppressWarnings(left_join_silent(df, pop, by=c("region", "period")))
     df <- df %>% group_by(.data$region,.data$period) %>% mutate(percapita = .data$value/.data$population) #creating per capita column
     df$percapitaDetails <- paste0(round(df$percapita,2)," EJ per capita<br>",gsub("\\|"," ",gsub("\\+\\|","",gsub("PE\\|","",as.character(df$variable)))), " primary energy consumption in ", ifelse(reg=="GLO","the World", as.character(df$region)),"<br>year: ",df$period)
     g$percapita <- suppressWarnings( ggplot(data=df,aes_(x=~period,y=~percapita,fill=~variable,text=~percapitaDetails,group = ~variable)) +

--- a/R/reportCrossVariables.R
+++ b/R/reportCrossVariables.R
@@ -326,7 +326,7 @@ reportCrossVariables <- function(gdx, output = NULL, regionSubsetList = NULL,
         as_tibble() %>%
         select(-'Cell') %>% 
         # join with population numbers
-        left_join(
+        left_join_silent(
           output[,,'Population (million)'] %>% 
             as.data.frame() %>% 
             as_tibble() %>% 
@@ -336,7 +336,7 @@ reportCrossVariables <- function(gdx, output = NULL, regionSubsetList = NULL,
         ) %>% 
         # join unit conversion
         extract(.data$Data1, c('variable', 'unit'), '^(.*) \\((.*)\\)$') %>% 
-        full_join(
+        full_join_silent(
           tribble(
             ~unit,                  ~new.unit,    ~factor,
             'Mt/yr',                't/yr',       1,
@@ -366,7 +366,7 @@ reportCrossVariables <- function(gdx, output = NULL, regionSubsetList = NULL,
         as_tibble() %>%
         select(-'Cell') %>%
         # join with population numbers
-        left_join(
+        left_join_silent(
           output[,,'GDP|PPP (billion US$2005/yr)'] %>%
             as.data.frame() %>%
             as_tibble() %>%
@@ -376,7 +376,7 @@ reportCrossVariables <- function(gdx, output = NULL, regionSubsetList = NULL,
         ) %>%
         # join unit conversion
         extract(.data$Data1, c('variable', 'unit'), '^(.*) \\((.*)\\)$') %>%
-        full_join(
+        full_join_silent(
           tribble(
             ~unit,                  ~new.unit,    ~factor,
             # Mt/$bn * 1e6 t/Mt * 1e-3 $bn/$m = t/$m

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -260,8 +260,8 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
   # only retain combinations of vm_demFeSector subdimensions which are in entyFe2Sector and sector2emiMkt
   emi.map.fe <- data.frame(all_enty = getItems(pm_emifac.co2.fe, dim = "all_enty",  full = T),
                            all_enty1 = getItems(pm_emifac.co2.fe, dim = "all_enty1",  full = T)) %>%
-    left_join(entyFe2Sector) %>%
-    left_join(sector2emiMkt) %>%
+    left_join_silent(entyFe2Sector) %>%
+    left_join_silent(sector2emiMkt) %>%
     mutate(name = paste(all_enty, all_enty1, emi_sectors, all_emiMkt, sep = "."))
 
 
@@ -1197,7 +1197,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
 
 
   # join mac mapping of sectors and markets
-  mac.map <- right_join(emiMac2sector, macSector2emiMkt)
+  mac.map <- right_join_silent(emiMac2sector, macSector2emiMkt)
 
   # create magpie array with MAC emissions per sector, market and gas
   # MAC emissions comprise non-energy CO2, CH4, N2O emissions

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -50,11 +50,11 @@ reportFE <- function(gdx, regionSubsetList = NULL,
   sector2emiMkt <- readGDX(gdx, "sector2emiMkt")
   
   demFemapping <- entyFe2Sector %>% 
-    full_join(sector2emiMkt, by = 'emi_sectors') %>% 
+    full_join_silent(sector2emiMkt, by = 'emi_sectors') %>% 
     # rename such that all_enty1 always signifies the FE carrier like in 
     # vm_demFeSector
     rename(all_enty1 = all_enty) %>% 
-    left_join(se2fe, by = 'all_enty1') %>% 
+    left_join_silent(se2fe, by = 'all_enty1') %>% 
     select(-all_te)
   
   #sety <- readGDX(gdx,c("entySe","sety"),format="first_found")
@@ -1370,7 +1370,7 @@ reportFE <- function(gdx, regionSubsetList = NULL,
                         rename( encar = data) %>% 
                         # join current FE|Industry|Liquids etc. with non-energy use subsectors data
                         revalue.levels(encar = map.vars.nechem) %>% 
-                        left_join(df.fe_nechem) %>% 
+                        left_join_silent(df.fe_nechem) %>% 
                         mutate( Value_NonEn = ifelse(value >= value_subsectors, value_subsectors, value)) %>% 
                         filter( SSP == "SSP2") %>% 
                         # map to non-energy use variable names

--- a/R/reportPrices.R
+++ b/R/reportPrices.R
@@ -121,7 +121,7 @@ reportPrices <- function(gdx, output=NULL, regionSubsetList=NULL,
 
   sector <- emi_sectors <- emiMkt <- all_emiMkt <- NULL
   fe.entries <- entyFe2Sector %>%
-                  left_join(sector2emiMkt) %>%
+                  left_join_silent(sector2emiMkt) %>%
                   rename( sector = emi_sectors, emiMkt = all_emiMkt) %>%
                   filter( sector != "CDR")
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,3 +14,18 @@ getLine <- function() {
   }
   return(s)
 }
+
+
+# use left_join, right_join, full_join and inner_join without messages such as 'joined by "all_regi"'
+left_join_silent <- function(...) {
+  return(suppressMessages(left_join(...)))
+}
+right_join_silent <- function(...) {
+  return(suppressMessages(right_join(...)))
+}
+full_join_silent <- function(...) {
+  return(suppressMessages(full_join(...)))
+}
+inner_join_silent <- function(...) {
+  return(suppressMessages(inner_join(...)))
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.85.8**
+R package **remind2**, version **1.85.9**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.85.8, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.85.9, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.85.8},
+  note = {R package version 1.85.9},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
The `join` commands regularly clutter the logs like that:
```
[1] "start generation of LCOE reporting"
Joining, by = "tech"
Joining, by = c("region", "tech", "rlf")
Joining, by = c("region", "tech")
Joining, by = c("region", "fuel")
Joining, by = c("region", "tech")
Joining, by = "tech"
Joining, by = "region"
Joining, by = "gridtech"
Joining, by = c("region", "tech")
Joining, by = "tech"
Joining, by = "teStor"
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "tech")
Joining, by = c("region", "tech")
Joining, by = c("region", "period", "tech")
Joining, by = "tech"
Joining, by = c("region", "period", "fuel")
Joining, by = c("region", "period")
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "tech")
Joining, by = c("region", "tech")
Joining, by = c("region", "period")
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "period")
Joining, by = c("region", "period", "tech", "fuel")
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "period", "output")
Joining, by = c("region", "period", "tech", "sector")
[1] "end generation of LCOE reporting"
```
I added utility functions that suppress this message and used them everywhere, avoiding these not so helpful messages in the REMIND logs. Also, @chroetz, I added a warning message to `compareScenarios` that it is outdated.