### PR TITLE
add by= to join messages in reportLCOE to reduce log clutter

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '35845872'
+ValidationKey: '35865000'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.87.4",
+  "version": "1.87.5",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.87.4
+Version: 1.87.5
 Date: 2022-05-16
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.87.4**
+R package **remind2**, version **1.87.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.87.4, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.87.5, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.87.4},
+  note = {R package version 1.87.5},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
The different `join` commands regularly clutter the logs like that:
```
[1] "start generation of LCOE reporting"
Joining, by = "tech"
Joining, by = c("region", "tech", "rlf")
Joining, by = c("region", "tech")
Joining, by = c("region", "fuel")
Joining, by = c("region", "tech")
Joining, by = "tech"
Joining, by = "region"
Joining, by = "gridtech"
Joining, by = c("region", "tech")
Joining, by = "tech"
Joining, by = "teStor"
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "tech")
Joining, by = c("region", "tech")
Joining, by = c("region", "period", "tech")
Joining, by = "tech"
Joining, by = c("region", "period", "fuel")
Joining, by = c("region", "period")
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "tech")
Joining, by = c("region", "tech")
Joining, by = c("region", "period")
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "period")
Joining, by = c("region", "period", "tech", "fuel")
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "period", "tech")
Joining, by = c("region", "period", "output")
Joining, by = c("region", "period", "tech", "sector")
[1] "end generation of LCOE reporting"
```
I mapped these `by` messages to the join statements in `reportLCOE` and added them. I ran `reportLCOE` once in the old state and a second time afterwards, and checked that there was no difference.