### PR TITLE
require dplyr 1.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Imports:
     abind,
     assertr,
     data.table,
-    dplyr,
+    dplyr (>= 1.1.1),
     gdx (>= 1.29),
     gdxdt,
     gdxrrw,


### PR DESCRIPTION
Avoid fails because if old dplyr version is used with https://github.com/pik-piam/remind2/pull/393