### PR TITLE
add optional parameter modelHistExclude to compareScenarios2.R

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '36373600'
+ValidationKey: '36394645'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.90.0",
+  "version": "1.90.1",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.90.0
-Date: 2022-06-01
+Version: 1.90.1
+Date: 2022-06-02
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/R/compareScenarios2.R
+++ b/R/compareScenarios2.R
@@ -55,6 +55,10 @@
 #'     \code{NULL} or \code{character(n)}.
 #'     Default: \code{NULL}.
 #'     Regions to show. \code{NULL} means all.}
+#'   \item{\code{modelsHistExclude}}{
+#'     \code{character(n) or NULL}.
+#'     Default: \code{c()}.
+#'     Models in historical data to exclude.}
 #'   \item{\code{sections}}{
 #'     \code{character(n) or numeric(n) or NULL}.
 #'     Default: \code{"all"}.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.90.0**
+R package **remind2**, version **1.90.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -48,7 +48,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.90.0, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.90.1, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,7 +57,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.90.0},
+  note = {R package version 1.90.1},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/inst/markdown/compareScenarios2/cs2_main.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_main.Rmd
@@ -27,6 +27,7 @@ params:
   yearsBarPlot: !r c(2010, 2030, 2050, 2100)
   yearRef: 2020
   reg: null
+  modelsHistExclude: !r c()
   sections: "all"
   userSectionPath: null
   mainReg: "World"
@@ -195,7 +196,7 @@ dataScen %>%
   filter(period %in% params$yearsScen) ->
   dataScen
 dataHist %>%
-  filter(period %in% params$yearsHist, !is.na(value)) ->
+  filter(period %in% params$yearsHist, !(model %in% params$modelsHistExclude), !is.na(value)) ->
   dataHist
 
 # Combine into one data frame and remove old.

--- a/inst/markdown/compareScenarios2/cs2_main.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_main.Rmd
@@ -196,7 +196,8 @@ dataScen %>%
   filter(period %in% params$yearsScen) ->
   dataScen
 dataHist %>%
-  filter(period %in% params$yearsHist, !(model %in% params$modelsHistExclude), !is.na(value)) ->
+  filter(period %in% params$yearsHist, !(model %in% params$modelsHistExclude), !is.na(value)) %>%
+  droplevels() ->
   dataHist
 
 # Combine into one data frame and remove old.

--- a/man/compareScenarios2.Rd
+++ b/man/compareScenarios2.Rd
@@ -81,6 +81,10 @@ choose Rmd as output format and obtain a copy of the *.Rmd-files.
     \code{NULL} or \code{character(n)}.
     Default: \code{NULL}.
     Regions to show. \code{NULL} means all.}
+  \item{\code{modelsHistExclude}}{
+    \code{character(n) or NULL}.
+    Default: \code{c()}.
+    Models in historical data to exclude.}
   \item{\code{sections}}{
     \code{character(n) or numeric(n) or NULL}.
     Default: \code{"all"}.

--- a/man/readSupplycurveBio.Rd
+++ b/man/readSupplycurveBio.Rd
@@ -6,7 +6,9 @@
 \usage{
 readSupplycurveBio(
   outputdirs,
-  userfun = function(param, x) {     return(param[[1]] + param[[2]] * x) },
+  userfun = function(param, x) {
+     return(param[[1]] + param[[2]] * x)
+ },
   mult_on = "all"
 )
 }


### PR DESCRIPTION
The optional parameter modelHistExclude allows removal of models from historical data. In some contexts, some historical data is not useful, for example does is not make sense to plot IEA ETP in plots with focus on Germany because it is coarsely downscaled from EU data and therefore not meaningful.