### PR TITLE
fix Total Energy costs|Liquids|Fossil error in reportCosts

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '212752008'
+ValidationKey: '212934058'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -67,9 +67,9 @@ jobs:
         uses: pat-s/always-upload-cache@v3
         with:
           path: /usr/local/lib/R/
-          key: ${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
+          key: 2-${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
           restore-keys: |
-            ${{ runner.os }}-usr-local-lib-R-
+            2-${{ runner.os }}-usr-local-lib-R-
 
       - name: Restore R library permissions
         run: |
@@ -79,7 +79,8 @@ jobs:
         run: |
           ./run.sh install_aptget libhdf5-dev libharfbuzz-dev libfribidi-dev
           ./run.sh install_all
-          ./run.sh install_r lucode2 covr rstudioapi
+          ./run.sh install_r_binary covr rstudioapi
+          ./run.sh install_r lucode2
 
       - name: Install python dependencies if applicable
         run: |

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.103.6",
+  "version": "1.103.8",
   "description": "<p>Contains the REMIND-specific routines for data and model\n    output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.103.6
-Date: 2022-10-13
+Version: 1.103.8
+Date: 2022-10-26
 Authors@R: 
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre"))
 Description: Contains the REMIND-specific routines for data and model

--- a/R/reportCosts.R
+++ b/R/reportCosts.R
@@ -556,16 +556,15 @@ reportCosts <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,
   tmp  <- mbind(tmp,setNames(cost_pe2se + cost_se2fe + output[regi_on_gdx,,"Energy Investments|Liquids (billion US$2005/yr)"], "Total Energy costs|Liquids (billion US$2005/yr)"))
   
   ##### Liquids|Oil Ref
-  cost <- op_costs(ei="peoil",eo=se_Liq,te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Liquids|Oil Ref (billion US$2005/yr)"], "Total Energy costs|Liquids|Oil Ref (billion US$2005/yr)"))
+  costoil <- op_costs(ei="peoil",eo=se_Liq,te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
+  tmp  <- mbind(tmp,setNames(costoil + output[regi_on_gdx,,"Energy Investments|Liquids|Oil Ref (billion US$2005/yr)"], "Total Energy costs|Liquids|Oil Ref (billion US$2005/yr)"))
   
-  ##### Liquids|Fossil|w/ oil
+  ##### Liquids|Fossil
   cost <- op_costs(ei=petyf,eo=se_Liq,te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Liquids|Fossil|w/o oil (billion US$2005/yr)"], "Total Energy costs|Liquids|Fossil|w/o oil (billion US$2005/yr)"))
-  
-  ##### Liquids|Fossil 
-  cost <- op_costs(ei="pecoal",eo=se_Liq,te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
   tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Liquids|Fossil (billion US$2005/yr)"], "Total Energy costs|Liquids|Fossil (billion US$2005/yr)"))
+
+  ##### Liquids|Fossil|w/o oil
+  tmp  <- mbind(tmp,setNames(cost - costoil + output[regi_on_gdx,,"Energy Investments|Liquids|Fossil|w/o oil (billion US$2005/yr)"], "Total Energy costs|Liquids|Fossil|w/o oil (billion US$2005/yr)"))
   
   ##### Liquids|Bio
   cost <- op_costs(ei=perenew,eo=se_Liq,te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.103.6**
+R package **remind2**, version **1.103.8**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.103.6, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.103.8, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues},
   year = {2022},
-  note = {R package version 1.103.6},
+  note = {R package version 1.103.8},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
- errors @Renato-Rodrigues identified after digging into this error https://github.com/pik-piam/piamInterfaces/issues/15:
- `Total Energy costs|Liquids|Fossil|w/o oil` contained all of `petyf` and therefore oil as well
- `Total Energy costs|Liquids|Fossil` contained only coal
- I don't know if I fixed it correctly, let me know, @dklein-pik :)
- (I will run the buildLibrary stuff later)