### PR TITLE
cs2 refactoring

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '211516227'
+ValidationKey: '211535454'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.100.1",
+  "version": "1.100.2",
   "description": "<p>Contains the REMIND-specific routines for data and model\n    output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.100.1
+Version: 1.100.2
 Date: 2022-08-23
 Authors@R: 
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre"))

--- a/R/loadModeltest.R
+++ b/R/loadModeltest.R
@@ -138,6 +138,13 @@ loadModeltest <- function(
   modeltests <- getNewsestModeltests(namePattern, requireMif = TRUE)
   if (NROW(modeltests) == 0) stop("Did not find model tests.")
   path <- cs2InputPaths(modeltests$path)
+
+  if (!dir.exists(folder)) {
+    cat(folder, "does not exist -> creating it.\n")
+    dir.create(folder, recursive = TRUE)
+  }
+  folder <- normalizePath(folder, mustWork = TRUE)
+
   tmpPath <- list(
     mifScen = file.path(folder, paste0(modeltests$name, ".mif")),
     mifHist = file.path(folder, "historical.mif"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.100.1**
+R package **remind2**, version **1.100.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.100.1, <https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.100.2, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.100.1},
+  note = {R package version 1.100.2},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/inst/markdown/compareScenarios2/cs2_main.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_main.Rmd
@@ -82,10 +82,10 @@ if (interactive()) {
 # may cause "Undefined control sequence" errors in LaTeX.
 try(unloadNamespace("kableExtra"), silent = TRUE)
 
-library(gridExtra) # nolint
+suppressMessages(library(gridExtra)) # nolint
 options(tidyverse.quiet = TRUE) # nolint
 library(tidyverse) # nolint
-library(kableExtra) # nolint
+suppressMessages(library(kableExtra)) # nolint
 library(quitte) # nolint
 library(mip) # nolint
 library(remind2) # nolint
@@ -131,14 +131,10 @@ if (!is.null(params$cfgDefault)) {
 dataScenNested <-
   tibble(path = unname(params$mifScen)) %>%
   rowid_to_column("fileid") %>%
-  mutate(data = map(
-    path,
-    read.quitte,
-    factors = TRUE,
-    # read.quitte() default NA-strings and Inf, -Inf
-    na.strings = c("UNDF", "NA", "N/A", "n_a", "Inf", "-Inf"))) %>%
+  mutate(data = map(path, read.quitte)) %>%
   unnest(data) %>%
   nest(data = -c(fileid, path, scenario))
+
 # Add column character column "newScenarioName",
 # either with contents of params$mifScenNames or copy names from column scenario.
 if (is.null(params$mifScenNames)) {
@@ -154,6 +150,7 @@ if (is.null(params$mifScenNames)) {
         newScenarioName = params$mifScenNames),
       by = "fileid")
 }
+
 # Check for duplicated scenario names.
 if (anyDuplicated(dataScenNested$newScenarioName)) {
   warning("There are duplicated scenario names. They will be renamed.")
@@ -161,6 +158,7 @@ if (anyDuplicated(dataScenNested$newScenarioName)) {
     dataScenNested %>%
     mutate(newScenarioName = make.unique(newScenarioName))
 }
+
 # Retrieve data for reference table to be shown at the beginning of the document.
 fileReference <-
   dataScenNested %>%
@@ -203,9 +201,8 @@ dataHist <-
   filter(period %in% params$yearsHist, !(model %in% params$modelsHistExclude), !is.na(value)) %>%
   droplevels()
 
-# Combine into one data frame and remove old.
+# Combine into one data frame.
 data <- bind_rows(dataScen, dataHist)
-rm(dataScen, dataScenNested, dataHist)
 
 data <-
   data %>%
@@ -421,6 +418,20 @@ if (length(params$sections) == 1 && params$sections == "all") {
   }
 }
 ```
+
+```{r remove objects not to be used anymore}
+varNames <- c( 
+  "availableSections", "cfgTopLevel", "dataGDP", "dataPCap", 
+  "dataPGdp", "dataPop", "dataScenNested", "env", "envToolsRstudio", 
+  "fn", "histRefModel", "insertExprAtStartOfFun", "lightenColor", 
+  "loadCfg", "matches", "oldRsSetNotebookGraphicsOption", "pCapVariables", 
+  "pGdpVariables")
+for (vn in varNames) if (exists(vn)) rm(list = vn)
+rm(varNames)
+rm(vn)
+gc()
+```
+
 
 
 ```{r prepare mark}

--- a/inst/markdown/compareScenarios2/cs2_main.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_main.Rmd
@@ -420,11 +420,11 @@ if (length(params$sections) == 1 && params$sections == "all") {
 ```
 
 ```{r remove objects not to be used anymore}
-varNames <- c( 
-  "availableSections", "cfgTopLevel", "dataGDP", "dataPCap", 
-  "dataPGdp", "dataPop", "dataScenNested", "env", "envToolsRstudio", 
-  "fn", "histRefModel", "insertExprAtStartOfFun", "lightenColor", 
-  "loadCfg", "matches", "oldRsSetNotebookGraphicsOption", "pCapVariables", 
+varNames <- c(
+  "availableSections", "cfgTopLevel", "dataGDP", "dataPCap",
+  "dataPGdp", "dataPop", "dataScenNested", "env", "envToolsRstudio",
+  "fn", "histRefModel", "insertExprAtStartOfFun", "lightenColor",
+  "loadCfg", "matches", "oldRsSetNotebookGraphicsOption", "pCapVariables",
   "pGdpVariables")
 for (vn in varNames) if (exists(vn)) rm(list = vn)
 rm(varNames)

--- a/vignettes/compareScenarios2.Rmd
+++ b/vignettes/compareScenarios2.Rmd
@@ -118,7 +118,7 @@ Now we want to load the `data` object so that the code-chunks can be executed. I
 3. Clone the repository and switch to the newly created branch to get your local copy.
 4. In your local copy, open `remind2.Rproj` in RStudio.
 5. Press `CTRL+SHIFT+L` to call `devtools::load_all(".")`, which loads `remind2` from your local copy.
-6. If it is sufficient to test your new plots on the latest AMTs and you are connected to the PIK network (possibly via VPN), call `loadModeltest()`. Otherwise call an adapted form of 
+6. If it is sufficient to test your new plots on the latest AMTs and you are connected to the PIK network (possibly via VPN), call `loadModeltest(folder = "some/folder")`. Otherwise call an adapted form of 
 
 ```{r}
 loadCs2Data(
@@ -133,7 +133,7 @@ This might take some time (up to 1min). After this, an R-object `data` should be
 9. Insert a new chunk by copying an old one or by pressing `CTRL+ALT+I`. Note: It is better to not assign names to the chunks as cs2 will crash if you used the same name twice.
 10. Add a new plot inside the chunk, e.g., `showLinePlots(data, "Your|Variable|Name")`. See [Plot Functions] below.
 11. Run your newly created chunk to see the plot.
-12. Run the following code to see your new plot in a PDF.
+12. Run the following code to see your new plot in a PDF. If you used `loadModeltest()` in 6., mif-files should be available in `some/folder/`.
 
 ```{r}
 compareScenarios2(


### PR DESCRIPTION
* suppress messages form packages loaded in `cs2_main.Rmd`
* use default `na.strings` when calling `read.quitte()` in `cs2_main.Rmd`, see https://github.com/pik-piam/remind2/issues/314
* clean up environment after loading of data in `cs2_main.Rmd`. This is helpful as some functions like `loadCs2Data()` or `loadModeltest()` run `cs2_main.Rmd` to make objects containing the loaded information (like `data`) available to the user. Now the users environment gets less polluted. Furthermore, it makes it implicitly defines, which variables are allowed to be used in further Rmd-section.
* `loadModeltest(folder = "some/folder")` now creates the folder if it does not exist
* small improvement to the cs2 vignette