### PR TITLE
fix Moving Avg Prices such that periods < cm_startyear are identical to ref run

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '215655426'
+ValidationKey: '215741367'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.107.8
-date-released: '2023-04-20'
+version: 1.107.9
+date-released: '2023-04-26'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.107.8
-Date: 2023-04-20
+Version: 1.107.9
+Date: 2023-04-26
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/convGDX2MIF.R
+++ b/R/convGDX2MIF.R
@@ -68,7 +68,7 @@ convGDX2MIF <- function(gdx, gdx_ref = NULL, file = NULL, scenario = "default",
   message("running reportTechnology...")
   output <- mbind(output,reportTechnology(gdx,output,regionSubsetList,t)[,t,])    # needs output from reportSE
   message("running reportPrices...")
-  output <- mbind(output,reportPrices(gdx,output,regionSubsetList,t)[,t,]) # needs output from reportSE, reportFE, reportEmi, reportExtraction, reportMacroEconomy
+  output <- mbind(output,reportPrices(gdx,output,regionSubsetList,t,gdx_ref = gdx_ref)[,t,]) # needs output from reportSE, reportFE, reportEmi, reportExtraction, reportMacroEconomy
   message("running reportCosts...")
   output <- mbind(output,reportCosts(gdx,output,regionSubsetList,t)[,t,])  # needs output from reportEnergyInvestment, reportPrices, reportEnergyInvestments
   message("running reportTax...")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.107.8**
+R package **remind2**, version **1.107.9**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.107.8, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.107.9, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort},
   year = {2023},
-  note = {R package version 1.107.8},
+  note = {R package version 1.107.9},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/man/reportPrices.Rd
+++ b/man/reportPrices.Rd
@@ -8,7 +8,8 @@ reportPrices(
   gdx,
   output = NULL,
   regionSubsetList = NULL,
-  t = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150)
+  t = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150),
+  gdx_ref = NULL
 )
 }
 \arguments{
@@ -22,6 +23,9 @@ be created.}
 
 \item{t}{temporal resolution of the reporting, default:
 t=c(seq(2005,2060,5),seq(2070,2110,10),2130,2150)}
+
+\item{gdx_ref}{a GDX object as created by readGDX, or the path to a gdx of the reference run.
+It is used to guarantee consistency for Moving Avg prices before cm_startyear}
 }
 \value{
 MAgPIE object - contains the price variables


### PR DESCRIPTION
- Let a run have `cm_startyear = 2025`. Then, the `Price|*|Moving Avg` values that are used in [the AR6 mapping](https://github.com/pik-piam/piamInterfaces/blob/master/inst/templates/mapping_template_AR6.csv#L209) for 2020 are `p_average(2020) = (p(2015) + 2p(2020) + p(2025))/4` as calculated in [`remind2::reportPrices()`](https://github.com/pik-piam/remind2/blob/master/R/reportPrices.R#L672) by using [`magclass::lowpass()`](https://github.com/pik-piam/magclass/blob/master/R/lowpass.R). And as the 2025 prices differ between the scenarios, so does the reported 2020 price, which it should not.
- See discussion [here](https://mattermost.pik-potsdam.de/rd3/pl/wwnm331yntduzfg8q5za55x3ca).
- Now, `reportPrices` gets an optional dependency on `gdx_ref` as well, calculates the moving averages for the reference run and uses them for t <- cm_startyear.
- Maybe @fbenke-pik and @0UmfHxcvx5J7JoaOhFSs5mncnisTJJ6q can have a look whether that makes sense
- Also, I wonder whether there are other places where we have to call `reportPrices` with the `gdx_ref`: I will figure out with @dklein-pik whether convGDX2MIF_REMIND2MAgPIE() as called [in the REMIND reporting](https://github.com/remindmodel/remind/blob/8d3099374865ac88daa02905c7a942f0b805a8d1/scripts/output/single/reporting.R#L47) should also get that added. Not sure whether MAgPIE uses these averages prices…