### PR TITLE
Fix welfare reporting and dplyr buildLibrary issues

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '215117888'
+ValidationKey: '215380923'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.107.2
-Date: 2023-03-13
+Version: 1.107.3
+Date: 2023-04-04
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -264,8 +264,8 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
   # only retain combinations of vm_demFeSector subdimensions which are in entyFe2Sector and sector2emiMkt
   emi.map.fe <- data.frame(all_enty = getItems(pm_emifac.co2.fe, dim = "all_enty",  full = T),
                            all_enty1 = getItems(pm_emifac.co2.fe, dim = "all_enty1",  full = T)) %>%
-    left_join(entyFe2Sector, by = "all_enty1", multiple = "all") %>%
-    left_join(sector2emiMkt, by = "emi_sectors", multiple = "all") %>%
+    left_join(entyFe2Sector, by = "all_enty1", relationship = "many-to-many") %>%
+    left_join(sector2emiMkt, by = "emi_sectors", relationship = "many-to-many") %>%
     mutate(name = paste(all_enty, all_enty1, emi_sectors, all_emiMkt, sep = "."))
 
 

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -50,11 +50,11 @@ reportFE <- function(gdx, regionSubsetList = NULL,
   sector2emiMkt <- readGDX(gdx, "sector2emiMkt")
 
   demFemapping <- entyFe2Sector %>%
-    full_join(sector2emiMkt, by = 'emi_sectors', multiple = "all") %>%
+    full_join(sector2emiMkt, by = 'emi_sectors', relationship = "many-to-many") %>%
     # rename such that all_enty1 always signifies the FE carrier like in
     # vm_demFeSector
     rename(all_enty1 = all_enty) %>%
-    left_join(se2fe, by = 'all_enty1', multiple = "all") %>%
+    left_join(se2fe, by = 'all_enty1', relationship = "many-to-many") %>%
     select(-all_te)
 
   #sety <- readGDX(gdx,c("entySe","sety"),format="first_found")
@@ -1390,7 +1390,7 @@ reportFE <- function(gdx, regionSubsetList = NULL,
                         revalue.levels(encar = map.vars.nechem) %>%
                         left_join(df.fe_nechem,
                                   by = c("region", "period", "encar"),
-                                  multiple = "all") %>%
+                                  relationship = "many-to-many") %>%
                         mutate( Value_NonEn = ifelse(value >= value_subsectors, value_subsectors, value)) %>%
                         filter( SSP == "SSP2") %>%
                         # map to non-energy use variable names

--- a/R/reportMacroEconomy.R
+++ b/R/reportMacroEconomy.R
@@ -347,7 +347,7 @@ reportMacroEconomy <- function(gdx, regionSubsetList = NULL,
 
 
   # define list of variables that will be exported:
-  varlist <- list(cons, gdp, gdp_ppp, gdp_net, gdp_ppp_net, invE, invM, pop, cap, inv, ces)#, damageFactor, welf) # ,curracc)
+  varlist <- list(cons, gdp, gdp_ppp, gdp_net, gdp_ppp_net, invE, invM, pop, cap, inv, ces, welf)#, damageFactor) # ,curracc)
   # use the same temporal resolution for all variables
   # calculate minimal temporal resolution
   tintersect <- Reduce(intersect, lapply(varlist, getYears))

--- a/R/reportPrices.R
+++ b/R/reportPrices.R
@@ -143,7 +143,7 @@ reportPrices <- function(gdx, output=NULL, regionSubsetList=NULL,
 
   sector <- emi_sectors <- emiMkt <- all_emiMkt <- NULL
   fe.entries <- entyFe2Sector %>%
-                  left_join(sector2emiMkt, by = "emi_sectors", multiple = "all") %>%
+                  left_join(sector2emiMkt, by = "emi_sectors", relationship = "many-to-many") %>%
                   rename( sector = emi_sectors, emiMkt = all_emiMkt) %>%
                   filter( sector != "CDR")
 
@@ -310,8 +310,8 @@ reportPrices <- function(gdx, output=NULL, regionSubsetList=NULL,
     all_enty <- all_enty1 <- NULL
     se.fe.sector.emiMkt <- se2fe[,-3] %>% #remove te dimension
       rename(se = all_enty, fe = all_enty1) %>% # rename dimensions
-      left_join(entyFe2Sector %>% rename(fe = all_enty, sector = emi_sectors), by = "fe", multiple = "all") %>% # adding sectors column
-      left_join(sector2emiMkt %>% rename(emiMkt = all_emiMkt, sector = emi_sectors), by = "sector", multiple = "all") # adding emiMkt column
+      left_join(entyFe2Sector %>% rename(fe = all_enty, sector = emi_sectors), by = "fe", relationship = "many-to-many") %>% # adding sectors column
+      left_join(sector2emiMkt %>% rename(emiMkt = all_emiMkt, sector = emi_sectors), by = "sector", relationship = "many-to-many") # adding emiMkt column
 
     pm_FEPrice_by_SE_Sector_EmiMkt <- pm_FEPrice_by_SE_Sector_EmiMkt[,YearsFrom2005,unique(paste(se.fe.sector.emiMkt$se,se.fe.sector.emiMkt$fe,se.fe.sector.emiMkt$sector,se.fe.sector.emiMkt$emiMkt,sep="."))]*tdptwyr2dpgj
     pm_FEPrice_by_Sector_EmiMkt    <-    pm_FEPrice_by_Sector_EmiMkt[,YearsFrom2005,unique(paste(                       se.fe.sector.emiMkt$fe,se.fe.sector.emiMkt$sector,se.fe.sector.emiMkt$emiMkt,sep="."))]*tdptwyr2dpgj

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.107.2**
+R package **remind2**, version **1.107.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.107.2, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.107.3, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort},
   year = {2023},
-  note = {R package version 1.107.2},
+  note = {R package version 1.107.3},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
Fixes a bug that was preventing the reporting of welfare variables and could crash the mif generation altogether.

Also addresses [the dplyr problem that generates warnings](https://github.com/pik-piam/piamInterfaces/pull/103/commits/f9224b3556f75df7107bf97c6259e7c73d57037c) about many-to-many joins and was making the tests fail. This was done by replacing all instances of `multiple = "all"` on `left_join` calls to `relationship = "many-to-many"`.