### PR TITLE
Make getMifScenPath find reportings also from coupled runs

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '212498384'
+ValidationKey: '212517646'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '212401905'
+ValidationKey: '212498384'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.103.2",
+  "version": "1.103.3",
   "description": "<p>Contains the REMIND-specific routines for data and model\n    output manipulation.<\/p>",
   "creators": [
     {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.103.1",
+  "version": "1.103.2",
   "description": "<p>Contains the REMIND-specific routines for data and model\n    output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.103.1
-Date: 2022-09-20
+Version: 1.103.2
+Date: 2022-09-27
 Authors@R: 
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre"))
 Description: Contains the REMIND-specific routines for data and model

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.103.2
+Version: 1.103.3
 Date: 2022-09-27
 Authors@R: 
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre"))

--- a/R/getPath.R
+++ b/R/getPath.R
@@ -1,8 +1,3 @@
-getScenNamesFast <- function(outputDirs) {
-  folder <- basename(outputDirs)
-  substr(folder, start = 0, stop = nchar(folder) - 20)
-}
-
 #' Get Paths to Certain Files in the REMIND Directory
 #'
 #' \code{getMifScenPath}: get path to the scenarios' reporting mifs.
@@ -16,8 +11,10 @@ getScenNamesFast <- function(outputDirs) {
 #' @rdname getPath
 #' @export
 getMifScenPath <- function(outputDirs, mustWork = FALSE) {
-  names <- getScenNamesFast(outputDirs)
-  path <- file.path(outputDirs, paste0("REMIND_generic_", names, ".mif"))
+  # Find all mif files starting with REMIND_generic_. The result will also contain REMIND_generic_withoutPlus.mif
+  reports <- list.files(outputDirs, "^REMIND_generic_.*\\.mif$", full.names = TRUE)
+  # Filter out filenames having "withoutPlus.mif" in their name
+  path <- reports[grepl("REMIND_generic_(?!.*(withoutPlus)\\.mif).*\\.mif$", reports, perl = TRUE)]
   normalizePath(path, mustWork = mustWork)
 }
 

--- a/R/getPath.R
+++ b/R/getPath.R
@@ -11,11 +11,9 @@
 #' @rdname getPath
 #' @export
 getMifScenPath <- function(outputDirs, mustWork = FALSE) {
-  # Find all mif files starting with REMIND_generic_. The result will also contain REMIND_generic_withoutPlus.mif
-  reports <- list.files(outputDirs, "^REMIND_generic_.*\\.mif$", full.names = TRUE)
-  # Filter out filenames having "withoutPlus.mif" in their name
-  path <- reports[grepl("REMIND_generic_(?!.*(withoutPlus)\\.mif).*\\.mif$", reports, perl = TRUE)]
-  normalizePath(path, mustWork = mustWork)
+  scenNames <- lucode2::getScenNames(outputDirs)
+  path <- file.path(outputDirs, paste0("REMIND_generic_", scenNames, ".mif"))
+  return(normalizePath(path, mustWork = mustWork))
 }
 
 #' @rdname getPath

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.103.2**
+R package **remind2**, version **1.103.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.103.2, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.103.3, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.103.2},
+  note = {R package version 1.103.3},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.103.1**
+R package **remind2**, version **1.103.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.103.1, <https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.103.2, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.103.1},
+  note = {R package version 1.103.2},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
Remove old function that was making up the reporting filename from the name of the results folder and was relying on result folders that end with a time stamp. Now: explicitly searching for existing mif files.