### PR TITLE
Add sub-categories of landuse emissions to REMIND report

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '36877371'
+ValidationKey: '37017400'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.92.3",
+  "version": "1.93.0",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.92.3
-Date: 2022-07-04
+Version: 1.93.0
+Date: 2022-07-07
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -1352,12 +1352,19 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
                           "Emi|CH4|Land-Use Change|+|Forest Burning (Mt CH4/yr)"),
                # land-use change Savanna Burning CH4 emissions in MtCH4
                setNames(mselect(EmiMAC, macsector = "ch4savan"),
-                          "Emi|CH4|Land-Use Change|+|Savanna Burning (Mt CH4/yr)"),
+                          "Emi|CH4|Land-Use Change|+|Savanna Burning (Mt CH4/yr)")
+  )
+
+  if ("ch4peatland" %in% mac.map$all_enty) {
+
+    out <- mbind(out,
                # land-use change Peatland CH4 emissions in MtCH4
                setNames(mselect(EmiMAC, macsector = "ch4peatland"),
-                          "Emi|CH4|Land-Use Change|+|Peatland (Mt CH4/yr)"),
+                          "Emi|CH4|Land-Use Change|+|Peatland (Mt CH4/yr)")
+    )
+  }
 
-
+  out <- mbind(out,
                # N2O Emissions
                # total N2O emissions
                setNames((dimSums(mselect(EmiMAC, gas = "n2o"), dim = 3)
@@ -1411,12 +1418,18 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
                           "Emi|N2O|Land-Use Change|+|Forest Burning (kt N2O/yr)"),
                # land-use change Savanna Burning N2O emissions in kt N2O
                setNames(mselect(EmiMAC, macsector = "n2osavan") * MtN2_to_ktN2O,
-                          "Emi|N2O|Land-Use Change|+|Savanna Burning (kt N2O/yr)"),
+                          "Emi|N2O|Land-Use Change|+|Savanna Burning (kt N2O/yr)")
+  )
+
+  if ("n2opeatland" %in% mac.map$all_enty) {
+    out <- mbind(out,
                # land-use change Peatland N2O emissions in kt N2O
                setNames(mselect(EmiMAC, macsector = "n2opeatland") * MtN2_to_ktN2O,
-                          "Emi|N2O|Land-Use Change|+|Peatland (kt N2O/yr)")
+                         "Emi|N2O|Land-Use Change|+|Peatland (kt N2O/yr)")
+    )
+  }
 
-  )
+
 
   # CH4 and N2O Emissions by sector in MtCO2eq
 

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -1319,7 +1319,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
                # extraction CH4 emissions in MtCH4
                setNames(dimSums(mselect(EmiMAC, sector = "extraction", gas = "ch4"), dim = 3),
                           "Emi|CH4|+|Extraction (Mt CH4/yr)"),
-               # extraction CH4 emissions in MtCH4
+               # Agriculture CH4 emissions in MtCH4
                setNames(dimSums(mselect(EmiMAC, sector = "Agriculture", gas = "ch4"), dim = 3),
                           "Emi|CH4|+|Agriculture (Mt CH4/yr)"),
                # waste CH4 emissions in MtCH4
@@ -1331,6 +1331,31 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
                # CH4 emissions from energy system transformations in MtCH4
                setNames(dimSums(sel_v_emiTeDetailMkt_ch4, dim = 3),
                           "Emi|CH4|+|Energy Supply (Mt CH4/yr)"),
+
+               # CH4 Agriculture sub-categories
+               # Agriculture Rice CH4 emissions in MtCH4
+               setNames(mselect(EmiMAC, macsector = "ch4rice"),
+                          "Emi|CH4|Agriculture|+|Rice (Mt CH4/yr)"),
+               # Agriculture Enteric fermentation CH4 emissions in MtCH4
+               setNames(mselect(EmiMAC, macsector = "ch4animals"),
+                          "Emi|CH4|Agriculture|+|Enteric fermentation (Mt CH4/yr)"),
+               # Agriculture Animal waste management CH4 emissions in MtCH4
+               setNames(mselect(EmiMAC, macsector = "ch4anmlwst"),
+                          "Emi|CH4|Agriculture|+|Animal waste management (Mt CH4/yr)"),
+               # Agriculture Waste Burning CH4 emissions in MtCH4
+               setNames(mselect(EmiMAC, macsector = "ch4agwaste"),
+                          "Emi|CH4|Agriculture|+|Waste Burning (Mt CH4/yr)"),
+
+               # CH4 land-use change sub-categories
+               # land-use change Forest Burning CH4 emissions in MtCH4
+               setNames(mselect(EmiMAC, macsector = "ch4forest"),
+                          "Emi|CH4|Land-Use Change|+|Forest Burning (Mt CH4/yr)"),
+               # land-use change Savanna Burning CH4 emissions in MtCH4
+               setNames(mselect(EmiMAC, macsector = "ch4savan"),
+                          "Emi|CH4|Land-Use Change|+|Savanna Burning (Mt CH4/yr)"),
+               # land-use change Peatland CH4 emissions in MtCH4
+               setNames(mselect(EmiMAC, macsector = "ch4peatland"),
+                          "Emi|CH4|Land-Use Change|+|Peatland (Mt CH4/yr)"),
 
 
                # N2O Emissions
