### PR TITLE
in compareScenConf, fix wrong sorting if using renamedCols or renamedRows

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '37017400'
+ValidationKey: '37057821'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -72,7 +72,7 @@ jobs:
         run: |
           ./run.sh install_aptget libhdf5-dev
           ./run.sh install_all
-          ./run.sh install_r lucode2 covr
+          ./run.sh install_r lucode2 covr rstudioapi
 
       - name: Remove bspm integration # to get rid of error when running install.packages
         run: |

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.93.0",
+  "version": "1.93.1",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.93.0
-Date: 2022-07-07
+Version: 1.93.1
+Date: 2022-07-18
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.93.0**
+R package **remind2**, version **1.93.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -48,7 +48,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.93.0, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.93.1, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,7 +57,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.93.0},
+  note = {R package version 1.93.1},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/man/compareScenConf.Rd
+++ b/man/compareScenConf.Rd
@@ -23,7 +23,8 @@ compareScenConf(
 
 \item{renamedCols}{vector with old and new column names such as c("old1" = "new1", "old2" = "new2"))}
 
-\item{renamedRows}{vector with old and new row names such as c("old3" = "new3", "old4" = "new4"))}
+\item{renamedRows}{vector with old and new row names such as c("old3" = "new3", "old3" = "new4", "old5" = "new5"))
+the "old" name can also remain in the new file, if you generated a variant}
 
 \item{printit}{boolean switch (default: TRUE) whether function prints its output}
 }

--- a/tests/testthat/test-compareScenConf.R
+++ b/tests/testthat/test-compareScenConf.R
@@ -16,9 +16,9 @@ test_that("Check compareScenConf", {
                        "description" = c("D", "E", "F"),
                        row.names = "title")
   write.csv2(csv2df, file2)
-  csv3df <- data.frame("title" = c("default", "SSP2-Base", "SSP6-Base"),
-                       "startnew" = c(1, 1, 0),
-                       "value" = c(1, 2, 3),
+  csv3df <- data.frame("title" = c("default", "SSP2-Base", "SSP6-Base", "SSP7-Base"),
+                       "startnew" = c(1, 1, 0, 2),
+                       "value" = c(1, 2, 3, 4),
                        row.names = "title")
   write.csv2(csv3df, file3)
   # normal case: should go through without a warning
@@ -28,17 +28,17 @@ test_that("Check compareScenConf", {
   expect_true(sum(grepl("description: was changed", test1$out)) == 3)
   # check renamed column start -> startnew
   test2 <- compareScenConf(fileList = c(file1, file3), renamedCols = c(start = "startnew"),
-                           renamedRows = c("SSP5-Base" = "SSP6-Base"), printit = FALSE)
+                           renamedRows = c("SSP5-Base" = "SSP6-Base", "SSP5-Base" = "SSP7-Base"), printit = FALSE)
   expect_true(is.null(test2$allwarnings))
   expect_true(any(grepl("Renamed columns:.*start -> startnew", test2$out)))
   expect_true(any(grepl("Renamed rows:.*SSP5-Base -> SSP6-Base", test2$out)))
+  expect_true(any(grepl("Renamed rows:.*SSP5-Base -> SSP7-Base", test2$out)))
   # check renamed column and row where this didn't happen
   test3 <- suppressWarnings(compareScenConf(fileList = c(file1, file2), renamedCols = c(start = "startnew"),
                                             renamedRows = c("SSP5-Base" = "SSP6-Base"), printit = FALSE,
                                             configfile = "default2.cfg"))
-  expect_true(all(c("oldColAlsoIn2", "newColNotIn2", "oldRowAlsoIn2", "newRowNotIn2") %in% names(test3$allwarnings)) &
+  expect_true(all(c("oldColAlsoIn2", "newColNotIn2", "newRowNotIn2") %in% names(test3$allwarnings)) &
               ! any(c("oldColNotIn1", "newColAlsoIn1", "newRowNotIn1", "newRowAlsoIn1") %in% names(test3$allwarnings)))
-  expect_true(all(c("- SSP6-Base was deleted.", "+ SSP5-Base was added.") %in% test3$out))
   expect_true(any(grepl("Columns deleted:.*startnew", test3$out)))
   expect_true(any(grepl("Columns added:.*start", test3$out)))
   expect_true(! any(grepl("No configfile", test3$out)))
@@ -47,7 +47,7 @@ test_that("Check compareScenConf", {
                                             renamedRows = c("SSP9-Base" = "SSP5-Base"), printit = FALSE,
                                             configfile = "nonexisting.cfg"))
   expect_true(all(c("oldColNotIn1", "newColAlsoIn1", "newRowNotIn1", "newRowAlsoIn1") %in% names(test4$allwarnings)) &
-              ! any(c("oldColAlsoIn2", "newColNotIn2", "oldRowAlsoIn2", "newRowNotIn2") %in% names(test4$allwarnings)))
+              ! any(c("oldColAlsoIn2", "newColNotIn2", "newRowNotIn2") %in% names(test4$allwarnings)))
   expect_true(any(grepl("No configfile nonexisting.cfg found in ", test4$out)))
   unlink(c(file1, file2, file3, "default.cfg", "default2.cfg"))
 })


### PR DESCRIPTION
- if the renamedCols or renamedRows are not defined in the same order as in the config file, the printed messages were incorrect, comparing the wrong scenarios with each other.
- you can now use the "old" feature in `renamedRows` multiple times with the same "old" scenario, and it also is no problem anymore if an old name is still present in the new file. This allows to create variants of a scenario and show the difference to the old one, while keeping the old in the file