### PR TITLE
change renewable marginal capacity factor calculation

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '212008170'
+ValidationKey: '212250290'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.102.2",
+  "version": "1.103.0",
   "description": "<p>Contains the REMIND-specific routines for data and model\n    output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.102.2
-Date: 2022-08-31
+Version: 1.103.0
+Date: 2022-09-08
 Authors@R: 
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre"))
 Description: Contains the REMIND-specific routines for data and model

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.102.2**
+R package **remind2**, version **1.103.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.102.2, <https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.103.0, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.102.2},
+  note = {R package version 1.103.0},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/man/readSupplycurveBio.Rd
+++ b/man/readSupplycurveBio.Rd
@@ -6,9 +6,7 @@
 \usage{
 readSupplycurveBio(
   outputdirs,
-  userfun = function(param, x) {
-     return(param[[1]] + param[[2]] * x)
- },
+  userfun = function(param, x) {     return(param[[1]] + param[[2]] * x) },
   mult_on = "all"
 )
 }


### PR DESCRIPTION
change how marginal cost is calculated in reportLCOE, now renewable capacity factor takes the lowest filled grade, not the highest grade that is still free (<90% filled)

The reason we made this change is due to hydro capacity factor in Germany in REMIND and in reporting are not aligned. 

Robert:
"Now for hydro, it seems REMIND stays always inside grade 4, but fills it (as much as possible with the deltacap/2-zigzag), so that the model sees the CF of grade 4, while the reporting sees the CF of grade 5
I would change the reporting and use the last grade that is still filled
this will then slightly overestimate CF for the cases that the model expands this technology, but in such a case it will anyway go into the next bad grade in the next time step, so it should in general look better"