### PR TITLE
Rename exogains vars

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2132264960'
+ValidationKey: '2132615251'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'
@@ -9,5 +9,6 @@ AcceptedNotes:
 - unable to verify current time
 - checking installed package size
 - Namespace in Imports field not imported from: ‘piamInterfaces’
+- Namespace in Imports field not imported from: piamInterfaces
 AutocreateReadme: yes
 allowLinterWarnings: yes

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.103.20",
+  "version": "1.103.21",
   "description": "<p>Contains the REMIND-specific routines for data and model\n    output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.103.20
-Date: 2022-12-02
+Version: 1.103.21
+Date: 2022-12-05
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,7 +62,7 @@ Imports:
     madrat,
     mip (>= 0.139.1),
     openxlsx,
-    piamInterfaces (>= 0.0.31),
+    piamInterfaces (>= 0.0.34),
     plotly,
     quitte,
     readr,

--- a/R/reportEmiAirPol.R
+++ b/R/reportEmiAirPol.R
@@ -55,7 +55,7 @@ reportEmiAirPol <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2
       remind = c("power", "indst", "res", "trans", "indprocess", "solvents", "extraction"),
       reporting = c(paste0("Emi|", pollutant, "|Energy Supply|Electricity (Mt ", pollutant, "/yr)"),
                     paste0("Emi|", pollutant, "|Energy Demand|Industry (Mt ", pollutant, "/yr)"), 
-                    paste0("Emi|", pollutant, "|Energy Demand|ResCom (Mt ", pollutant, "/yr)"),
+                    paste0("Emi|", pollutant, "|Energy Demand|Buildings (Mt ", pollutant, "/yr)"),
                     paste0("Emi|", pollutant, "|Energy Demand|Transport|Ground Trans (Mt ", pollutant, "/yr)"),
                     paste0("Emi|", pollutant, "|Energy Demand|Industry (Mt ", pollutant, "/yr)"), 
                     paste0("Emi|", pollutant, "|Solvents (Mt ", pollutant, "/yr)"), 
@@ -120,7 +120,7 @@ reportEmiAirPol <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2
     # Aggregation: Energy Demand + Energy Supply, Land Use
     tmp3 <- mbind(tmp2, 
                   setNames(dimSums(tmp2[,,c(paste0("Emi|",pollutant,"|Energy Demand|Industry (Mt ",pollutant,"/yr)"),
-                                            paste0("Emi|",pollutant,"|Energy Demand|ResCom (Mt ",pollutant,"/yr)"),
+                                            paste0("Emi|",pollutant,"|Energy Demand|Buildings (Mt ",pollutant,"/yr)"),
                                             paste0("Emi|",pollutant,"|Energy Demand|Transport (Mt ",pollutant,"/yr)"),
                                             paste0("Emi|",pollutant,"|Energy Supply (Mt ",pollutant,"/yr)"))],dim = 3),
                            paste0("Emi|",pollutant,"|Energy Supply and Demand (Mt ",pollutant,"/yr)")),
@@ -322,7 +322,7 @@ reportEmiAirPol <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2
       remind = c("power", "indst", "res", "trans", "indprocess", "solvents", "extraction"),
       reporting = c(paste0("Emi|", pollutant, "|Energy Supply|Electricity (Mt ", pollutant, "/yr)"),
                     paste0("Emi|", pollutant, "|Energy Demand|Industry (Mt ", pollutant, "/yr)"), 
-                    paste0("Emi|", pollutant, "|Energy Demand|ResCom (Mt ", pollutant, "/yr)"),
+                    paste0("Emi|", pollutant, "|Energy Demand|Buildings (Mt ", pollutant, "/yr)"),
                     paste0("Emi|", pollutant, "|Energy Demand|Transport|Ground Trans (Mt ", pollutant, "/yr)"),
                     paste0("Emi|", pollutant, "|Energy Demand|Industry (Mt ", pollutant, "/yr)"), 
                     paste0("Emi|", pollutant, "|Solvents (Mt ", pollutant, "/yr)"), 
@@ -369,7 +369,7 @@ reportEmiAirPol <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2
     # Aggregation: Energy Demand + Energy Supply, Land Use
     tmp3 <- mbind(tmp2, 
                   setNames(dimSums(tmp2[,,c(paste0("Emi|",pollutant,"|Energy Demand|Industry (Mt ",pollutant,"/yr)"),
-                                            paste0("Emi|",pollutant,"|Energy Demand|ResCom (Mt ",pollutant,"/yr)"),
+                                            paste0("Emi|",pollutant,"|Energy Demand|Buildings (Mt ",pollutant,"/yr)"),
                                             paste0("Emi|",pollutant,"|Energy Demand|Transport (Mt ",pollutant,"/yr)"),
                                             paste0("Emi|",pollutant,"|Energy Supply (Mt ",pollutant,"/yr)"))],dim = 3),
                            paste0("Emi|",pollutant,"|Energy Supply and Demand (Mt ",pollutant,"/yr)")),
@@ -521,7 +521,7 @@ reportEmiAirPol <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2
         remind = c("power", "indst", "res", "trans", "solvents", "extraction"),
         reporting = c(paste0("Emi|", poll_rep, "|Energy Supply|Electricity (Mt ", poll_rep, "/yr)"),
                       paste0("Emi|", poll_rep, "|Energy Demand|Industry (Mt ", poll_rep, "/yr)"), 
-                      paste0("Emi|", poll_rep, "|Energy Demand|ResCom (Mt ", poll_rep, "/yr)"),
+                      paste0("Emi|", poll_rep, "|Energy Demand|Buildings (Mt ", poll_rep, "/yr)"),
                       paste0("Emi|", poll_rep, "|Energy Demand|Transport|Ground Trans (Mt ", poll_rep, "/yr)"),
                       paste0("Emi|", poll_rep, "|Solvents (Mt ", poll_rep, "/yr)"), 
                       paste0("Emi|", poll_rep, "|Energy Supply|Extraction (Mt ", poll_rep, "/yr)")))
@@ -595,7 +595,7 @@ reportEmiAirPol <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2
         # Aggregation: Energy Demand + Energy Supply, Land Use
         out <- mbind(out, 
                       setNames(dimSums(out[,,c(paste0("Emi|",poll_rep,"|Energy Demand|Industry (Mt ",poll_rep,"/yr)"),
-                                               paste0("Emi|",poll_rep,"|Energy Demand|ResCom (Mt ",poll_rep,"/yr)"),
+                                               paste0("Emi|",poll_rep,"|Energy Demand|Buildings (Mt ",poll_rep,"/yr)"),
                                                paste0("Emi|",poll_rep,"|Energy Demand|Transport (Mt ",poll_rep,"/yr)"),
                                                paste0("Emi|",poll_rep,"|Energy Supply (Mt ",poll_rep,"/yr)"))],dim = 3),
                                paste0("Emi|",poll_rep,"|Energy Supply and Demand (Mt ",poll_rep,"/yr)")),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.103.20**
+R package **remind2**, version **1.103.21**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.103.20, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.103.21, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort},
   year = {2022},
-  note = {R package version 1.103.20},
+  note = {R package version 1.103.21},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/tests/testthat/test-piamInterfaces.R
+++ b/tests/testthat/test-piamInterfaces.R
@@ -1,5 +1,4 @@
 library(gdx)
-library(piamInterfaces)
 
 test_that("Test if REMIND reporting produces mandatory variables for NGFS reporting", {
   skip_if_not(as.logical(gdxrrw::igdx(silent = TRUE)), "gdxrrw is not initialized properly")


### PR DESCRIPTION
Buildings emissions from exogains used an inconsistent sector name (`ResCom`) which is now aligned with all other buildings variables. I also changed quotes in .buildlibrary as the old quotes caused `lucode2::buildlibrary()` to fail. @fbenke-pik, will theses quotes also work on ubuntu? I didn't check that so far.