### PR TITLE
in cs2 fix y-axis for area plots and write warnings to log, not PDF. + Add all contributors

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2132005668'
+ValidationKey: '2132135313'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.103.18",
+  "version": "1.103.19",
   "description": "<p>Contains the REMIND-specific routines for data and model\n    output manipulation.<\/p>",
   "creators": [
     {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -5,6 +5,90 @@
   "creators": [
     {
       "name": "Rodrigues, Renato"
+    },
+    {
+      "name": "Baumstark, Lavinia"
+    },
+    {
+      "name": "Benke, Falk"
+    },
+    {
+      "name": "Dietrich, Jan Philipp"
+    },
+    {
+      "name": "Dirnaichner, Alois"
+    },
+    {
+      "name": "Führlich, Pascal"
+    },
+    {
+      "name": "Giannousakis, Anastasis"
+    },
+    {
+      "name": "Hasse, Robin"
+    },
+    {
+      "name": "Hilaire, Jérome"
+    },
+    {
+      "name": "Klein, David"
+    },
+    {
+      "name": "Koch, Johannes"
+    },
+    {
+      "name": "Kowalczyk, Katarzyna"
+    },
+    {
+      "name": "Levesque, Antoine"
+    },
+    {
+      "name": "Malik, Aman"
+    },
+    {
+      "name": "Merfort, Anne"
+    },
+    {
+      "name": "Merfort, Leon"
+    },
+    {
+      "name": "Morena-Leiva, Simón"
+    },
+    {
+      "name": "Pehl, Michaja"
+    },
+    {
+      "name": "Pietzcker, Robert"
+    },
+    {
+      "name": "Rauner, Sebastian"
+    },
+    {
+      "name": "Richters, Oliver"
+    },
+    {
+      "name": "Rottoli, Marianna"
+    },
+    {
+      "name": "Schötz, Christof"
+    },
+    {
+      "name": "Schreyer, Felix"
+    },
+    {
+      "name": "Siala, Kais"
+    },
+    {
+      "name": "Sörgel, Björn"
+    },
+    {
+      "name": "Spahr, Mike"
+    },
+    {
+      "name": "Strefler, Jessica"
+    },
+    {
+      "name": "Verpoort, Philipp"
     }
   ]
 }

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.103.18
-Date: 2022-11-30
+Version: 1.103.19
+Date: 2022-12-01
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,8 +3,37 @@ Package: remind2
 Title: The REMIND R package (2nd generation)
 Version: 1.103.18
 Date: 2022-11-30
-Authors@R: 
-    person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre"))
+Authors@R: c(
+    person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
+    person("Lavinia", "Baumstark", role = "aut"),
+    person("Falk", "Benke", role = "aut"),
+    person("Jan Philipp", "Dietrich", role = "aut"),
+    person("Alois", "Dirnaichner", role = "aut"),
+    person("Pascal", "Führlich", role = "aut"),
+    person("Anastasis", "Giannousakis", role = "aut"),
+    person("Robin", "Hasse", role = "aut"),
+    person("Jérome", "Hilaire", role = "aut"),
+    person("David", "Klein", role = "aut"),
+    person("Johannes", "Koch", role = "aut"),
+    person("Katarzyna", "Kowalczyk", role = "aut"),
+    person("Antoine", "Levesque", role = "aut"),
+    person("Aman", "Malik", role = "aut"),
+    person("Anne", "Merfort", role = "aut"),
+    person("Leon", "Merfort", role = "aut"),
+    person("Simón", "Morena-Leiva", role = "aut"),
+    person("Michaja", "Pehl", role = "aut"),
+    person("Robert", "Pietzcker", role = "aut"),
+    person("Sebastian", "Rauner", role = "aut"),
+    person("Oliver", "Richters", role = "aut"),
+    person("Marianna", "Rottoli", role = "aut"),
+    person("Christof", "Schötz", role = "aut"),
+    person("Felix", "Schreyer", role = "aut"),
+    person("Kais", "Siala", role = "aut"),
+    person("Björn", "Sörgel", role = "aut"),
+    person("Mike", "Spahr", role = "aut"),
+    person("Jessica", "Strefler", role = "aut"),
+    person("Philipp", "Verpoort", role = "aut")
+  )
 Description: Contains the REMIND-specific routines for data and model
     output manipulation.
 License: LGPL-3
@@ -31,7 +60,7 @@ Imports:
     luscale,
     lusweave,
     madrat,
-    mip,
+    mip (>= 0.139.1),
     openxlsx,
     piamInterfaces (>= 0.0.31),
     plotly,

--- a/R/reportPrices.R
+++ b/R/reportPrices.R
@@ -467,6 +467,7 @@ reportPrices <- function(gdx, output=NULL, regionSubsetList=NULL,
   price.investment <- vm_costTeCapital * p_teAnnuity / vm_capFac
   price.omf <- pm_data_omf * vm_costTeCapital / vm_capFac
   price.td <- collapseDim(price.investment + price.omf)  * 1e6 / 3.6 # [tr USD2005/TWh] -> [USD2005/GJ]
+  price.td[price.td == Inf] <- 0
 
   out <- mbind(
     out,

--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.103.18, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.103.17, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Manual{,
   title = {remind2: The REMIND R package (2nd generation)},
-  author = {Renato Rodrigues},
+  author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort},
   year = {2022},
   note = {R package version 1.103.18},
   url = {https://github.com/pik-piam/remind2},

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.103.18**
+R package **remind2**, version **1.103.19**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.103.17, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.103.19, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort},
   year = {2022},
-  note = {R package version 1.103.18},
+  note = {R package version 1.103.19},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/inst/markdown/compareScenarios2/cs2_01_summary.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_01_summary.Rmd
@@ -4,7 +4,7 @@
 
 ## GHG Emissions
 
-```{r}
+```{r summary GHG emissions}
 tot <- "Emi|GHG"
 items <- c(
   "Emi|CO2|Energy",
@@ -14,12 +14,12 @@ items <- c(
   "Emi|GHG|N2O",
   "Emi|GHG|F-Gases",
   "Emi|CO2|non-BECCS CDR")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ## GHG by sector (w/ gross emissions, excl. BECCS)
 
-```{r}
+```{r summary GHG by sector}
 tot <- "Emi|GHG"
 items <- c(
   "Emi|GHG|Gross|Energy|Supply|Electricity",
@@ -35,18 +35,18 @@ items <- c(
   "Emi|CO2|CDR|Industry CCS|Synthetic Fuels",
   "Emi|CO2|CDR|DACCS",
   "Emi|CO2|CDR|EW")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ### GHG pCap by sector
 
-```{r}
-showAreaAndBarPlots(data, paste(items, "pCap"), paste(tot, "pCap"))
+```{r GHG pCap by sector}
+showAreaAndBarPlots(data, paste(items, "pCap"), paste(tot, "pCap"), scales = "fixed")
 ```
 
 ## CO2 by sector (w/ gross emissions, excl. BECCS)
 
-```{r}
+```{r CO2 by sector}
 tot <- "Emi|CO2"
 items <- c(
   "Emi|CO2|Land-Use Change",
@@ -60,19 +60,19 @@ items <- c(
   "Emi|CO2|CDR|Industry CCS|Synthetic Fuels",
   "Emi|CO2|CDR|DACCS",
   "Emi|CO2|CDR|EW")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ###  CO2 pCap by sector
 
-```{r}
-showAreaAndBarPlots(data, paste(items, "pCap"), paste(tot, "pCap"))
+```{r CO2 pCap by sector}
+showAreaAndBarPlots(data, paste(items, "pCap"), paste(tot, "pCap"), scales = "fixed")
 ```
 
 
 ###  CO2 cumulated by sector
 
-```{r}
+```{r CO2 cumulated by sector}
 tot <- "Emi|CO2|Cumulated"
 items <- c(
   "Emi|CO2|Cumulated|Land-Use Change",
@@ -85,34 +85,34 @@ items <- c(
   "Emi|CO2|Cumulated|CDR|BECCS",
   "Emi|CO2|Cumulated|CDR|DACCS",
   "Emi|CO2|Cumulated|CDR|EW")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 
 ## FE by sector
 
-```{r}
+```{r FE by sector}
 items <- c(
   "FE|CDR",
   "FE|Transport",
   "FE|Buildings",
   "FE|Industry")
-showAreaAndBarPlots(data, items)
+showAreaAndBarPlots(data, items, scales = "fixed")
 ```
 
 ## FE per capita (by sector, time domain, area plot)
 
-```{r}
+```{r FE per capita area plot}
 items <- c(
   "FE|Transport pCap",
   "FE|Buildings pCap",
   "FE|Industry pCap")
-showAreaAndBarPlots(data, items)
+showAreaAndBarPlots(data, items, scales = "fixed")
 ```
 
 ## FE per capita (by sector, time domain, line graph)
 
-```{r}
+```{r FE per capita line plot}
 dIea <- data %>%
   # To make the plots less crowded, show only IEA historical data.
   filter(scenario != "historical" | model == "IEA")
@@ -126,7 +126,7 @@ showMultiLinePlots(dIea, items, scales = "fixed")
 
 ## FE per capita (by sector, GDP)
 
-```{r}
+```{r FE per capita}
 dIea <- data %>%
   # To make the plots less crowded, show only IEA historical data.
   filter(scenario != "historical" | model == "IEA")
@@ -140,7 +140,7 @@ showMultiLinePlotsByVariable(dIea, items, "GDP|PPP pCap", scales = "fixed")
 
 ## FE by carrier
 
-```{r}
+```{r FE by carrier}
 items <- c(
   "FE|Solids",
   "FE|Liquids",
@@ -148,12 +148,12 @@ items <- c(
   "FE|Heat",
   "FE|Hydrogen",
   "FE|Electricity")
-showAreaAndBarPlots(data, items)
+showAreaAndBarPlots(data, items, scales = "fixed")
 ```
 
 ## FE Industry by carrier
 
-```{r}
+```{r FE Industry by carrier}
 items <- c(
   "FE|Industry|Solids",
   "FE|Industry|Liquids",
@@ -161,12 +161,12 @@ items <- c(
   "FE|Industry|Heat",
   "FE|Industry|Hydrogen",
   "FE|Industry|Electricity")
-showAreaAndBarPlots(data, items)
+showAreaAndBarPlots(data, items, scales = "fixed")
 ```
 
 ## FE Buildings by carrier
 
-```{r}
+```{r FE Buildings by carrier}
 items <- c(
   "FE|Buildings|Solids",
   "FE|Buildings|Liquids",
@@ -174,35 +174,35 @@ items <- c(
   "FE|Buildings|Heat",
   "FE|Buildings|Hydrogen",
   "FE|Buildings|Electricity")
-showAreaAndBarPlots(data, items)
+showAreaAndBarPlots(data, items, scales = "fixed")
 ```
 
 ## FE Transport by carrier
 
-```{r}
+```{r FE Transport by carrier}
 items <- c(
   "FE|Transport|Electricity",
   "FE|Transport|Hydrogen",
   "FE|Transport|Liquids",
   "FE|Transport|Gases")
-showAreaAndBarPlots(data, items)
+showAreaAndBarPlots(data, items, scales = "fixed")
 ```
 
 ## FE CDR by carrier
 
 
-```{r}
+```{r FE CDR by carrier}
 items <- c(
   "FE|CDR|Liquids",
   "FE|CDR|Gases",
   "FE|CDR|Hydrogen",
   "FE|CDR|Electricity")
-showAreaAndBarPlots(data, items)
+showAreaAndBarPlots(data, items, scales = "fixed")
 ```
 
 ## SE Electricity by carrier
 
-```{r}
+```{r SE Electricity by carrier}
 
 tot <- "SE|Electricity"
 
@@ -224,14 +224,14 @@ items <- c(
   "SE|Electricity|Hydrogen",
   "SE|Electricity|Net Imports")
 
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 
 
 ## PE by carrier
 
-```{r}
+```{r PE by carrier}
 items <- c(
   "PE|Coal",
   "PE|Oil",
@@ -242,18 +242,18 @@ items <- c(
   "PE|Wind",
   "PE|Hydro",
   "PE|Geothermal")
-showAreaAndBarPlots(data, items)
+showAreaAndBarPlots(data, items, scales = "fixed")
 ```
 
 
 ## CO2 Prices
 
-```{r}
+```{r CO2 Prices}
 showLinePlots(data, "Price|Carbon")
 showRegiLinePlots(data, "Price|Carbon")
 ```
 
-```{r}
+```{r CO2 Prices per sector}
 items <- c(
   "Price|Carbon|Demand|Transport",
   "Price|Carbon|Demand|Buildings",
@@ -281,7 +281,7 @@ if (all(items %in% data$variable)) {
 }
 ```
 
-```{r}
+```{r CO2 Prices ETS/ESR}
 showLinePlots(data, "Price|Carbon|ETS")
 showLinePlots(data, "Price|Carbon|ESR")
 ```
@@ -289,17 +289,17 @@ showLinePlots(data, "Price|Carbon|ESR")
 
 ## Policy Costs
 
-```{r}
+```{r Policy Costs Consumption}
 showLinePlots(data, "Policy Cost|Consumption Loss")
 ```
 
 
-```{r}
+```{r Policy Costs Relative}
 showLinePlots(data, "Policy Cost|Consumption Loss|Relative to Reference Consumption")
 ```
 
 
-```{r}
+```{r Policy Costs GDP}
 showLinePlots(data, "Policy Cost|GDP Loss")
 ```
 
@@ -311,7 +311,7 @@ Every statistic in the following tables, e.g., $\max$, $\min$, is taken over the
 
 ### Emi|CO2: Max, Min, and Net 0
 
-```{r}
+```{r Tables CO2 Max}
 data %>%
   calcTimeSeriesStats(
     "Emi|CO2",
@@ -323,7 +323,7 @@ data %>%
   showStatsTable()
 ```
 
-```{r}
+```{r Tables CO2 Min}
 data %>%
   calcTimeSeriesStats(
     "Emi|CO2",
@@ -335,7 +335,7 @@ data %>%
   showStatsTable()
 ```
 
-```{r}
+```{r Tables CO2 Net Zero}
 data %>%
   calcTimeSeriesStats(
     "Emi|CO2",
@@ -350,7 +350,7 @@ data %>%
 
 ### Emi|GHG: Max, Min, and Net 0
 
-```{r}
+```{r Tables GHG Max}
 data %>%
   calcTimeSeriesStats(
     "Emi|GHG",
@@ -362,7 +362,7 @@ data %>%
   showStatsTable()
 ```
 
-```{r}
+```{r Tables GHG Min}
 data %>%
   calcTimeSeriesStats(
     "Emi|GHG",
@@ -374,7 +374,7 @@ data %>%
   showStatsTable()
 ```
 
-```{r}
+```{r Tables GHG Net Zero}
 data %>%
   calcTimeSeriesStats(
     "Emi|GHG",
@@ -390,7 +390,7 @@ data %>%
 
 ### Temperature|Global Mean: Max
 
-```{r}
+```{r Temperature}
 data %>%
   calcTimeSeriesStats(
     "Temperature|Global Mean",

--- a/inst/markdown/compareScenarios2/cs2_02_macro.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_02_macro.Rmd
@@ -3,38 +3,38 @@
 
 ## Consumption
 
-```{r}
+```{r Consumption}
 showLinePlots(data, "Consumption")
 ```
 
 
 ## Population
 
-```{r}
+```{r Population}
 showLinePlots(data, "Population")
 ```
 
 ## GDP - MER
 
-```{r}
+```{r GDP - MER}
 showLinePlots(data, "GDP|MER")
 ```
 
 ## GDP - PPP
 
-```{r}
+```{r GDP - PPP}
 showLinePlots(data, "GDP|PPP")
 ```
 
 ## GDP - MER per Capita
 
-```{r}
+```{r GDP - MER per Capita}
 showLinePlots(data, "GDP|MER pCap")
 ```
 
 ## GDP - PPP per Capita
 
-```{r}
+```{r GDP - PPP per Capita}
 showLinePlots(data, "GDP|PPP pCap")
 ```
 
@@ -43,20 +43,20 @@ showLinePlots(data, "GDP|PPP pCap")
 ## Capital Stock
 
 
-```{r}
+```{r Capital Stock}
 showLinePlots(data, "Capital Stock|Non-ESM")
 ```
 
 ## Investments
 
-```{r}
+```{r Investments}
 showLinePlots(data, "Investments|Non-ESM")
 ```
 
 
 ## Interest Rate
 
-```{r}
+```{r Interest Rate}
 showLinePlots(data, "Interest Rate (t+1)/(t-1)|Real")
 ```
 
@@ -75,7 +75,7 @@ items <- c(
   "Internal|CES Function|Value|enb",
   "Internal|CES Function|Value|ue_industry")
   
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 
@@ -90,7 +90,7 @@ items <- c(
   "Internal|CES Function|Value|entrp_frgt_sm",
   "Internal|CES Function|Value|entrp_frgt_lo")
 
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ### Buildings Value Disaggregation
@@ -102,7 +102,7 @@ items <- c(
   "Internal|CES Function|Value|enhb",
   "Internal|CES Function|Value|feelcb")
   
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 
@@ -117,14 +117,14 @@ items <- c(
   "Internal|CES Function|Value|ue_chemicals",
   "Internal|CES Function|Value|ue_otherInd")
   
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 
 
 ## Prices
 
-```{r}
+```{r Prices preprocessing}
 # Local (this subsection) preprocessing for all price variables.
 dPrice <-
   data %>%
@@ -137,7 +137,7 @@ dPrice <-
 
 ### PE Prices
 
-```{r}
+```{r PE Prices}
 vars <-
   levels(dPrice$variable) %>%
   str_subset("^Price\\|Primary Energy\\|") %>%
@@ -148,7 +148,7 @@ walk(vars, showLinePlots, data = dPrice, scale = "fixed")
 ### SE Prices
 
 
-```{r}
+```{r SE Prices}
 vars <-
   levels(dPrice$variable) %>%
   str_subset("^Price\\|Secondary Energy\\|") %>%
@@ -158,7 +158,7 @@ walk(vars, showLinePlots, data = dPrice, scale = "fixed")
 
 ### FE Prices
 
-```{r}
+```{r FE Prices}
 vars <-
 levels(dPrice$variable) %>%
   str_subset("^Price\\|Final Energy\\|") %>%
@@ -188,7 +188,7 @@ vars %>%
 
 ### FE LCOE Prices Transport
 
-```{r}
+```{r FE LCOE Prices Transport}
 
 groups <- c(
   "Price|Final Energy|Transport|Liquids|Petroleum",
@@ -218,7 +218,7 @@ for (g in groups) {
 
 ### FE LCOE Prices Buildings
 
-```{r}
+```{r FE LCOE Prices Buildings}
 
 groups <- c(
   "Price|Final Energy|Buildings|Liquids|Oil",
@@ -250,7 +250,7 @@ for (g in groups) {
 
 ### FE LCOE Prices Industry
 
-```{r}
+```{r FE LCOE Prices Industry}
 
 groups <- c(
   "Price|Final Energy|Industry|Liquids|Oil",
@@ -283,7 +283,7 @@ for (g in groups) {
 
 ## Trade
 
-```{r}
+```{r Trade}
 vars <-
   levels(data$variable) %>%
   str_subset("^Trade\\|[^|]*$")
@@ -292,17 +292,17 @@ walk(vars, showLinePlots, data = data)
 
 ## FE intensity of GDP
 
-```{r}
+```{r FE intensity of GDP}
 items <- c(
   "FE|Transport pGDP",
   "FE|Buildings pGDP",
   "FE|Industry pGDP")
-showAreaAndBarPlots(data, items)
+showAreaAndBarPlots(data, items, scales = "fixed")
 ```
 
 ## FE intensity of GDP, linegraph (by GDP)
 
-```{r}
+```{r FE intensity of GDP, linegraph}
 dIea <-
   data %>%
   # To make the plots less crowded, show only IEA historical data.
@@ -315,9 +315,9 @@ showMultiLinePlots(dIea, items, scales = "fixed")
 showMultiLinePlotsByVariable(dIea, items, "GDP|PPP pCap", scales = "fixed")
 ```
 
-## Kaya-Decomposition
+## Kaya Decomposition
 
-```{r}
+```{r Kaya Decomposition}
 d <-
   data %>%
   filter(variable %in% c("Emi|CO2|Energy", "FE", "GDP|MER", "Population")) %>%
@@ -369,22 +369,22 @@ kayaRel <-
 
 ### Absolute
 
-```{r}
+```{r Kaya Decomposition Absolute}
 showMultiLinePlots(kaya, kayaVars)
 walk(kayaVars, showRegiLinePlots, data = kaya)
 ```
 
-```{r results='asis'}
+```{r Kaya Decomposition Relative text, results='asis'}
 cat("### Relative to ", refYear, "\n")
 ```
 
-```{r}
+```{r Kaya Decomposition Relative}
 showMultiLinePlots(kayaRel, kayaVars)
 walk(kayaVars, showRegiLinePlots, data = kayaRel)
 ```
 
 ### Components
 
-```{r}
+```{r Kaya Components}
 walk(kayaVars, showLinePlots, data = kaya)
 ```

--- a/inst/markdown/compareScenarios2/cs2_03_emissions.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_03_emissions.Rmd
@@ -2,7 +2,7 @@
 
 ## GHG - total
 
-```{r}
+```{r GHG total}
 items <- c(
   "Emi|GHG", # scenario
   "Emi|GHGtot") # historical
@@ -10,14 +10,14 @@ showLinePlots(data, items)
 showLinePlotsWithTarget(data, items)
 ```
 
-```{r}
+```{r GHG - total w/ Bunkers}
 showLinePlots(data, "Emi|GHG|w/ Bunkers")
 ```
 
 
 ##  GHG Sectors
 
-```{r}
+```{r GHG Sectors}
 items <- c(
   "Emi|GHG|Energy",
   "Emi|GHG|Industrial Processes",
@@ -31,7 +31,7 @@ walk(items, showLinePlots, data = data)
 
 ### ETS
 
-```{r}
+```{r GHG ETS}
 items <- "Emi|GHG|ETS"
 showLinePlots(data, items)
 showLinePlotsWithTarget(data, items)
@@ -40,7 +40,7 @@ showLinePlotsWithTarget(data, items)
 
 ### ESR
 
-```{r}
+```{r GHG ESR}
 items <- "Emi|GHG|ESR"
 showLinePlots(data, items)
 showLinePlotsWithTarget(data, items)
@@ -51,7 +51,7 @@ Note: Reduction targets wrt 2005
 
 ### Other - Outside ETS and ESR
 
-```{r}
+```{r GHG Other}
 showLinePlots(data, "Emi|GHG|Outside ETS and ESR")
 ```
 
@@ -60,7 +60,7 @@ showLinePlots(data, "Emi|GHG|Outside ETS and ESR")
 
 ### CO2 by sector (net emissions, incl. BECCS)
 
-```{r}
+```{r CO2 by sector net incl. BECCS}
 tot <- "Emi|CO2"
 items <- c(
   "Emi|CO2|Land-Use Change",
@@ -72,20 +72,20 @@ items <- c(
   "Emi|CO2|Energy|Supply|Electricity w/ couple prod",
   "Emi|CO2|CDR|DACCS",
   "Emi|CO2|CDR|EW")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 
 ### Total CO2
 
-```{r}
+```{r CO2 total}
 showLinePlots(data, "Emi|CO2")
 ```
 
 
 ### Energy and Industrial Processes - Net (incl BECCS)
 
-```{r}
+```{r CO2 Energy and Industry}
 items <- c(
   "Emi|CO2|Energy and Industrial Processes", # scenario
   "Emi|CO2|Fossil Fuels and Industry") # historical
@@ -95,7 +95,7 @@ showLinePlots(data, items)
 
 ### Energy and Industrial Processes - Gross
 
-```{r}
+```{r CO2 Energy and Industry Gross}
 items <- c(
   "Emi|CO2|Gross|Energy and Industrial Processes", # scenario
   "Emi|CO2|Fossil Fuels and Industry") # historical
@@ -105,14 +105,14 @@ showLinePlots(data, items)
 
 ### Energy
 
-```{r}
+```{r CO2 Energy}
 showLinePlots(data, "Emi|CO2|Energy")
 ```
 
 
 ### Energy Supply
 
-```{r}
+```{r CO2 Energy Supply}
 items <- c(
   "Emi|CO2|Energy|Supply", # scenario
   "Emi|CO2|Fossil Fuels and Industry|Energy Supply") # historical
@@ -122,7 +122,7 @@ showLinePlots(data, items)
 
 ### Electricity
 
-```{r}
+```{r CO2 Electricity}
 items <- c(
   "Emi|CO2|Energy|Supply|Electricity w/ couple prod", # scenario
   "Emi|CO2|Energy|Supply|Electricity") # historical
@@ -132,7 +132,7 @@ showLinePlots(data, items)
 
 ### Electricity and Heat
 
-```{r}
+```{r CO2 Electricity and Heat}
 # UNFCCC has "EMI|CO2|Energy|Demand|Electricity and Heat",
 # CEDS and REMIND only separate
 # manually added for now
@@ -157,7 +157,7 @@ showLinePlots(bind_rows(data, newRows) %>% as.quitte(), item)
 
 ### Buildings
 
-```{r}
+```{r CO2 Buildings}
 items <- c(
   "Emi|CO2|Energy|Demand|Buildings", # scenario
   "Emi|CO2|Buildings|Direct") # historical
@@ -167,7 +167,7 @@ showLinePlots(data, items)
 
 ### Industry
 
-```{r}
+```{r CO2 Industry}
 items <- c(
   "Emi|CO2|Energy|Demand|Industry", # scenario
   "Emi|CO2|Industry|Direct") # historical
@@ -177,7 +177,7 @@ showLinePlots(data, items)
 
 ### Industry, Gross
 
-```{r}
+```{r CO2 Industry Gross}
 items <- c(
   "Emi|CO2|Gross|Energy|Demand|Industry", # scenario
   "Emi|CO2|Industry|Direct") # historical
@@ -187,7 +187,7 @@ showLinePlots(data, items)
 
 ### Industry with Industrial Processes
 
-```{r}
+```{r CO2 Industry with Industrial Processes}
 # Emi|CO2|Industry = Emi|CO2|Energy|Demand|Industry + Emi|CO2|Industrial Processes
 # (new REMIND reporting variable coming soon, current solution is terrible)
 # TODO: Switch to new variable as soon as it is also available in historical data.
@@ -210,7 +210,7 @@ showLinePlots(bind_rows(data, newRows) %>% as.quitte(), item)
 
 ### Transport
 
-```{r}
+```{r CO2 Transport}
 items <- c(
   "Emi|CO2|Energy|Demand|Transport", # scenario
   "Emi|CO2|Transport|Demand") # historical
@@ -220,14 +220,14 @@ showLinePlots(data, items)
 
 ### International Bunkers
 
-```{r}
+```{r CO2 Bunkers}
 showLinePlots(data, "Emi|CO2|Energy|Demand|Transport|International Bunkers")
 ```
 
 
 ### Process Emissions
 
-```{r}
+```{r CO2 Process Emissions}
 items <- c(
   "Emi|CO2|Industrial Processes", # scenario
   "Emi|CO2|FFaI|Industry|Process") # historical
@@ -236,7 +236,7 @@ showLinePlots(data, items)
 
 ### Land-Use Change
 
-```{r}
+```{r CO2 Land-Use Change}
 items <- c(
   "Emi|CO2|Land-Use Change", # scenario
   "Emi|CO2|Land Use") # historical
@@ -246,13 +246,13 @@ showLinePlots(data, items)
 
 ### non-BECCS CDR
 
-```{r}
+```{r CO2 non-BECCS CDR}
 showLinePlots(data, "Emi|CO2|non-BECCS CDR")
 ```
 
 ### CDR
 
-```{r}
+```{r CO2 CDR}
 tot <- "Emi|CO2"
 items <- c(
   "Emi|CO2|Gross|Energy and Industrial Processes",
@@ -262,11 +262,11 @@ items <- c(
   "Emi|CO2|CDR|DACCS",
   "Emi|CO2|CDR|EW"
 )
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 
-```{r}
+```{r CO2 CDR Detail}
 tot <- "Emi|CO2|CDR"
 items <- c(
   "Emi|CO2|CDR|Land-Use Change",
@@ -276,11 +276,11 @@ items <- c(
   "Emi|CO2|CDR|DACCS",
   "Emi|CO2|CDR|EW"
 )
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 
-```{r}
+```{r CO2 CDR Subcategories}
 cdrVars <-
   levels(data$variable) %>%
   str_subset(fixed("Emi|CO2|CDR|"))
@@ -290,7 +290,7 @@ walk(cdrVars, showLinePlots, data = data)
 
 ### Cumulated Emissions
 
-```{r}
+```{r CO2 Cumulated}
 d <-
   data %>%
   filter(variable == "Emi|CO2|Cumulated")
@@ -306,14 +306,14 @@ showLinePlots(d)
 ```
 
 
-```{r}
+```{r CO2 Cumulated Subcategories}
 cdrVars <-
   levels(data$variable) %>%
   str_subset(fixed("Emi|CO2|Cumulated|CDR|"))
 walk(cdrVars, showLinePlots, data = data)
 ```
 
-```{r}
+```{r CO2 Cumulated bar plots}
 tot <- "Emi|CO2|Cumulated"
 items <- c(
   "Emi|CO2|Cumulated|Gross|Energy and Industrial Processes",
@@ -323,14 +323,14 @@ items <- c(
   "Emi|CO2|Cumulated|CDR|Industry CCS|Synthetic Fuels",
   "Emi|CO2|Cumulated|CDR|DACCS",
   "Emi|CO2|Cumulated|CDR|EW")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ## Market Emissions
 
 ### GHG ETS Emissions
 
-```{r}
+```{r GHG ETS Market Emissions}
 tot <- "Emi|GHG|ETS"
 items <- c(
   "Emi|GHG|ETS|Energy Supply",
@@ -339,12 +339,12 @@ items <- c(
   "Emi|GHG|ETS|Extraction",
   "Emi|GHG|ETS|Waste",
   "Emi|GHG|ETS|non-BECCS CDR")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ### GHG ESR Emissions
 
-```{r}
+```{r GHG ESR Market Emissions}
 tot <- "Emi|GHG|ESR"
 items <- c(
   "Emi|GHG|ESR|Buildings",
@@ -352,23 +352,23 @@ items <- c(
   "Emi|GHG|ESR|Transport",
   "Emi|GHG|ESR|Agriculture",
   "Emi|GHG|ESR|Waste")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
-### GHG Other Emissions - Outisde ETS and ESR
+### GHG Other Emissions - Outside ETS and ESR
 
-```{r}
+```{r GHG Other Market Emissions}
 tot <- "Emi|GHG|Outside ETS and ESR"
 items <- c(
   "Emi|GHG|Outside ETS and ESR|Transport",
   "Emi|GHG|Outside ETS and ESR|Land-Use Change",
   "Emi|GHG|Outside ETS and ESR|F-Gases")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ### Market Emissions across GHGs
 
-```{r}
+```{r GHG Market Emissions}
 showLinePlots(data, "Emi|CO2|ETS")
 showLinePlots(data, "Emi|CO2|ESR")
 showLinePlots(data, "Emi|CO2|Outside ETS and ESR")
@@ -376,7 +376,7 @@ showLinePlots(data, "Emi|CO2|Outside ETS and ESR")
 
 ### Market CH4
 
-```{r}
+```{r CH4 Market Emissions}
 showLinePlots(data, "Emi|CH4|ETS")
 showLinePlots(data, "Emi|CH4|ESR")
 showLinePlots(data, "Emi|CH4|Outside ETS and ESR")
@@ -384,7 +384,7 @@ showLinePlots(data, "Emi|CH4|Outside ETS and ESR")
 
 ### Market N2O
 
-```{r}
+```{r N2O Market Emissions}
 showLinePlots(data, "Emi|N2O|ETS")
 showLinePlots(data, "Emi|N2O|ESR")
 showLinePlots(data, "Emi|N2O|Outside ETS and ESR")
@@ -393,7 +393,7 @@ showLinePlots(data, "Emi|N2O|Outside ETS and ESR")
 
 ## CH4
 
-```{r}
+```{r CH4 by sector}
 tot <- "Emi|CH4"
 items <- c(
   "Emi|CH4|Extraction",
@@ -401,12 +401,12 @@ items <- c(
   "Emi|CH4|Land-Use Change",
   "Emi|CH4|Waste",
   "Emi|CH4|Energy Supply")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ## N2O
 
-```{r}
+```{r N2O by sector}
 tot <- "Emi|N2O"
 items <- c(
   "Emi|N2O|Agriculture",
@@ -415,23 +415,23 @@ items <- c(
   "Emi|N2O|Transport",
   "Emi|N2O|Industry",
   "Emi|N2O|Energy Supply")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ### F-Gases
 
-```{r}
+```{r F-Gases}
 showLinePlots(data, "Emi|GHG|F-Gases")
 ```
 
 ## Industry Subsector Emissions
 
-```{r}
+```{r Industry Subsector Emissions}
 items <- c(
   "Emi|CO2|Energy|Demand|Industry|Steel",
   "Emi|CO2|Energy|Demand|Industry|Cement",
   "Emi|CO2|Energy|Demand|Industry|Chemicals",
   "Emi|CO2|Energy|Demand|Industry|Other Industry")
-showAreaAndBarPlots(data, items)
+showAreaAndBarPlots(data, items, scales = "fixed")
 walk(items, showLinePlots, data = data)
 ```

--- a/inst/markdown/compareScenarios2/cs2_04_energy_supply.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_04_energy_supply.Rmd
@@ -2,7 +2,7 @@
 
 ## Investments Electricity
 
-```{r}
+```{r Investments Electricity}
 items <- c(
 #  "Energy Investments|Elec|Grid",
   "Energy Investments|Elec|Grid|BEV Chargers",
@@ -22,12 +22,12 @@ items <- c(
   "Energy Investments|Elec|Coal|w/ CC",
   "Energy Investments|Elec|Coal|w/o CC",
   "Energy Investments|Elec|Nuclear")
-showAreaAndBarPlots(data, items, orderVars = "user")
+showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
 ```
 
 ## Capacities Electricity
 
-```{r}
+```{r Capacities Electricity}
 items <- c(
   "Cap|Electricity|Storage|Battery",
   "Cap|Electricity|Solar",
@@ -46,61 +46,61 @@ items <- c(
   "Cap|Electricity|Coal|w/o CC",
   "Cap|Electricity|Nuclear"
   )
-showAreaAndBarPlots(data, items, orderVars = "user")
+showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
 ```
 
 ## Capacities electricity line plots
 
 ### Nuclear
-```{r}
+```{r Cap Nuclear}
 showLinePlots(data, "Cap|Electricity|Nuclear")
 ```
 
 ### Hydro
-```{r}
+```{r Cap Hydro}
 showLinePlots(data, "Cap|Electricity|Hydro")
 ```
 
 ### Wind
-```{r}
+```{r Cap Wind}
 showLinePlots(data, "Cap|Electricity|Wind")
 showLinePlots(data, "Cap|Electricity|Wind|Onshore")
 showLinePlots(data, "Cap|Electricity|Wind|Offshore")
 ```
 
 ### Solar
-```{r}
+```{r Cap Solar}
 showLinePlots(data, "Cap|Electricity|Solar")
 ```
 
 ### Coal
-```{r}
+```{r Cap Coal}
 showLinePlots(data, "Cap|Electricity|Coal")
 ```
 
-### Coal
-```{r}
+### Gas
+```{r Cap Gas}
 showLinePlots(data, "Cap|Electricity|Gas")
 ```
 
 ### Oil
-```{r}
+```{r Cap Oil}
 showLinePlots(data, "Cap|Electricity|Oil")
 ```
 
 ### Biomass
-```{r}
+```{r Cap Biomass}
 showLinePlots(data, "Cap|Electricity|Biomass")
 ```
 
 ### Hydrogen
-```{r}
+```{r Cap Hydrogen}
 showLinePlots(data, "Cap|Electricity|Hydrogen")
 ```
 
 ## PE Mix
 ### PE|Coal
-```{r}
+```{r PE|Coal}
 items <- c(
   "PE|Coal|Gases",
   "PE|Coal|Liquids",
@@ -108,11 +108,11 @@ items <- c(
   "PE|Coal|Heat",
   "PE|Coal|Electricity",
   "PE|Coal|Hydrogen")
-showAreaAndBarPlots(data, items)
+showAreaAndBarPlots(data, items, scales = "fixed")
 ```
 
 ### PE|Gas
-```{r}
+```{r PE|Gas}
 items <- c(
   "PE|Gas|Gases",
   "PE|Gas|Heat",
@@ -122,13 +122,13 @@ items <- c(
   "PE|Gas|Liquids|w/o CC",
   "PE|Gas|Hydrogen|w/ CC",
   "PE|Gas|Hydrogen|w/o CC")
-showAreaAndBarPlots(data, items)
+showAreaAndBarPlots(data, items, scales = "fixed")
 ```
 
 
 ### PE|Biomass
 
-```{r}
+```{r PE|Biomass}
 items <- c(
   "PE|Biomass|Solids",
   "PE|Biomass|Heat",
@@ -139,12 +139,12 @@ items <- c(
   "PE|Biomass|Electricity|w/o CC",
   "PE|Biomass|Hydrogen|w/ CC",
   "PE|Biomass|Hydrogen|w/o CC")
-showAreaAndBarPlots(data, items)
+showAreaAndBarPlots(data, items, scales = "fixed")
 ```
 
 ## Primary Energy line plots
 
-```{r}
+```{r Primary Energy line plots}
 showLinePlots(data, "PE|Coal")
 showLinePlots(data, "PE|Oil")
 showLinePlots(data, "PE|Gas")
@@ -153,17 +153,17 @@ showLinePlots(data, "Primary Energy Production|Biomass|Energy Crops")
 ```
 
 ### PE|Coal|Extraction
-```{r}
+```{r PE|Coal|Extraction}
 showLinePlots(data, "Res|Extraction|Coal")
 ```
 
 ### PE|Oil|Extraction
-```{r}
+```{r PE|Oil|Extraction}
 showLinePlots(data, "Res|Extraction|Oil")
 ```
 
 ### PE|Gas|Extraction
-```{r}
+```{r PE|Gas|Extraction}
 showLinePlots(data, "Res|Extraction|Gas")
 ```
 
@@ -172,7 +172,7 @@ showLinePlots(data, "Res|Extraction|Gas")
 
 ### SE Electricity
 
-```{r}
+```{r SE Electricity}
 
 tot <- "SE|Electricity"
 
@@ -194,13 +194,13 @@ items <- c(
   "SE|Electricity|Hydrogen",
   "SE|Electricity|Net Imports")
 
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 
 
 ### SE|Electricity - Usage
-```{r}
+```{r SE|Electricity - Usage}
 
 tot <- "SE|Electricity"
 
@@ -215,24 +215,24 @@ items <- c(
   "SE|Input|Electricity|CDR",
   "SE|Input|Electricity|Self Consumption Energy System")
 
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 
 ### SE|Heat
-```{r}
+```{r SE|Heat}
 tot <- "SE|Heat"
 items <- c(
   "SE|Heat|Biomass",
   "SE|Heat|Coal",
   "SE|Heat|Gas",
   "SE|Heat|Electricity|Heat Pump")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 
 ### SE|Hydrogen
-```{r}
+```{r SE|Hydrogen}
 
 tot <- "SE|Hydrogen"
 
@@ -246,11 +246,11 @@ items <- c(
   "SE|Hydrogen|Electricity|VRE Storage Electrolysis",
   "SE|Hydrogen|Electricity|Standard Electrolysis",
   "SE|Hydrogen|Net Imports")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ### SE|Hydrogen - Usage
-```{r}
+```{r SE|Hydrogen - Usage}
 
 tot <- "SE|Hydrogen"
 
@@ -263,13 +263,13 @@ items <- c(
   "SE|Input|Hydrogen|Electricity|Forced VRE Turbines",
   "SE|Input|Hydrogen|Synthetic Fuels|Liquids",
   "SE|Input|Hydrogen|Synthetic Fuels|Gases")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 
 
 ### SE|Solids
-```{r}
+```{r SE|Solids}
 
 tot <- "SE|Solids"
 
@@ -277,13 +277,13 @@ items <- c(
   "SE|Solids|Biomass",
   "SE|Solids|Traditional Biomass",
   "SE|Solids|Coal")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 
 ### SE|Liquids
 
-```{r}
+```{r SE|Liquids}
 
 tot <- "SE|Liquids"
 
@@ -297,11 +297,11 @@ items <- c(
   "SE|Liquids|Fossil|Gas|w/o CC",
   "SE|Liquids|Hydrogen",
   "SE|Liquids|Hydrogen|Net Imports")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ### SE|Gases
-```{r}
+```{r SE|Gases}
 
 tot <- "SE|Gases"
 
@@ -313,7 +313,7 @@ items <- c(
   "SE|Gases|Fossil|Coal|w/o CC",
   "SE|Gases|Hydrogen",
   "SE|Gases|Waste")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 
@@ -324,34 +324,34 @@ showAreaAndBarPlots(data, items, tot)
 ## Secondary Energy line plots - totals
 
 ### SE|Electricity
-```{r}
+```{r SE|Electricity total line}
 showLinePlots(data, "SE|Electricity")
 ```
 
 ### SE|Heat
-```{r}
+```{r SE|Heat total line}
 showLinePlots(data, "SE|Heat")
 ```
 
 ### SE|Hydrogen
-```{r}
+```{r SE|Hydrogen total line}
 showLinePlots(data, "SE|Hydrogen")
 ```
 
 
 ### SE|Solids
-```{r}
+```{r SE|Solids total line}
 showLinePlots(data, "SE|Solids")
 ```
 
 
 ### SE|Liquids
-```{r}
+```{r SE|Liquids total line}
 showLinePlots(data, "SE|Liquids")
 ```
 
 ### SE|Gases
-```{r}
+```{r SE|Gases total line}
 showLinePlots(data, "SE|Gases")
 ```
 
@@ -362,7 +362,7 @@ showLinePlots(data, "SE|Gases")
 
 
 ### SE|Electricity
-```{r}
+```{r SE|Electricity detail line}
 showLinePlots(data, "SE|Electricity|Gas")
 showLinePlots(data, "SE|Electricity|Coal")
 showLinePlots(data, "SE|Electricity|Oil")
@@ -380,7 +380,7 @@ showLinePlots(data, "SE|Electricity|Biomass")
 
 
 ### SE|Heat
-```{r}
+```{r SE|Heat detail line}
 
 showLinePlots(data, "SE|Heat|Coal")
 showLinePlots(data, "SE|Heat|Gas")
@@ -390,7 +390,7 @@ showLinePlots(data, "SE|Heat|Electricity|Heat Pump")
 ```
 
 ### SE|Hydrogen
-```{r}
+```{r SE|Hydrogen detail line}
 
 showLinePlots(data,  "SE|Hydrogen|Biomass|w/ CC")
 showLinePlots(data,  "SE|Hydrogen|Biomass|w/o CC")
@@ -405,7 +405,7 @@ showLinePlots(data,  "SE|Hydrogen|Net Imports")
 ```
 
 ### SE|Solids
-```{r}
+```{r SE|Solids detail line}
 showLinePlots(data, "SE|Solids|Coal")
 showLinePlots(data, "SE|Solids|Biomass")
 showLinePlots(data, "SE|Solids|Traditional Biomass")
@@ -413,7 +413,7 @@ showLinePlots(data, "SE|Solids|Traditional Biomass")
 
 ### SE|Liquids
 
-```{r}
+```{r SE|Liquids detail line}
 
 
 showLinePlots(data, "SE|Liquids|Fossil|Oil")
@@ -430,7 +430,7 @@ showLinePlots(data, "SE|Liquids|Hydrogen")
 
 
 ### SE|Gases
-```{r}
+```{r SE|Gases detail line}
 showLinePlots(data,  c("SE|Gases|Fossil|Natural Gas", "SE|Gases|Gas"))
 showLinePlots(data, "SE|Gases|Fossil|Coal")
 showLinePlots(data, "SE|Gases|Biomass")

--- a/inst/markdown/compareScenarios2/cs2_05_energy_demand.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_05_energy_demand.Rmd
@@ -4,7 +4,7 @@
 
 ### Basics
 
-```{r}
+```{r Final Energy total}
 tot <- "FE"
 items <- c(
   "FE|Electricity",
@@ -19,21 +19,21 @@ items <- c(
 
 #### FE|* Area Plots
 
-```{r}
-showAreaAndBarPlots(data, items, tot)
+```{r FE|* Area Plots}
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 showAreaAndBarPlots(data, items, tot, fill = TRUE)
 ```
 
 #### FE|* Line Plots
 
-```{r}
+```{r FE|* Line Plots}
 showLinePlots(data, tot)
 walk(items, showLinePlots, data = data)
 ```
 
 #### FE|Electricity|Share
 
-```{r}
+```{r FE|Electricity|Share}
 showLinePlots(data, "FE|Electricity|Share")
 ```
 
@@ -41,7 +41,7 @@ showLinePlots(data, "FE|Electricity|Share")
 
 ### Basics
 
-```{r}
+```{r Buildings Final Energy}
 tot <- "FE|Buildings"
 items <- c(
   "FE|Buildings|Electricity",
@@ -68,22 +68,22 @@ items2 <- c(
 
 #### FE|Buildings|* Area Plots
 
-```{r}
-showAreaAndBarPlots(data, items, tot)
+```{r FE|Buildings|* Area Plots}
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 showAreaAndBarPlots(data, items, tot, fill = TRUE)
-showAreaAndBarPlots(data, items2, tot, orderVars = "user")
+showAreaAndBarPlots(data, items2, tot, orderVars = "user", scales = "fixed")
 ```
 
 #### FE|Buildings|* Line Plots
 
-```{r}
+```{r FE|Buildings|* Line Plots}
 showLinePlots(data, tot)
 walk(items, showLinePlots, data = data)
 ```
 
 #### FE|Buildings|Electricity|Share
 
-```{r}
+```{r FE|Buildings|Electricity|Share}
 showLinePlots(data, "FE|Buildings|Electricity|Share")
 ```
 
@@ -92,7 +92,7 @@ showLinePlots(data, "FE|Buildings|Electricity|Share")
 
 ### Basics
 
-```{r}
+```{r Industry Final Energy}
 tot <- "FE|Industry"
 items <- c(
   "FE|Industry|Electricity",
@@ -119,28 +119,28 @@ items2 <- c(
 
 #### FE|Industry|* Area Plots
 
-```{r}
-showAreaAndBarPlots(data, items, tot)
+```{r FE|Industry|* Area Plots}
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 showAreaAndBarPlots(data, items, tot, fill = TRUE)
-showAreaAndBarPlots(data, items2, tot, orderVars = "user")
+showAreaAndBarPlots(data, items2, tot, orderVars = "user", scales = "fixed")
 ```
 
 #### FE|Industry|* Line Plots
 
-```{r}
+```{r FE|Industry|* Line Plots}
 showLinePlots(data, tot)
 walk(items, showLinePlots, data = data)
 ```
 
 #### FE|Industry|Electricity|Share
 
-```{r}
+```{r FE|Industry|Electricity|Share}
 showLinePlots(data, "FE|Industry|Electricity|Share")
 ```
 
 
 ### FE mix Steel
-```{r}
+```{r FE mix Steel}
 tot <- "FE|Industry|Steel"
 items <- c(
   "FE|Industry|Steel|Heat",
@@ -150,11 +150,11 @@ items <- c(
   "FE|Industry|Steel|Gases",
   "FE|Industry|Steel|Primary|Electricity",
   "FE|Industry|Steel|Secondary|Electricity")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ### FE mix Cement
-```{r}
+```{r FE mix Cement}
 tot <- "FE|Industry|Cement"
 items <- c(
   "FE|Industry|Cement|Heat",
@@ -163,11 +163,11 @@ items <- c(
   "FE|Industry|Cement|Liquids",
   "FE|Industry|Cement|Gases",
   "FE|Industry|Cement|Electricity")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ### FE mix Non-metallic minerals
-```{r}
+```{r FE mix Non-metallic minerals}
 tot <- "FE|Industry|Non-metallic minerals"
 items <- c(
   "FE|Industry|Electricity|Non-metallic minerals",
@@ -176,11 +176,11 @@ items <- c(
   "FE|Industry|Hydrogen|Non-metallic minerals",
   "FE|Industry|Liquids|Non-metallic minerals",
   "FE|Industry|Solids|Non-metallic minerals")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ### FE mix Chemicals
-```{r}
+```{r FE mix Chemicals}
 tot <- "FE|Industry|Chemicals"
 items <- c(
   "FE|Industry|Chemicals|Heat",
@@ -190,11 +190,11 @@ items <- c(
   "FE|Industry|Chemicals|Gases",
   "FE|Industry|Chemicals|Electricity|Mechanical work and low-temperature heat",
   "FE|Industry|Chemicals|Electricity|High-temperature heat")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ### FE mix Other Industry
-```{r}
+```{r FE mix Other Industry}
 tot <- "FE|Industry|Other Industry"
 items <- c(
   "FE|Industry|Other Industry|Heat",
@@ -204,11 +204,11 @@ items <- c(
   "FE|Industry|Other Industry|Gases",
   "FE|Industry|Other Industry|Electricity|Mechanical work and low-temperature heat",
   "FE|Industry|Other Industry|Electricity|High-temperature heat")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ### FE|Industry|* line plots
-```{r}
+```{r FE|Industry|* line plots}
 showLinePlots(data, "FE|Industry|Steel")
 showLinePlots(data, "FE|Industry|Steel|Primary")
 showLinePlots(data, "FE|Industry|Steel|Secondary")
@@ -220,7 +220,7 @@ showLinePlots(data, c("FE|Industry|Other Industry", "FE|Industry|other"))
 
 ### Specific Energy Consumption
 
-```{r}
+```{r Specific Energy Consumption}
 items <- c(
   "FE|Industry|Specific Energy Consumption|Chemicals",
   "FE|Industry|Specific Energy Consumption|Other Industry")
@@ -228,7 +228,7 @@ walk(items, showLinePlots, data = data)
 ```
 
 ### Specific Energy Consumption with thermodynamic limits
-```{r}
+```{r Specific Energy Consumption with thermodynamic limits}
 # estimated values for thermodynamic limits are hardcoded here. Could be improved
 
 # Cement and other non-metallic minerals
@@ -279,7 +279,7 @@ data %>%
 
 ### Basics -- with Bunkers
 
-```{r}
+```{r Transport Final Energy}
 tot <- "FE|Transport"
 items <- c(
   "FE|Transport|Electricity",
@@ -299,29 +299,29 @@ items2 <- c(
 
 #### FE|Transport|* Area Plots -- with Bunkers
 
-```{r}
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items2, tot)
+```{r FE|Transport|* Area Plots -- with Bunkers}
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
+showAreaAndBarPlots(data, items2, tot, scales = "fixed")
 showAreaAndBarPlots(data, items, tot, fill = TRUE)
 ```
 
 #### FE|Transport|* Line Plots -- with Bunkers
 
-```{r}
+```{r FE|Transport|* Line Plots -- with Bunkers}
 showLinePlots(data, tot)
 walk(items, showLinePlots, data = data)
 ```
 
 #### FE|Transport|Electricity|Share
 
-```{r}
+```{r FE|Transport|Electricity|Share}
 showLinePlots(data, "FE|Transport|Electricity|Share")
 ```
 
 
 ### Basics -- w/o Bunkers
 
-```{r}
+```{r Basics -- w/o Bunkers}
 tot <- "FE|Transport|w/o Bunkers"
 items <- c(
   "FE|Transport|w/o Bunkers|Electricity",
@@ -341,15 +341,15 @@ items2 <- c(
 
 #### FE|Transport|* Area Plots -- w/o Bunkers
 
-```{r}
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items2, tot)
+```{r FE|Transport|* Area Plots -- w/o Bunkers}
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
+showAreaAndBarPlots(data, items2, tot, scales = "fixed")
 showAreaAndBarPlots(data, items, tot, fill = TRUE)
 ```
 
 #### FE|Transport|* Line Plots -- w/o Bunkers
 
-```{r}
+```{r FE|Transport|* Line Plots -- w/o Bunkers}
 showLinePlots(data, tot)
 walk(items, showLinePlots, data = data)
 ```
@@ -357,7 +357,7 @@ walk(items, showLinePlots, data = data)
 
 ### Transport per type
 
-```{r}
+```{r Transport per type}
 tot <- "FE|Transport"
 items <- c(
   "FE|Transport|LDV|Liquids",
@@ -368,15 +368,15 @@ items <- c(
   "FE|Transport|non-LDV|Gases",
   "FE|Transport|non-LDV|Electricity",
   "FE|Transport|non-LDV|Hydrogen")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ### Bunkers
 
-```{r}
+```{r FE Transport Bunkers}
 tot <- "FE|Transport"
 items <- c(
   "FE|Transport|Bunkers",
   "FE|Transport|w/o Bunkers")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```

--- a/inst/markdown/compareScenarios2/cs2_06_energy_services.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_06_energy_services.Rmd
@@ -1,7 +1,7 @@
 # Energy Services and Products
 
 ## FE|Buildings
-```{r}
+```{r FE Buildings}
 tot <- "FE|Buildings"
 items <- c(
   "FE|Buildings|non-Heating|Electricity|Conventional",
@@ -12,12 +12,12 @@ items <- c(
   "FE|Buildings|Heating|Liquids",
   "FE|Buildings|Heating|Gases",
   "FE|Buildings|Heating|Hydrogen")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ### Region Intercomparison FE|Buildings
 
-```{r}
+```{r FE Buildings Region}
 items <- c(
   "FE|Buildings|Heating",
   "FE|Buildings|Appliances and Light",
@@ -33,7 +33,7 @@ showMultiLinePlotsByVariable(data, items[4:5], "GDP|PPP pCap")
 
 ## Transport
 ### Energy Services for Passenger Transport
-```{r}
+```{r ES Transport}
 items <- c(
   "ES|Transport|Pass pCap",
   "ES|Transport|Pass|Road|LDV pCap",
@@ -42,7 +42,7 @@ showMultiLinePlots(data, items)
 showMultiLinePlotsByVariable(data, items, "GDP|PPP pCap")
 ```
 
-```{r}
+```{r ES Transport passenger per capita}
 ## ---- ES passenger transport per capita (bar graph)----
 items <- c(
   "ES|Transport|Pass|Road|LDV|BEV pCap",
@@ -50,11 +50,11 @@ items <- c(
   "ES|Transport|Pass|Road|LDV|Gases pCap",
   "ES|Transport|Pass|Road|LDV|Hybrid Electric pCap",
   "ES|Transport|Pass|Road|LDV|Liquids pCap")
-showAreaAndBarPlots(data, items)
+showAreaAndBarPlots(data, items, scales = "fixed")
 ```
 
 ### Energy Services for Freight Transport per Capita
-```{r}
+```{r ES transport freight per capita}
 items <- c(
   "ES|Transport|Freight pCap")
 showMultiLinePlots(data, items)
@@ -62,53 +62,53 @@ showMultiLinePlotsByVariable(data, items, "GDP|PPP pCap")
 ```
 
 
-```{r}
+```{r ES transport freight road per capita}
 items <- c(
   "ES|Transport|Freight|Road|Electric pCap",
   "ES|Transport|Freight|Road|FCEV pCap",
   "ES|Transport|Freight|Road|Gases pCap",
   "ES|Transport|Freight|Road|Liquids pCap")
-showAreaAndBarPlots(data, items)
+showAreaAndBarPlots(data, items, scales = "fixed")
 ```
 
 ### LDV Vehicles Stock
-```{r}
+```{r LDV Vehicles Stock}
 tot <- "Est LDV Stock"
 items <- c(
   "Est EV LDV Stock",
   "Est H2 LDV Stock",
   "Est ICE LDV Stock")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ### LDV Vehicles Sales
-```{r}
+```{r LDV Vehicles Sales}
 tot <- "Est LDV Sales"
 items <- c(
   "Est EV LDV Sales",
   "Est H2 LDV Sales",
   "Est ICE LDV Sales")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ### non-LDV Vehicles Stock
-```{r}
+```{r non-LDV Vehicles Stock}
 tot <- "Services and Products|Transport|non-LDV|Stock|uedit"
 items <- c(
   "Services and Products|Transport|non-LDV|Stock|apCarDiT",
   "Services and Products|Transport|non-LDV|Stock|apcarDiEffT",
   "Services and Products|Transport|non-LDV|Stock|apcarDiEffH2T")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ### non-LDV Vehicles Sales
-```{r}
+```{r non-LDV Vehicles Sales}
 tot <- "Services and Products|Transport|non-LDV|Sales|uedit"
 items <- c(
   "Services and Products|Transport|non-LDV|Sales|apCarDiT",
   "Services and Products|Transport|non-LDV|Sales|apcarDiEffT",
   "Services and Products|Transport|non-LDV|Sales|apcarDiEffH2T")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
 ## Industry Production
@@ -122,7 +122,7 @@ showLinePlots(data, "Production|Industry|Steel|Secondary")
 showLinePlots(data, "Value Added|Industry|Other Industry")
 ```
 
-### Steel Produciton Mix
+### Steel Production Mix
 ```{r plot steel production mix, results = 'asis'}
 items <- c("Production|Industry|Steel|Primary",
            "Production|Industry|Steel|Secondary")
@@ -179,7 +179,7 @@ walk(items, showLinePlots, data = data, scales = "fixed")
 
 
 ### Steel accumulation
-```{r}
+```{r plot steel accumulation}
 stockT0 <- filter(data, period == 2005, model == "Mueller", variable == "Steel stock") %>% select("region", "value")
 
 population <- filter(data, period >= 2005, model == "REMIND", variable == "Population") %>%

--- a/inst/markdown/compareScenarios2/cs2_07_climate.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_07_climate.Rmd
@@ -1,6 +1,6 @@
 # Climate
 
-```{r}
+```{r Climate}
 showLinePlots(data, "Forcing")
 showLinePlots(data, "Temperature|Global Mean")
 ```

--- a/inst/markdown/compareScenarios2/cs2_08_sdp.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_08_sdp.Rmd
@@ -2,7 +2,7 @@
 
 ## SDG 1
 
-```{r}
+```{r SDG 1}
 items <- c(
   "Population|Extreme poverty",
   "Population|Extreme poverty|International poverty line",
@@ -13,7 +13,7 @@ walk(items, showLinePlots, data = data)
 
 ## SDG 3
 
-```{r}
+```{r SDG 3}
 items <- c(
   "Premature mortality|PM2_5",
   "Disability-Adjusted Life Year|PM2_5")
@@ -22,7 +22,7 @@ walk(items, showLinePlots, data = data)
 
 ## SDG 4
 
-```{r}
+```{r SDG 4}
 items <- c(
   "Population|Primary education",
   "Population|Secondary education",
@@ -39,7 +39,7 @@ walk(items, showLinePlots, data = data)
 
 ## SDG 5
 
-```{r}
+```{r SDG 5}
 items <- c(
   "Population|Gender education gap|Primary",
   "Population|Gender education gap|Secondary")
@@ -48,7 +48,7 @@ walk(items, showLinePlots, data = data)
 
 ## SDG 6
 
-```{r}
+```{r SDG 6}
 items <- c(
   "Water Consumption|Electricity",
   "Water Consumption|Electricity w/o Hydro")
@@ -59,7 +59,7 @@ walk(items, showLinePlots, data = data)
 
 ### access
 
-```{r}
+```{r SDG 7 access}
 items <- c(
   "UE|per capita|Buildings",
   "UE|per capita|Industry",
@@ -71,7 +71,7 @@ walk(items, showLinePlots, data = data)
 
 ### modern
 
-```{r}
+```{r SDG 7 modern}
 items <- c(
   "FE|Electricity|Share",
   "UE|Electricity and Hydrogen|Share|Transport",
@@ -88,7 +88,7 @@ walk(items, showLinePlots, data = data)
 
 ### clean
 
-```{r}
+```{r SDG 7 clean}
 items <- c(
   "PE|Non-Biomass Renewables",
   "SE|Electricity|Non-Biomass Renewables",
@@ -99,7 +99,7 @@ walk(items, showLinePlots, data = data)
 
 ## SDG 8
 
-```{r}
+```{r SDG 8}
 items <- c(
   "GDP|PPP|Per capita growth rate",
   "GDP|PPP|Per capita ratio to OECD")
@@ -108,7 +108,7 @@ walk(items, showLinePlots, data = data)
 
 ## SDG 9
 
-```{r}
+```{r SDG 9}
 items <- c(
   "Final Energy|Industry|Electricity|Share",
   "Final Energy|Industry|Hydrogen and Electricity|Share",
@@ -123,7 +123,7 @@ walk(items, showLinePlots, data = data)
 
 ## SDG 10
 
-```{r}
+```{r SDG 10}
 items <- c(
   "Population|Relative poverty|wrt median income|Share",
   "Inequality|Bottom 40% average income|Ratio")
@@ -132,7 +132,7 @@ walk(items, showLinePlots, data = data)
 
 ## SDG 11
 
-```{r}
+```{r SDG 11}
 items <- c(
   "Energy Service|per capita|Buildings|Residential|Floor Space",
   "Air pollution concentration|PM2_5|Urban population")
@@ -141,7 +141,7 @@ walk(items, showLinePlots, data = data)
 
 ## SDG 12
 
-```{r}
+```{r SDG 12}
 items <- c(
   "Emi|CO2|Industry|Direct",
   "Intensity|GDP|Final Energy")
@@ -150,7 +150,7 @@ walk(items, showLinePlots, data = data)
 
 ## LCA
 
-```{r}
+```{r SDG 12 LCA}
 items <- c(
   "Resource|Use|Mineral|Electricity",
   "Ecotoxicity|Freshwater|Electricity",
@@ -166,7 +166,7 @@ walk(items, showLinePlots, data = data)
 
 ## SDG 13
 
-```{r}
+```{r SDG 13}
 items <- c(
   "Emi|CO2",
   "Emi|GHGtot",
@@ -176,7 +176,7 @@ walk(items, showLinePlots, data = data)
 
 ## SDG 14
 
-```{r}
+```{r SDG 14}
 items <- c(
   "Ocean|New production",
   "Ocean|Extension of suboxic zones",
@@ -189,7 +189,7 @@ walk(items, showLinePlots, data = data)
 
 ## SDG 16
 
-```{r}
+```{r SDG 16}
 items <- c(
   "Political institutions|Equality before law and individual liberty",
   "Conflict|Battle-related deaths|Probability of below 2005 value")
@@ -198,7 +198,7 @@ walk(items, showLinePlots, data = data)
 
 ## SDG 17
 
-```{r}
+```{r SDG 17}
 items <- c(
   "Policy Cost|Transfers",
   "Policy Cost|GDP Loss",

--- a/inst/markdown/compareScenarios2/cs2_08_sdp.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_08_sdp.Rmd
@@ -55,6 +55,7 @@ items <- c(
 walk(items, showLinePlots, data = data)
 ```
 
+\newpage
 ## SDG 7
 
 ### access
@@ -139,6 +140,7 @@ items <- c(
 walk(items, showLinePlots, data = data)
 ```
 
+\newpage
 ## SDG 12
 
 ```{r SDG 12}

--- a/inst/markdown/compareScenarios2/cs2_09_carbon_management.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_09_carbon_management.Rmd
@@ -4,29 +4,29 @@
 
 ```{r carbon capture}
 showLinePlots(data, "Carbon Management|Carbon Capture")
-showAreaAndBarPlotsPlus(data, "Carbon Management|Carbon Capture")
-showAreaAndBarPlotsPlus(data, "Carbon Management|Carbon Capture|Biomass|Pe2Se")
-showAreaAndBarPlotsPlus(data, "Carbon Management|Carbon Capture|Fossil|Pe2Se")
-showAreaAndBarPlotsPlus(data, "Carbon Management|Carbon Capture|Industry Energy")
+showAreaAndBarPlotsPlus(data, "Carbon Management|Carbon Capture", scales = "fixed")
+showAreaAndBarPlotsPlus(data, "Carbon Management|Carbon Capture|Biomass|Pe2Se", scales = "fixed")
+showAreaAndBarPlotsPlus(data, "Carbon Management|Carbon Capture|Fossil|Pe2Se", scales = "fixed")
+showAreaAndBarPlotsPlus(data, "Carbon Management|Carbon Capture|Industry Energy", scales = "fixed")
 ```
 
 ## Storage
 
-```{r storage}
+```{r carbon management storage}
 showLinePlots(data, "Carbon Management|Storage")
-showAreaAndBarPlotsPlus(data, "Carbon Management|Storage")
-showAreaAndBarPlotsPlus(data, "Carbon Management|Storage|Industry Energy")
+showAreaAndBarPlotsPlus(data, "Carbon Management|Storage", scales = "fixed")
+showAreaAndBarPlotsPlus(data, "Carbon Management|Storage|Industry Energy", scales = "fixed")
 ```
 
 ## Usage
 
-```{r usage}
+```{r carbon management usage}
 showLinePlots(data, "Carbon Management|Usage")
-showAreaAndBarPlotsPlus(data, "Carbon Management|Usage")
+showAreaAndBarPlotsPlus(data, "Carbon Management|Usage", scales = "fixed")
 ```
 
 ## Share
 
-```{r share}
+```{r carbon management share}
 showLinePlots(data, "Carbon Management|Share of Stored CO2 from Captured CO2")
 ```

--- a/inst/markdown/compareScenarios2/cs2_99_further_info.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_99_further_info.Rmd
@@ -1,4 +1,7 @@
+\begingroup
+\let\newpage\relax
 # Further Information
+\endgroup
 
 ```{r Further information}
 # varsPerTable # Number of variable columns in table.
@@ -138,7 +141,7 @@ if (exists("cfgDefault") && !is.null(cfgDefault) &&
 if (exists("cfgGmsWideDiff") && !is.null(cfgGmsWideDiff)) {
   cat("## GAMS Config Differences\n\n")
 
-  cat("Following GAMS settings are different among the sceanrios:\n\n")
+  cat("Following GAMS settings are different among the scenarios:\n\n")
 
   showInTables(cfgGmsWideDiff, bkgndColors)
 }

--- a/inst/markdown/compareScenarios2/cs2_99_further_info.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_99_further_info.Rmd
@@ -1,6 +1,6 @@
 # Further Information
 
-```{r}
+```{r Further information}
 # varsPerTable # Number of variable columns in table.
 # firstColumnWidth  # in mm; first column shows the scenario title.
 # pageTextWidth <- # in mm; DIN A4 landscape minus margins.
@@ -68,7 +68,7 @@ showInTables <- function(
 }
 ```
 
-```{r}
+```{r get config options}
 # Get config options where scenarios differ and where all scenarios are the same.
 if (exists("cfgGms") && !is.null(cfgGms)) {
   cfgGmsWide <-

--- a/inst/markdown/compareScenarios2/cs2_latex_template.tex
+++ b/inst/markdown/compareScenarios2/cs2_latex_template.tex
@@ -1,4 +1,4 @@
-%% NOTE: This a slightly modified verseion of the default Pandoc LaTeX template https://github.com/jgm/pandoc/tree/master/data/templates/
+%% NOTE: This a slightly modified version of the default Pandoc LaTeX template https://github.com/jgm/pandoc/tree/master/data/templates/
 %% Modifications:
 %% * package hyperref is loaded last
 %% 
@@ -481,7 +481,10 @@ $if(colorlinks)$
 \hypersetup{linkcolor=$if(toccolor)$$toccolor$$else$$endif$}
 $endif$
 \setcounter{tocdepth}{$toc-depth$}
+\begingroup
+\let\newpage\relax
 \tableofcontents
+\endgroup
 }
 $endif$
 $endif$

--- a/inst/markdown/compareScenarios2/cs2_main.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_main.Rmd
@@ -380,6 +380,7 @@ data <- as.quitte(data)
 
 
 ```{r global variables}
+on.exit(options(warn = getOption("warn")))
 options(warn = 1)
 
 

--- a/inst/markdown/compareScenarios2/cs2_main.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_main.Rmd
@@ -34,7 +34,7 @@ params:
   mainReg: "World"
   figWidth: 15 
   figHeight: 10
-  warning: yes
+  warning: FALSE
 ---
 
 ```{r setup, include=FALSE}
@@ -380,6 +380,9 @@ data <- as.quitte(data)
 
 
 ```{r global variables}
+options(warn = 1)
+
+
 # Set global variables for use in plotting.
 options(mip.mainReg = params$mainReg) # nolint
 options(mip.yearsBarPlot = params$yearsBarPlot) # nolint
@@ -387,6 +390,9 @@ options(mip.histRefModel = histRefModel) # nolint
 
 # Reference year for Kaya decomposition is params$yearRef or the first available year therafter.
 options(kaya.refYear = min(params$yearsScen[params$yearsScen >= params$yearRef])) # nolint
+
+# allow for duplicate chunk labels
+options(knitr.duplicate.label = "allow")
 ```
 
 

--- a/inst/markdown/compareScenarios2/cs2_main.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_main.Rmd
@@ -250,7 +250,7 @@ histRefModel <- c(
 ```
 
 
-```{r calcuate pCap variables}
+```{r calculate pCap variables}
 # For all variables in following table, add a new variable to data with the name
 # "OldName pCap". Calculate its value by
 #     OldValue * conversionFactor # nolint
@@ -334,7 +334,7 @@ data <-
 ```
 
 
-```{r calcuate pGDP variables}
+```{r calculate pGDP variables}
 dataGDP <-
   data %>%
   filter(variable == "GDP|PPP pCap") %>%


### PR DESCRIPTION
- I was always a bit confused by cs2 plots as the automatic adaptation of the y-axis often made it difficult to compare scenarios. This PR together with https://github.com/pik-piam/mip/pull/48 fixes the y-axes for the area plots, making the differences between the scenarios more obvious, see the differences below
- full files available at `/p/tmp/oliverr/NGFS_v3_tests/2022-11-16/remind` (`compScen-47tests-2022-11-23_16.51.17-H12.pdf` vs. `compScen-47tests-2022-11-23_16.51.17-H12-new.pdf`)
- for most variables, it simply improves readability and comparability
- for CDR that is often close to zero in current policy runs, this means you can hardly see anything, but I think this is rather a boon as it reflects the scenario reality, than a drawback, but maybe @katarkow or @strefler can comment whether I undo the CDR plots
- add all contributors to the author list as agreed with @Renato-Rodrigues a while ago

left: old, right: new

- cumulative CO2
![test-cs2-fixed-yaxes-co2](https://user-images.githubusercontent.com/90761609/204281425-5f58c6ed-af90-47ef-bc60-9af824ea1dab.png)

- Capacity Electricity
![test-cs2-fixed-yaxes-cap-elec](https://user-images.githubusercontent.com/90761609/204281430-11ec3a09-3d0b-4610-bdd9-e735faa2144c.png)

- FE CDR
![test-cs2-fixed-yaxes-cdr](https://user-images.githubusercontent.com/90761609/204281422-b8dd2c23-28c0-47ef-88c9-96d2cdd10c86.png)

- Emi CDR
![test-cs2-fixed-yaxes-cdr-2](https://user-images.githubusercontent.com/90761609/204281436-316f1ebc-14ea-4e0e-afe0-94616f26ac3a.png)