### PR TITLE
Add and rename floor space variables.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '214328997'
+ValidationKey: '214403684'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,6 +1,6 @@
 # Run CI for R using https://eddelbuettel.github.io/r-ci/
 
-name: lucode2-check
+name: check
 
 on:
   push:
@@ -14,7 +14,7 @@ env:
   NO_BINARY_INSTALL_R_PACKAGES: 'c("madrat", "magclass", "citation", "gms", "goxygen", "GDPuc", "roxygen2")'
 
 jobs:
-  lucode2-check:
+  check:
     runs-on: ubuntu-latest
 
     steps:

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind2: The REMIND R package (2nd generation)",
-  "version": "1.106.1",
+  "version": "1.106.2",
   "description": "<p>Contains the REMIND-specific routines for data and model\n    output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.106.1
-Date: 2023-01-20
+Version: 1.106.2
+Date: 2023-01-25
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),
@@ -62,7 +62,7 @@ Imports:
     madrat,
     mip (>= 0.139.1),
     openxlsx,
-    piamInterfaces (>= 0.0.48),
+    piamInterfaces (>= 0.0.59),
     plotly,
     quitte,
     readr,

--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,22 @@ test:           ## Run testthat tests
 	Rscript -e 'devtools::test(show_report = TRUE)'
 
 lint:           ## Check if code etiquette is followed using lucode2::lint()
+                ## Only checks files you changed.
 	Rscript -e 'lucode2::lint()'
+
+lint-all:       ## Check if code etiquette is followed using lucode2::lint()
+                ## Checks all files.
+	Rscript -e 'lucode2::lint(".")'
 
 format:         ## Apply auto-formatting to changed files and lint afterwards
 	Rscript -e 'lucode2::autoFormat()'
 
+format-all:     ## Apply auto-formatting to all files and lint afterwards
+	Rscript -e 'lucode2::autoFormat(files=list.files("./R", full.names = TRUE, pattern = "\\.R"))'
+
 install:        ## Install the package locally via devtools::install()
 	Rscript -e 'devtools::install(upgrade = "never")'
 
-docs:           ## Generate the package documentation via roxygen2::roxygenize()
+docs:           ## Generate the package documentation (man/*.Rd files) via roxygen2::roxygenize(),
+                ## view the generated documentation with `?package::function`
 	Rscript -e 'roxygen2::roxygenize()'

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -20,7 +20,7 @@
 #' @export
 #' @importFrom gdx readGDX
 #' @importFrom magclass new.magpie mselect getRegions getYears mbind setNames
-#'                      dimSums getNames<- as.data.frame as.magpie
+#'                      dimSums getNames<- as.data.frame as.magpie getSets
 #' @importFrom dplyr filter %>% mutate select group_by summarise left_join full_join
 #'                   ungroup rename
 #' @importFrom quitte inline.data.frame revalue.levels
@@ -539,7 +539,15 @@ reportFE <- function(gdx, regionSubsetList = NULL,
 
   p36_floorspace <- readGDX(gdx, "p36_floorspace", react = "silent")[, t, ]
   if (!is.null(p36_floorspace)) {
-    out <- mbind(out, setNames(p36_floorspace, "Energy Service|Buildings|Floor Space (bn m2/yr)"))
+    if (length(dim(p36_floorspace)[3]) > 1) {
+      out <- mbind(out,
+                  setNames(p36_floorspace[, , "buildings"],   "ES|Buildings|Floor Space (bn m2)"),
+                  setNames(p36_floorspace[, , "residential"], "ES|Buildings|Residential|Floor Space (bn m2)"),
+                  setNames(p36_floorspace[, , "commercial"],  "ES|Buildings|Commercial|Floor Space (bn m2)"))
+    } else {
+      out <- mbind(out, setNames(p36_floorspace, "ES|Buildings|Floor Space (bn m2)"))
+    }
+
   }
 
   if (buil_mod == "simple") {

--- a/R/reportMacroEconomy.R
+++ b/R/reportMacroEconomy.R
@@ -160,9 +160,6 @@ reportMacroEconomy <- function(gdx, regionSubsetList = NULL,
                                  + invM[, , "Investments|Non-ESM|Macro (billion US$2005/yr)"],
                                  "Investments|Non-ESM (billion US$2005/yr)"))
 
-    # add floorspace
-    invM <- mbind(invM, setNames(p36_floorspace[, getYears(invM), ] * 1000, "Floorspace demand (million m2)"))
-
   } else {
     cap <- setNames(vm_cesIO[, , "kap"] * 1000, "Capital Stock|Non-ESM (billion US$2005)")
     invM <- setNames(vm_invMacro[, , "kap"] * 1000, "Investments|Non-ESM (billion US$2005/yr)")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.106.1**
+R package **remind2**, version **1.106.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.106.1, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.106.2, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort},
   year = {2023},
-  note = {R package version 1.106.1},
+  note = {R package version 1.106.2},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
Adds extra floor space variables for residential and commercial Buildings if present in the gdx. Also, I rename these variables from `Energy Service|*` to `ES|*` to be consistent with transport variable names. Variable mappings in piamInterfaces are changed in [#76](https://github.com/pik-piam/piamInterfaces/pull/76).