### PR TITLE
allow to fill empty cells with default values in colorScenConf + compareScenConf

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '215441975'
+ValidationKey: '215527884'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.107.5
-date-released: '2023-04-06'
+version: 1.107.6
+date-released: '2023-04-12'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.107.5
-Date: 2023-04-06
+Version: 1.107.6
+Date: 2023-04-12
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/colorScenConf.R
+++ b/R/colorScenConf.R
@@ -23,14 +23,14 @@ colorScenConf <- function(fileList = "", remindPath = ".", expanddata = FALSE) {
     remindPath <- normalizePath(file.path(remindPath, ".."))
   }
   cfg <- gms::readDefaultConfig(remindPath)
-  readCheckScenarioConfig <- function(csvFile, fillWithDefault = FALSE) {
+  readCheckScenarioConfig <- function(csvFile, ...) {
     return(read.csv2(csvFile, stringsAsFactors = FALSE, row.names = 1,
                             comment.char = "", na.strings = "", dec = "."))
   }
   if (expanddata) {
-    source(file.path(remindPath, "scripts", "start", "path_gdx_list.R"))
+    source(file.path(remindPath, "scripts", "start", "path_gdx_list.R"), local = TRUE)
     # overwrite readCheckScenarioConfig
-    source(file.path(remindPath, "scripts", "start", "readCheckScenarioConfig.R"))
+    source(file.path(remindPath, "scripts", "start", "readCheckScenarioConfig.R"), local = TRUE)
   }
   # enable script to match default data not in gms
   try(cfg$gms[["output"]] <- paste0(cfg$output, collapse = ","))
@@ -58,7 +58,7 @@ colorScenConf <- function(fileList = "", remindPath = ".", expanddata = FALSE) {
   for (csvFile in fileList) {
     xlsxFile <- sub(".csv", "_colorful.xlsx", csvFile, fixed = TRUE)
     cat(paste0("\nStart converting '", csvFile, "' to '..._colorful.xlsx'.\n"))
-    settings <- readCheckScenarioConfig(csvFile, fillWithDefault = TRUE)
+    settings <- readCheckScenarioConfig(csvFile, remindPath = remindPath, fillWithDefault = TRUE)
     settings <- rbind(rep("unknown", length(names(settings))), settings)
     for (switchname in intersect(names(cfg$gms), names(settings))) {
       settings[1, switchname] <- cfg$gms[[switchname]]

--- a/R/compareScenConf.R
+++ b/R/compareScenConf.R
@@ -42,7 +42,7 @@ compareScenConf <- function(fileList = "", remindPath = ".", row.names = 1,
     fileList <- fileList[identifier]
   }
   if (! is.null(remindPath) && ! file.exists(file.path(remindPath, "main.gms"))) {
-    if(dir.exists("..") && file.exists("../main.gms")) {
+    if (dir.exists("..") && file.exists("../main.gms")) {
       remindPath <- normalizePath("..")
     } else {
       remindPath <- NULL
@@ -61,10 +61,18 @@ compareScenConf <- function(fileList = "", remindPath = ".", row.names = 1,
     try(cfg$gms[["inputRevision"]] <- cfg$inputRevision)
   }
 
-  settings1 <- read.csv2(fileList[[1]], stringsAsFactors = FALSE, row.names = row.names,
-                         comment.char = "#", na.strings = "", dec = ".")
-  settings2 <- read.csv2(fileList[[2]], stringsAsFactors = FALSE, row.names = row.names,
-                         comment.char = "#", na.strings = "", dec = ".")
+  readCheckScenarioConfig <- function(csvFile, ...) {
+    return(read.csv2(csvFile, stringsAsFactors = FALSE, row.names = row.names,
+                            comment.char = "#", na.strings = "", dec = "."))
+  }
+  if (expanddata) {
+    message("Loading path_gdx_list and readCheckScenarioConfig")
+    source(file.path(remindPath, "scripts", "start", "path_gdx_list.R"), local = TRUE)
+    # overwrite readCheckScenarioConfig
+    source(file.path(remindPath, "scripts", "start", "readCheckScenarioConfig.R"), local = TRUE)
+  }
+  settings1 <- readCheckScenarioConfig(fileList[[1]], remindPath = remindPath, fillWithDefault = TRUE)
+  settings2 <- readCheckScenarioConfig(fileList[[2]], remindPath = remindPath, fillWithDefault = TRUE)
 
   # for mapping files
   if (is.null(row.names)) {
@@ -112,7 +120,7 @@ compareScenConf <- function(fileList = "", remindPath = ".", row.names = 1,
     }
   }
   if (printit) {
-    message(paste0(m, collapse = "\n"), "\n");
+    message(paste0(m, collapse = "\n"), "\n")
     if (length(allwarnings) > 0) warning(paste0(allwarnings, collapse = "\n"), "\n")
     return(list(allwarnings = allwarnings))
   } else {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.107.5**
+R package **remind2**, version **1.107.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.107.5, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.107.6, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort},
   year = {2023},
-  note = {R package version 1.107.5},
+  note = {R package version 1.107.6},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/tests/testthat/test-compareScenConf.R
+++ b/tests/testthat/test-compareScenConf.R
@@ -25,12 +25,13 @@ test_that("Check compareScenConf", {
                        row.names = "title")
   write.csv2(csv3df, file3)
   # normal case: should go through without a warning
-  test1 <- compareScenConf(fileList = c(file1, file2), printit = FALSE)
+  test1 <- compareScenConf(fileList = c(file1, file2), printit = FALSE, expanddata = FALSE)
   expect_true(is.null(test1$allwarnings))
   expect_true(sum(grepl("description: was changed", test1$out)) == 3)
   # check renamed column start -> startnew
   test2 <- compareScenConf(fileList = c(file1, file3), renamedCols = c(start = "startnew"),
-                           renamedRows = c("SSP5-Base" = "SSP6-Base", "SSP5-Base" = "SSP7-Base"), printit = FALSE)
+                           renamedRows = c("SSP5-Base" = "SSP6-Base", "SSP5-Base" = "SSP7-Base"), printit = FALSE,
+                           expanddata = FALSE)
   expect_true(is.null(test2$allwarnings))
   expect_true(any(grepl("Renamed columns:.*start -> startnew", test2$out)))
   expect_true(any(grepl("Renamed rows:.*SSP5-Base -> SSP6-Base", test2$out)))
@@ -38,7 +39,7 @@ test_that("Check compareScenConf", {
   # check renamed column and row where this didn't happen
   test3 <- suppressWarnings(compareScenConf(fileList = c(file1, file2), renamedCols = c(start = "startnew"),
                                             renamedRows = c("SSP5-Base" = "SSP6-Base"), printit = FALSE,
-                                            remindPath <- tempdir()))
+                                            remindPath <- tempdir(), expanddata = FALSE))
   expect_true(all(c("oldColAlsoIn2", "newColNotIn2", "newRowNotIn2") %in% names(test3$allwarnings)) &
               ! any(c("oldColNotIn1", "newColAlsoIn1", "newRowNotIn1", "newRowAlsoIn1") %in% names(test3$allwarnings)))
   expect_true(any(grepl("Columns deleted:.*startnew", test3$out)))
@@ -46,7 +47,7 @@ test_that("Check compareScenConf", {
   # check renamed column and row where old files doesn't contain them
   test4 <- suppressWarnings(compareScenConf(fileList = c(file1, file2), renamedCols = c(startwrong = "start"),
                                             renamedRows = c("SSP9-Base" = "SSP5-Base"), printit = FALSE,
-                                            remindPath = NULL))
+                                            remindPath = NULL, expanddata = FALSE))
   expect_true(all(c("oldColNotIn1", "newColAlsoIn1", "newRowNotIn1", "newRowAlsoIn1") %in% names(test4$allwarnings)) &
               ! any(c("oldColAlsoIn2", "newColNotIn2", "newRowNotIn2") %in% names(test4$allwarnings)))
   unlink(c(file1, file2, file3, fileconfig, filemain))


### PR DESCRIPTION
- use `readCheckScenarioConfig` from remindmodel for `colorScenConf` and `compareScenConf` to be consistent
- bugfix that it was loaded into the global, not the local namespace
- make sure tests don't try that because they don't have a remind folder at hand

Maybe, @fbenke-pik, you can have a look? It is not clear to me who at RSE is currently responsible for what, so feel free to pass the burden :) Would have been a classical Mika job last month :(