### PR TITLE
make test-convGDX2mif.R more verbose, listing all elements of calculations that failed the integrity check

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '35763750'
+ValidationKey: '35782875'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.87.0",
+  "version": "1.87.1",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.87.0
+Version: 1.87.1
 Date: 2022-05-13
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.87.0**
+R package **remind2**, version **1.87.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.87.0, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.87.1, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.87.0},
+  note = {R package version 1.87.1},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/tests/testthat/test-convGDX2mif.R
+++ b/tests/testthat/test-convGDX2mif.R
@@ -20,7 +20,9 @@ checkEqs <- function(dt, eqs, scope = "all", sens = 1e-8) {
 
     dt[, diff := total - get(names(eqs)[LHS])]
     if (nrow(dt[abs(diff) > sens]) > 0) {
-      fail(paste("Check on data integrity failed for", names(eqs)[LHS]))
+      fail(paste(c(paste("Check on data integrity failed for", names(eqs)[LHS]),
+                 gsub('`', '', unlist(strsplit(eqs[[LHS]], '`+`', TRUE)))),
+                 collapse = '\n' ))
     }
   }
 }


### PR DESCRIPTION
Example output:
```
Failure (test-convGDX2mif.R:73:5): Test if REMIND reporting is produced as it should and check data integrity
Check on data integrity failed for Emi|GHG|Gross|Energy (Mt CO2eq/yr)
Emi|GHG|Gross|Energy|+|Demand (Mt CO2eq/yr)
Emi|GHG|Gross|Energy|+|Supply (Mt CO2eq/yr)
```