### PR TITLE
adapt ccsinjecrate to remindmodel PR #826

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '358015850'
+ValidationKey: '35975680'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.87.10",
+  "version": "1.88.0",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.87.10
-Date: 2022-05-23
+Version: 1.88.0
+Date: 2022-05-24
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.87.10**
+R package **remind2**, version **1.88.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.87.10, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.88.0, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.87.10},
+  note = {R package version 1.88.0},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
In [remindmodel PR #826](https://github.com/remindmodel/remind/pull/826), I will (probably) have to rename `sm_ccsinjecrate` to `s_ccsinjecrate`, but the actual value will be saved as parameter `pm_ccsinjecrate(regi)`. This PR adapts `reportLCOE` to this change.

If `pm_ccsinjecrate` does not exist (and therefore the call returns `null`), the old variable name is used. I checked it with `/p/tmp/oliverr/remind/output/testOneRegi_2022-05-24_11.01.22/fulldata.gdx` which contains the new setting and it worked, and it also the usual test works.

I'm aware of the fact that in the fallback case, `pm_ccsinjecrate` has no dependency on `all_regi`, but the division works perfectly fine.