### PR TITLE
compareScenConf more flexible, + deprecation message compareScenarios

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '35495232'
+ValidationKey: '35514336'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.85.8",
+  "version": "1.85.9",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.85.8
+Version: 1.85.9
 Date: 2022-04-22
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))

--- a/R/compareScenarios.R
+++ b/R/compareScenarios.R
@@ -36,6 +36,8 @@ compareScenarios <- function(mif, hist,
                              y_bar=c(2010,2030,2050,2100),
                              reg=NULL, mainReg="GLO", fileName="CompareScenarios.pdf",
                              sr15marker_RCP=NULL) {
+  .Deprecated("compareScenarios2")
+
   lineplots_perCap <- function(data, vars, percap_factor, ylabstr,
                                global=FALSE, mainReg_plot=mainReg, per_gdp=FALSE, histdata_plot=NULL){
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.85.8**
+R package **remind2**, version **1.85.9**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.85.8, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.85.9, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.85.8},
+  note = {R package version 1.85.9},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/man/compareScenConf.Rd
+++ b/man/compareScenConf.Rd
@@ -8,6 +8,7 @@ comparing it to a default.cfg}
 compareScenConf(
   fileList = "",
   configfile = "default.cfg",
+  row.names = 1,
   renamedColumns = NULL,
   renamedRows = NULL,
   printit = TRUE
@@ -17,6 +18,8 @@ compareScenConf(
 \item{fileList}{vector containing two csv file paths. If empty, user can select}
 
 \item{configfile}{path to configfile. If empty, uses './default.cfg'}
+
+\item{row.names}{column in csv used for row.names. Use NULL for mapping files}
 
 \item{renamedColumns}{vector with old and new column names such as c("old1" = "new1", "old2" = "new2"))}
 


### PR DESCRIPTION
- make compareScenConf more flexible such that it can be used for [project_interfaces as well to generate such messages for a  PR](https://github.com/pik-piam/project_interfaces/pull/18), because there the problem of unreadable diffs is [even worse](https://github.com/pik-piam/project_interfaces/pull/6/files)
- add warning message to compareScenarios