### PR TITLE
add AMT tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,6 +54,7 @@ Suggests:
     flexdashboard,
     gridExtra,
     kableExtra,
+    stringr,
     testthat,
     tidyverse
 VignetteBuilder: 

--- a/tests/testthat/test-convGDX2mif.R
+++ b/tests/testthat/test-convGDX2mif.R
@@ -7,7 +7,8 @@
 # should be checked for regions ("regional"), only globally ("world") or
 # both ("all"). Sensitivity determines the allowed offset when comparing
 # LHS to RHS
-checkEqs <- function(dt, eqs, scope = "all", sens = 1e-8) {
+library(dplyr)
+checkEqs <- function(dt, eqs, gdxPath = NULL, scope = "all", sens = 1e-8) {
   if (scope == "regional") {
     dt <- dt[all_regi != "World"]
   } else if (scope == "world") {
@@ -20,15 +21,15 @@ checkEqs <- function(dt, eqs, scope = "all", sens = 1e-8) {
 
     dt[, diff := total - get(names(eqs)[LHS])]
     if (nrow(dt[abs(diff) > sens]) > 0) {
-      fail(paste(c(paste("Check on data integrity failed for", names(eqs)[LHS]),
-                 gsub('`', '', unlist(strsplit(eqs[[LHS]], '`+`', TRUE)))),
-                 collapse = '\n' ))
+      fail(paste(c(gdxPath, paste("Check on data integrity failed for", names(eqs)[LHS]),
+                 gsub("`", "", unlist(strsplit(eqs[[LHS]], "`+`", TRUE)))),
+                 collapse = "\n"))
     }
   }
 }
 
 # please add variable tests below
-checkIntegrity <- function(out) {
+checkIntegrity <- function(out, gdxPath = NULL) {
   dt <- rmndt::magpie2dt(out)
   stopifnot(!(c("total", "diff") %in% unique(dt[["variable"]])))
   dtWide <- data.table::dcast(dt, ... ~ variable)
@@ -36,15 +37,16 @@ checkIntegrity <- function(out) {
   myList <- lapply(myList, FUN = function(x) paste0("`", x, "`"))
   myList <- lapply(myList, paste, collapse = "+")
   # remove from the tests the variables whose totals cannot be found
-  chck <- grep(" \\(.*.\\)$", names(myList), invert = T)
+  chck <- grep(" \\(.*.\\)$", names(myList), invert = TRUE)
   if (length(chck) > 0) {
     warning(paste0("For this group the corresponding total could not be found and the summation check ",
                    "will not be performed: \n", myList[chck], "\n\n"))
   }
   myList <- myList[grep(" \\(.*.\\)$", names(myList))]
 
-  checkEqs(dtWide, myList)
+  checkEqs(dtWide, myList, gdxPath)
 }
+
 
 test_that("Test if REMIND reporting is produced as it should and check data integrity", {
   skip_if_not(as.logical(gdxrrw::igdx(silent = TRUE)), "gdxrrw is not initialized properly")
@@ -61,13 +63,41 @@ test_that("Test if REMIND reporting is produced as it should and check data inte
     gdxPaths <- defaultGdxPath
   }
 
+  # finds for each AMT scenario the most recent, successfully converged GDX
+  .findAMTgdx <- function(gdxPaths = NULL) {
+    didremindfinish <- function(fulldatapath) {
+      logpath <- paste0(stringr::str_sub(fulldatapath, 1, -14), "/full.log")
+      return(file.exists(logpath) &&
+             any(grep("*** Status: Normal completion", readLines(logpath, warn = FALSE), fixed = TRUE)))
+    }
+    gdx <- Sys.glob("/p/projects/remind/modeltests/output/*/fulldata.gdx")
+    stamp <- lapply(gdx, stringr::str_sub, -32, -14) %>% strptime(format = "%Y-%m-%d_%H.%M.%S") %>% as.numeric
+    gdx <- data.frame(list(gdx = gdx, stamp = stamp))
+    gdx <- gdx[Sys.time() - gdx$stamp < 30 * 24 * 60 * 60 & ! is.na(gdx$stamp), ]
+    gdx <- gdx[unlist(lapply(gdx$gdx, didremindfinish)), ]
+    gdx <- gdx[order(gdx$stamp), ]
+    datetimepattern <- "_[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}\\.[0-9]{2}\\.[0-9]{2}"
+    gdx$scenario <- sub(datetimepattern, "", basename(dirname(as.vector(gdx$gdx))))
+    for (scenarioname in unique(gdx$scenario)) {
+      gdxPaths <- c(gdxPaths, as.character(tail(gdx[gdx$scenario == scenarioname, ]$gdx, n = 1)))
+    }
+    return(gdxPaths)
+  }
+
+  # uncomment to add current calibration gdxes
+  # gdxPaths <- c(gdxPaths, Sys.glob("/p/projects/remind/inputdata/CESparametersAndGDX/*.gdx"))
+  # uncomment to add debugging example gdx files
+  # gdxPaths <- c(gdxPaths, Sys.glob("/p/projects/remind/debugging/gdx-examples/*.gdx"))
+  # uncomment to add gdx files from most recent AMT runs
+  # gdxPaths <- c(gdxPaths, .findAMTgdx())
+
   numberOfMifs <- 0
   for (gdxPath in gdxPaths) {
     numberOfMifs <- numberOfMifs + 1
     message("Running convGDX2MIF(", gdxPath, ")...")
-    mifContent <- convGDX2MIF(gdxPath)
+    mifContent <- convGDX2MIF(gdxPath, gdx_ref = gdxPath)
     message("Checking integrity of created MIF...")
-    checkIntegrity(mifContent)
+    checkIntegrity(mifContent, gdxPath)
     magclass::write.report(
       x = magclass::collapseNames(mifContent),
       file = file.path(tempdir(), paste0(numberOfMifs, ".mif")),


### PR DESCRIPTION
This draft
- adds code such that a bunch of gdx files from AMT modeltests, the calibration gdx files and all in `/p/projects/remind/debugging/gdx-examples` can be added very quickly to the model tests to make testing various gdx files more easy.
- prints the filename with the groups that fail to facilitate debugging 