### PR TITLE
fix Capital Costs not aggregated in reportTechnology #283

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '36505618'
+ValidationKey: '36545748'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.90.6",
+  "version": "1.90.7",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.90.6
-Date: 2022-06-10
+Version: 1.90.7
+Date: 2022-06-21
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/R/reportTechnology.R
+++ b/R/reportTechnology.R
@@ -260,7 +260,7 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(
     factor <- 1000.
     
     tmp <- bind_category(tmp, v_investcost + v_adjustteinv_avg, category, unit, factor, techmap)
-    int2ext <- get_global_mapping(category, unit, techmap)
+    int2ext <- c(int2ext, get_global_mapping(category, unit, techmap))
   }
   
   if (tran_mod == "complex") {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.90.6**
+R package **remind2**, version **1.90.7**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -48,7 +48,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.90.6, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.90.7, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,7 +57,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.90.6},
+  note = {R package version 1.90.7},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
fixes #283 that `Tech|*|Capital Costs` variables have values for each region, but are 0 in World. The error was introduced in [this commit](https://github.com/pik-piam/remind2/commit/b643e577bf6163329c93f4fb93e80cbb9dcab9b9) in July 2021.

`int2ext <- get_global_mapping(category, unit, techmap)` which added the Capital Cost variables was overwritten some lines later, now they are joined together.