### PR TITLE
Add UE plot for buildings to cs2

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2132615251'
+ValidationKey: '213414240'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.103.21",
+  "version": "1.104.0",
   "description": "<p>Contains the REMIND-specific routines for data and model\n    output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.103.21
+Version: 1.104.0
 Date: 2022-12-05
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.103.21**
+R package **remind2**, version **1.104.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.103.21, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2022). _remind2: The REMIND R package (2nd generation)_. R package version 1.104.0, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort},
   year = {2022},
-  note = {R package version 1.103.21},
+  note = {R package version 1.104.0},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/inst/markdown/compareScenarios2/cs2_06_energy_services.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_06_energy_services.Rmd
@@ -60,7 +60,7 @@ showAreaAndBarPlots(data, items, tot, orderVars = "user", scales = "fixed")
 ```
 
 ### Region Intercomparison FE|Buildings
-```{r}
+```{r FE Buildings Region}
 items <- c(
   "FE|Buildings|Heating",
   "FE|Buildings|Appliances and Light",

--- a/inst/markdown/compareScenarios2/cs2_06_energy_services.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_06_energy_services.Rmd
@@ -1,22 +1,65 @@
 # Energy Services and Products
 
-## FE|Buildings
-```{r}
+## Buildings
+### FE mix
+```{r FE demand from buildings by carriers}
 tot <- "FE|Buildings"
 items <- c(
   "FE|Buildings|non-Heating|Electricity|Conventional",
-  "FE|Buildings|Heating|Electricity|Resistance",
-  "FE|Buildings|Heating|Electricity|Heat pump",
-  "FE|Buildings|Heating|District Heating",
   "FE|Buildings|Heating|Solids",
   "FE|Buildings|Heating|Liquids",
   "FE|Buildings|Heating|Gases",
+  "FE|Buildings|Heating|District Heating",
+  "FE|Buildings|Heating|Electricity|Resistance",
+  "FE|Buildings|Heating|Electricity|Heat pump",
   "FE|Buildings|Heating|Hydrogen")
-showAreaAndBarPlots(data, items, tot)
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+```
+
+### UE mix
+```{r UE demand from buildings by carriers}
+tot <- "UE|Buildings"
+items <- c(
+  "UE|Buildings|non-Heating|Electricity|Conventional",
+  "UE|Buildings|Heating|Solids",
+  "UE|Buildings|Heating|Liquids",
+  "UE|Buildings|Heating|Gases",
+  "UE|Buildings|Heating|District Heating",
+  "UE|Buildings|Heating|Electricity|Resistance",
+  "UE|Buildings|Heating|Electricity|Heat pump",
+  "UE|Buildings|Heating|Hydrogen")
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+```
+
+### FE heating
+```{r FE demand from buildings for heating by carriers}
+tot <- "FE|Buildings|Heating"
+items <- c(
+  "FE|Buildings|Heating|Solids",
+  "FE|Buildings|Heating|Liquids",
+  "FE|Buildings|Heating|Gases",
+  "FE|Buildings|Heating|District Heating",
+  "FE|Buildings|Heating|Electricity|Resistance",
+  "FE|Buildings|Heating|Electricity|Heat pump",
+  "FE|Buildings|Heating|Hydrogen")
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+```
+
+### UE heating
+```{r UE demand from buildings for heating by carriers}
+tot <- "UE|Buildings|Heating"
+items <- c(
+  "UE|Buildings|Heating|Solids",
+  "UE|Buildings|Heating|Liquids",
+  "UE|Buildings|Heating|Gases",
+  "UE|Buildings|Heating|District Heating",
+  "UE|Buildings|Heating|Electricity|Resistance",
+  "UE|Buildings|Heating|Electricity|Heat pump",
+  "UE|Buildings|Heating|Hydrogen")
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
 ```
 
 ### Region Intercomparison FE|Buildings
-
 ```{r}
 items <- c(
   "FE|Buildings|Heating",


### PR DESCRIPTION
This adds UE plots to cs2 for buildings where there was only FE. Additionally, FE and UE plots of heating (without non-heating electricity) are now available. To make the plots comparable, I set the colours explicitly [here](https://github.com/pik-piam/mip/pull/49).