### PR TITLE
Table hold and fix names in cs2

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '37466688'
+ValidationKey: '37493694'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          ./run.sh install_aptget libhdf5-dev
+          ./run.sh install_aptget libhdf5-dev libharfbuzz-dev libfribidi-dev
           ./run.sh install_all
           ./run.sh install_r lucode2 covr rstudioapi
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,22 @@ repos:
     hooks:
     -   id: check-case-conflict
     -   id: check-json
-    -   id: check-yaml
     -   id: check-merge-conflict
+    -   id: check-yaml
     -   id: fix-byte-order-marker
+    -   id: check-added-large-files
+        args: ['--maxkb=100']
+    -   id: mixed-line-ending
+
+-   repo: https://github.com/lorenzwalthert/precommit
+    rev: v0.3.2
+    hooks:
+    -   id: parsable-R
+    -   id: deps-in-desc
+        args: [--allow_private_imports]
+    -   id: no-browser-statement
+    -   id: no-debug-statement
+    -   id: readme-rmd-rendered
+    -   id: use-tidy-description
 ci:
     autoupdate_schedule: quarterly

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.95.2",
+  "version": "1.95.3",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind2
 Type: Package
 Title: The REMIND R package (2nd generation)
-Version: 1.95.2
-Date: 2022-07-21
+Version: 1.95.3
+Date: 2022-07-25
 Authors@R: as.person(c(
     "Renato Rodrigues <renato.rodrigues@pik-potsdam.de> [aut,cre]"))
 Description: Contains the REMIND-specific routines for data and model output manipulation.

--- a/R/showStatsTable.R
+++ b/R/showStatsTable.R
@@ -55,7 +55,7 @@ showStatsTable <- function(statsData) {
     ) %>%
     kableExtra::kable_styling(
       bootstrap_options = c("striped", "condensed"),
-      latex_options = c("striped", "hold_position"),
+      latex_options = c("striped", "HOLD_position"),
       full_width = FALSE
     ) %>%
     kableExtra::column_spec(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.95.2**
+R package **remind2**, version **1.95.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -48,7 +48,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.95.2, <https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.95.3, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,7 +57,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.95.2},
+  note = {R package version 1.95.3},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/inst/markdown/compareScenarios2/cs2_00_info.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_00_info.Rmd
@@ -13,7 +13,7 @@ fileReference %>%
     col.names = c("ID", "Name Used Here", "Original Name", "Path")) %>%
   kable_styling(
     bootstrap_options = c("condensed"),
-    latex_options = c("hold_position")) %>%
+    latex_options = c("HOLD_position")) %>%
   column_spec(1:4, background = bkgndColors) %>%
   column_spec(2:3, width = "5.5cm") %>%
   column_spec(4, width = "15.5cm")

--- a/inst/markdown/compareScenarios2/cs2_03_emissions.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_03_emissions.Rmd
@@ -247,7 +247,7 @@ showLinePlots(data, items)
 ### non-BECCS CDR
 
 ```{r}
-showLinePlots(data, "non-BECCS CDR")
+showLinePlots(data, "Emi|CO2|non-BECCS CDR")
 ```
 
 ### CDR
@@ -421,7 +421,7 @@ showAreaAndBarPlots(data, items, tot)
 ### F-Gases
 
 ```{r}
-showLinePlots(data, "Emi|GHG|FALSE-Gases")
+showLinePlots(data, "Emi|GHG|F-Gases")
 ```
 
 ## Industry Subsector Emissions

