### PR TITLE
improve rownames in compareScenConf

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '35731542'
+ValidationKey: '355785980'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.86.9",
+  "version": "1.86.10",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.86.9
+Version: 1.86.10
 Date: 2022-05-06
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))

--- a/R/compareScenConf.R
+++ b/R/compareScenConf.R
@@ -69,6 +69,12 @@ compareScenConf <- function(fileList = "", configfile = "default.cfg", row.names
   settings2 <- read.csv2(fileList[[2]], stringsAsFactors = FALSE, row.names = row.names,
                          comment.char = "#", na.strings = "", dec = ".")
 
+  # for mapping files
+  if (is.null(row.names)) {
+    rownames(settings1) <- make.unique(paste0(settings1[, 1], ": ", settings1[, 2]))
+    rownames(settings2) <- make.unique(paste0(settings2[, 1], ": ", settings2[, 2]))
+  }
+
   # rename columns and rows in old file to new names after some checks
   allwarnings <- checkRowsCols(settings1, settings2, renamedCols, renamedRows)
   names(settings1)[names(settings1) %in% names(renamedCols)] <-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.86.9**
+R package **remind2**, version **1.86.10**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.86.9, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.86.10, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.86.9},
+  note = {R package version 1.86.10},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
if `row.names = NULL` is passed, which is the option used for mapping files from `project_interfaces` that do not have a unique column identifier, put together something unique out of the first two columns instead of just numbering them.

Without that, if you add a single row, the whole matching procedure fails and all rows after the added row are considered as changed. With this PR, it looks like that:
```
~ 16: Carbon Sequestration|CCS|Biomass|Energy|Demand|Industry:
    r30m44: Emi|CO2|CDR|BECCS|Industry -> Carbon Management|Storage|Industry Energy|+|Biomass
~ 17: Carbon Sequestration|CCS|Biomass|Energy|Supply:
    r30m44: Emi|CO2|CDR|BECCS|Pe2Se -> Carbon Management|Storage|+|Biomass|Pe2Se
```