@@ -1355,7 +1380,42 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
                           "Emi|N2O|+|Industry (kt N2O/yr)"),
                # N2O emissions from energy system transformations in kt N2O
                setNames(dimSums(sel_v_emiTeDetailMkt_n2o, dim = 3) * MtN2_to_ktN2O,
-                          "Emi|N2O|+|Energy Supply (kt N2O/yr)")
+                          "Emi|N2O|+|Energy Supply (kt N2O/yr)"),
+
+               # N2O agricultural sub-categories
+               # Agriculture Inorganic Fertilizer N2O emissions in kt N2O
+               setNames(mselect(EmiMAC, macsector = "n2ofertin") * MtN2_to_ktN2O,
+                          "Emi|N2O|Agriculture|+|Inorganic Fertilizers (kt N2O/yr)"),
+               # Agriculture Decay of Crop Residues N2O emissions in kt N2O
+               setNames(mselect(EmiMAC, macsector = "n2ofertcr") * MtN2_to_ktN2O,
+                          "Emi|N2O|Agriculture|+|Decay of Crop Residues (kt N2O/yr)"),
+               # Agriculture Soil Organic Matter Loss N2O emissions in kt N2O
+               setNames(mselect(EmiMAC, macsector = "n2ofertsom") * MtN2_to_ktN2O,
+                          "Emi|N2O|Agriculture|+|Soil Organic Matter Loss (kt N2O/yr)"),
+               # Agriculture Manure applied to Croplands N2O emissions in kt N2O
+               setNames(mselect(EmiMAC, macsector = "n2oanwstc") * MtN2_to_ktN2O,
+                          "Emi|N2O|Agriculture|+|Manure applied to Croplands (kt N2O/yr)"),
+               # Agriculture Animal Waste Management N2O emissions in kt N2O
+               setNames(mselect(EmiMAC, macsector = "n2oanwstm") * MtN2_to_ktN2O,
+                          "Emi|N2O|Agriculture|+|Animal Waste Management (kt N2O/yr)"),
+               # Agriculture Pasture N2O emissions in kt N2O
+               setNames(mselect(EmiMAC, macsector = "n2oanwstp") * MtN2_to_ktN2O,
+                          "Emi|N2O|Agriculture|+|Pasture (kt N2O/yr)"),
+               # Agriculture Burning of Crop Residues N2O emissions in kt N2O
+               setNames(mselect(EmiMAC, macsector = "n2oagwaste") * MtN2_to_ktN2O,
+                          "Emi|N2O|Agriculture|+|Waste Burning (kt N2O/yr)"),
+
+               # N2O land-use change sub-categories
+               # land-use change Forest Burning N2O emissions in kt N2O
+               setNames(mselect(EmiMAC, macsector = "n2oforest") * MtN2_to_ktN2O,
+                          "Emi|N2O|Land-Use Change|+|Forest Burning (kt N2O/yr)"),
+               # land-use change Savanna Burning N2O emissions in kt N2O
+               setNames(mselect(EmiMAC, macsector = "n2osavan") * MtN2_to_ktN2O,
+                          "Emi|N2O|Land-Use Change|+|Savanna Burning (kt N2O/yr)"),
+               # land-use change Peatland N2O emissions in kt N2O
+               setNames(mselect(EmiMAC, macsector = "n2opeatland") * MtN2_to_ktN2O,
+                          "Emi|N2O|Land-Use Change|+|Peatland (kt N2O/yr)")
+
   )
 
   # CH4 and N2O Emissions by sector in MtCO2eq

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.92.3**
+R package **remind2**, version **1.93.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -48,7 +48,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.92.3, <https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.93.0, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,7 +57,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.92.3},
+  note = {R package version 1.93.0},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
They seem to have vanished when the emisssions reporting was refactored.