--- a/inst/markdown/compareScenarios2/cs2_04_energy_supply.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_04_energy_supply.Rmd
@@ -216,25 +216,25 @@ items <- c(
   "FE|Buildings|Hydrogen",
   "FE|Transport|Hydrogen",
   "FE|CDR|Hydrogen",
-  "SE|Input|Hydrogen|Electricity|Normal Turbines (EJ/yr)",
-  "SE|Input|Hydrogen|Electricity|Forced VRE Turbines (EJ/yr)",
-  "SE|Input|Hydrogen|Synthetic Fuels|Liquids (EJ/yr)",
-  "SE|Input|Hydrogen|Synthetic Fuels|Gases (EJ/yr)")
+  "SE|Input|Hydrogen|Electricity|Normal Turbines",
+  "SE|Input|Hydrogen|Electricity|Forced VRE Turbines",
+  "SE|Input|Hydrogen|Synthetic Fuels|Liquids",
+  "SE|Input|Hydrogen|Synthetic Fuels|Gases")
 showAreaAndBarPlots(data, items)
 ```
 
 ### SE|Electricity - Usage
 ```{r}
 items <- c(
-  "SE|Input|Hydrogen|Synthetic Fuels|Gases (EJ/yr)",
-  "SE|Input|Hydrogen|Synthetic Fuels|Liquids (EJ/yr)",
-  "SE|Input|Electricity|Hydrogen|direct FE H2 (EJ/yr)",
-  "SE|Input|Electricity|Hydrogen|VRE Storage (EJ/yr)",
-  "SE|Input|Electricity|Buildings (EJ/yr)",
-  "SE|Input|Electricity|Industry (EJ/yr)",
-  "SE|Input|Electricity|Transport (EJ/yr)",
-  "SE|Input|Electricity|CDR (EJ/yr)",
-  "SE|Input|Electricity|Self Consumption Energy System (EJ/yr)")
+  "SE|Input|Hydrogen|Synthetic Fuels|Gases",
+  "SE|Input|Hydrogen|Synthetic Fuels|Liquids",
+  "SE|Input|Electricity|Hydrogen|direct FE H2",
+  "SE|Input|Electricity|Hydrogen|VRE Storage",
+  "SE|Input|Electricity|Buildings",
+  "SE|Input|Electricity|Industry",
+  "SE|Input|Electricity|Transport",
+  "SE|Input|Electricity|CDR",
+  "SE|Input|Electricity|Self Consumption Energy System")
 
 showAreaAndBarPlots(data, items)
 ```

--- a/inst/markdown/compareScenarios2/cs2_99_further_info.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_99_further_info.Rmd
@@ -32,7 +32,7 @@ showInTables <- function(
         out %>%
         kable_styling(
           bootstrap_options = c("striped", "condensed"),
-          latex_options = c("striped", "hold_position")
+          latex_options = c("striped", "HOLD_position")
         )
     } else {
       out <-
@@ -43,7 +43,7 @@ showInTables <- function(
         ) %>%
         kable_styling(
           bootstrap_options = c("condensed"),
-          latex_options = c("hold_position")
+          latex_options = c("HOLD_position")
         )
     }
     out <-

--- a/inst/markdown/compareScenarios2/cs2_main.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_main.Rmd
@@ -8,6 +8,7 @@ output:
     toc_depth: 6
     keep_tex: false
     template: cs2_latex_template.tex
+    extra_dependencies: ["float"]
     includes: 
       in_header: cs2_pdf_header_include.tex
   html_document:
@@ -43,7 +44,8 @@ knitr::opts_chunk$set(
   message = FALSE,
   warning = params$warning,
   fig.width = params$figWidth,
-  fig.height = params$figHeight)
+  fig.height = params$figHeight,
+  fig.pos = "H")
 ```
 
 

--- a/vignettes/compareScenarios2.Rmd
+++ b/vignettes/compareScenarios2.Rmd
@@ -219,7 +219,7 @@ If `compareScenarios2()` is provided with paths to the `config.Rdata` files of t
 compareScenarios2(
   mifScen = c("path/to/scen1.mif", "path/to/scen2.mif"),
   cfgScen = c("path/to/scen1/config.RData", "path/to/scen2/config.RData"),
-  cfgDefault = "path/to/default.cfg"
+  cfgDefault = "path/to/default.cfg",
   ...)
 ```
 


### PR DESCRIPTION
* use `HOLD_position` instead of `hold_postion` to make sure that tables in PDF output of cs2 are placed at the specified position.
* correct some misnamed variable names in the cs2 Rmd files