### PR TITLE
fix the aggregation issue for capital costs

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '36570636'
+ValidationKey: '36589803'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.90.8",
+  "version": "1.90.9",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.90.8
+Version: 1.90.9
 Date: 2022-06-24
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))

--- a/R/reportTechnology.R
+++ b/R/reportTechnology.R
@@ -347,7 +347,9 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(
 
 
   ### write to output ###
-  output[is.na(output)] <- 0  # substitute na by 0
+  ## substitute NA by 1E-30 to avoid that if in 2005, 2010, 2015, 2130, 2150,
+  ## output is 0 in each region, the sum is returned by speed_aggregate
+  output[is.na(output) | output == 0] <- 1E-30
   ## delete "+" and "++" from variable names
   output <- deletePlus(output)
   

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.90.8**
+R package **remind2**, version **1.90.9**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -48,7 +48,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.90.8, <https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.90.9, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,7 +57,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.90.8},
+  note = {R package version 1.90.9},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
This is a maybe not entirely beautiful fix to https://github.com/pik-piam/remind2/issues/287.

If a certain technology is not used in any region, `speed_aggregate` returned the sum of the prices in [this line of reportTechnology.R](https://github.com/orichters/remind2/blob/a33b35a912a21d211bedbfe0c6692aa0d80d9362/R/reportTechnology.R#L363) instead of the weighted average value.

Setting each value to a minimum of `1E-30` fixes this problem. The values in `output` for all these variables are `≥ 0`, so we don't cut negative values here, and the smallest non-zero value derived from my GDX is of the order of `E-12`, so setting everything on a minimum of `1E-30` only in this aggregation process does not affect actual values.

I checked that it only has impact on the value of the variables that were wrong, and mostly affect 2005, 2010, 2015, 2110, 2130 and 2150 values, except for Hydrogen were also 2020 and 2025 values were affected.