### PR TITLE
increase reporting compatibility with older runs

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '212250290'
+ValidationKey: '212401905'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -11,7 +11,7 @@ on:
 env:
   USE_BSPM: "true"
   _R_CHECK_FORCE_SUGGESTS_: "false"
-  NO_BINARY_INSTALL_R_PACKAGES: 'c("madrat", "magclass", "citation", "gms", "goxygen", "GDPuc")'
+  NO_BINARY_INSTALL_R_PACKAGES: 'c("madrat", "magclass", "citation", "gms", "goxygen", "GDPuc", "roxygen2")'
 
 jobs:
   lucode2-check:

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.103.0",
+  "version": "1.103.1",
   "description": "<p>Contains the REMIND-specific routines for data and model\n    output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.103.0
-Date: 2022-09-08
+Version: 1.103.1
+Date: 2022-09-20
 Authors@R: 
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre"))
 Description: Contains the REMIND-specific routines for data and model

--- a/R/reportMacroEconomy.R
+++ b/R/reportMacroEconomy.R
@@ -245,8 +245,7 @@ reportMacroEconomy <- function(gdx, regionSubsetList = NULL,
   #  but that serve as diagnostic output for understanding REMIND results better)
 
   # check that CES derivatives output parameter exists in GDX
-  if (length(o01_CESderivatives > 0)) {
-
+  if ((length(o01_CESmrs > 0)) & (length(o01_CESderivatives > 0))) {
 
   ## 1.) CES Prices (CES Derivatives)
 
@@ -364,7 +363,7 @@ reportMacroEconomy <- function(gdx, regionSubsetList = NULL,
                        grep("Internal\\|CES Function\\|CES Price", getNames(out), value=T))
 
 
-  if (length(o01_CESderivatives > 0)) {
+  if ((length(o01_CESmrs > 0)) & (length(o01_CESderivatives > 0))) {
     # set to zero instead of NA because NA erases the labels in compare scenario 2
     out[setdiff(getRegions(out), getRegions(CES.price)),,vars.remove.agg] <- 0
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.103.0**
+R package **remind2**, version **1.103.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.103.0, <https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.103.1, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.103.0},
+  note = {R package version 1.103.1},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/man/readSupplycurveBio.Rd
+++ b/man/readSupplycurveBio.Rd
@@ -6,7 +6,9 @@
 \usage{
 readSupplycurveBio(
   outputdirs,
-  userfun = function(param, x) {     return(param[[1]] + param[[2]] * x) },
+  userfun = function(param, x) {
+     return(param[[1]] + param[[2]] * x)
+ },
   mult_on = "all"
 )
 }


### PR DESCRIPTION
Extending the solution introduced in this commit https://github.com/pik-piam/remind2/commit/b59d0a3b0fc2f301783aeec36679a895c6fab1ec to increase compatibility with older runs like: `/p/projects/remind/users/renatoro/ECEMF/v04_2022_04_06/output/04_DIAG-NZero_2022-04-08_16.53.53`