### PR TITLE
Report net GDP after damages and fix aggregation of damage factors

### DIFF
--- a/R/reportMacroEconomy.R
+++ b/R/reportMacroEconomy.R
@@ -342,7 +342,7 @@ reportMacroEconomy <- function(gdx, regionSubsetList = NULL,
 
 
   # define list of variables that will be exported:
-  varlist <- list(cons, gdp, gdp_ppp, invE, invM, pop, cap, inv, ces, damageFactor, welf) # ,curracc)
+  varlist <- list(cons, gdp, gdp_ppp, invE, invM, pop, cap, inv, ces)#, damageFactor, welf) # ,curracc)
   # use the same temporal resolution for all variables
   # calculate minimal temporal resolution
   tintersect <- Reduce(intersect, lapply(varlist, getYears))
@@ -351,8 +351,14 @@ reportMacroEconomy <- function(gdx, regionSubsetList = NULL,
   # put all together
   out <- Reduce(mbind, varlist)
 
+  # calculate global aggregation for the damage factor, weighted by MER GDP
+  mapping <- data.frame(region=getRegions(out),world="GLO",stringsAsFactors=FALSE)
+  glo_damageFactor <- speed_aggregate(damageFactor[,tintersect,], mapping, weight = gdp[,tintersect,])
+
   # add global region aggregation
   out <- mbind(out, dimSums(out, dim = 1))
+  # add damageFactor, which was aggregated differently
+  out <- mbind(out, mbind(damageFactor[,tintersect,],glo_damageFactor))
   # add other region aggregations
   if (!is.null(regionSubsetList))
     out <- mbind(out, calc_regionSubset_sums(out, regionSubsetList))

--- a/R/reportMacroEconomy.R
+++ b/R/reportMacroEconomy.R
@@ -87,6 +87,7 @@ reportMacroEconomy <- function(gdx, regionSubsetList = NULL,
   # Calculate net GDP using the damage factors
   tintersect <- intersect(getYears(gdp), getYears(damageFactor))
   gdp_net <- setNames(gdp[,tintersect,]*damageFactor[,tintersect,], "GDP|MER|Net_afterDamages (billion US$2005/yr)")  
+  gdp_ppp_net <- setNames(gdp_ppp[,tintersect,]*damageFactor[,tintersect,], "GDP|PPP|Net_afterDamages (billion US$2005/yr)")  
 
   ies                     <- readGDX(gdx, c("pm_ies", "p_ies"), format = "first_found")
   c_damage                <- readGDX(gdx, "cm_damage", "c_damage", format = "first_found", react = "silent")
@@ -346,7 +347,7 @@ reportMacroEconomy <- function(gdx, regionSubsetList = NULL,
 
 
   # define list of variables that will be exported:
-  varlist <- list(cons, gdp, gdp_ppp, gdp_net, invE, invM, pop, cap, inv, ces)#, damageFactor, welf) # ,curracc)
+  varlist <- list(cons, gdp, gdp_ppp, gdp_net, gdp_ppp_net, invE, invM, pop, cap, inv, ces)#, damageFactor, welf) # ,curracc)
   # use the same temporal resolution for all variables
   # calculate minimal temporal resolution
   tintersect <- Reduce(intersect, lapply(varlist, getYears))

--- a/R/reportMacroEconomy.R
+++ b/R/reportMacroEconomy.R
@@ -84,6 +84,10 @@ reportMacroEconomy <- function(gdx, regionSubsetList = NULL,
                                         format = "first_found"),
                        "Damage factor (1)")
 
+  # Calculate net GDP using the damage factors
+  tintersect <- intersect(getYears(gdp), getYears(damageFactor))
+  gdp_net <- setNames(gdp[,tintersect,]*damageFactor[,tintersect,], "GDP|MER|Net_afterDamages (billion US$2005/yr)")  
+
   ies                     <- readGDX(gdx, c("pm_ies", "p_ies"), format = "first_found")
   c_damage                <- readGDX(gdx, "cm_damage", "c_damage", format = "first_found", react = "silent")
   if (is.null(c_damage)) c_damage <- 0
@@ -342,7 +346,7 @@ reportMacroEconomy <- function(gdx, regionSubsetList = NULL,
 
 
   # define list of variables that will be exported:
-  varlist <- list(cons, gdp, gdp_ppp, invE, invM, pop, cap, inv, ces)#, damageFactor, welf) # ,curracc)
+  varlist <- list(cons, gdp, gdp_ppp, gdp_net, invE, invM, pop, cap, inv, ces)#, damageFactor, welf) # ,curracc)
   # use the same temporal resolution for all variables
   # calculate minimal temporal resolution
   tintersect <- Reduce(intersect, lapply(varlist, getYears))


### PR DESCRIPTION
Adds the calculation of net GDP, that is, GDP after damages, to the reporting. And fixes a bug in which the damage factors were aggregated incorrectly

The choice of name for the GDP variable may be contentious, please take a look @LaviniaBaumstark @fpiontek . What we currently report in `GDP|MER` (and `GDP|PPP`) is the gross GDP. In runs with damages set up, the net GDP is supposed to be that times `Damage factor`. I don't know if we want to change the name of such an important variable, so currently I just named the net GDP ones `GDP|MERNet_afterDamages` and `GDP|PPP|Net_afterDamages`. @fpiontek please see if you'd prefer a different name.

It also fixes the aggregation of the damage factor. Before, it was just aggregate in a sum with all the other variables. Now it's first aggregated as the mean between regions weighted by `GDP|MER`, and then added to `out`.


