### PR TITLE
use explicit gdx_refprices in convGDX2MIF, ignore LDV variables with NA unit

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,10 +1,9 @@
-ValidationKey: '216742277'
+ValidationKey: '216772896'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'
 - .*qpdf.* is needed for checks on size reduction of PDFs
 - .*following variables are expected in the piamInterfaces.*
-- These variables and units contain NA
 AcceptedNotes:
 - Imports includes .* non-default packages.
 - unable to verify current time

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.111.1
-date-released: '2023-05-30'
+version: 1.111.2
+date-released: '2023-05-31'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.111.1
-Date: 2023-05-30
+Version: 1.111.2
+Date: 2023-05-31
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/convGDX2MIF.R
+++ b/R/convGDX2MIF.R
@@ -12,6 +12,7 @@
 #' @param scenario scenario name that is used in the *.mif reporting
 #' @param t temporal resolution of the reporting, default:
 #' t=c(seq(2005,2060,5),seq(2070,2110,10),2130,2150)
+#' @param gdx_refprices reference-gdx for < cm_startyear, used for fixing the prices to this scenario
 #' @author Lavinia Baumstark
 #' @examples
 #'
@@ -22,9 +23,10 @@
 #' @importFrom magclass mbind write.report
 
 convGDX2MIF <- function(gdx, gdx_ref = NULL, file = NULL, scenario = "default",
-                        t = c(seq(2005, 2060, 5), seq(2070, 2110, 10),
-                              2130, 2150)) {
-   # Define region subsets
+                        t = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150),
+                        gdx_refprices = NULL) {
+
+  # Define region subsets
   regionSubsetList <- toolRegionSubsets(gdx)
   # ADD EU-27 region aggregation if possible
   if("EUR" %in% names(regionSubsetList)){
@@ -68,7 +70,7 @@ convGDX2MIF <- function(gdx, gdx_ref = NULL, file = NULL, scenario = "default",
   message("running reportTechnology...")
   output <- mbind(output,reportTechnology(gdx,output,regionSubsetList,t)[,t,])    # needs output from reportSE
   message("running reportPrices...")
-  output <- mbind(output,reportPrices(gdx,output,regionSubsetList,t,gdx_ref = gdx_ref)[,t,]) # needs output from reportSE, reportFE, reportEmi, reportExtraction, reportMacroEconomy
+  output <- mbind(output,reportPrices(gdx,output,regionSubsetList,t,gdx_ref = gdx_refprices)[,t,]) # needs output from reportSE, reportFE, reportEmi, reportExtraction, reportMacroEconomy
   message("running reportCosts...")
   output <- mbind(output,reportCosts(gdx,output,regionSubsetList,t)[,t,])  # needs output from reportEnergyInvestment, reportPrices, reportEnergyInvestments
   message("running reportTax...")

--- a/R/reportPrices.R
+++ b/R/reportPrices.R
@@ -691,6 +691,7 @@ reportPrices <- function(gdx, output=NULL, regionSubsetList=NULL,
   out.reporting <- pmax(out, 0) # avoid negative prices
 
   # for cm_startyear and non-SSP2, replace price by average of period before and after
+  # this is a workaround to avoid spikes caused by https://github.com/remindmodel/remind/issues/1068
   if (! grepl("gdp_SSP2", readGDX(gdx, "cm_GDPscen", format = "simplest"))
       && cm_startyear > min(getYears(out, as.integer = TRUE))) {
     out.reporting[, cm_startyear, ] <- 0.5 * (out[, cm_startyear - 5, ] + out[, cm_startyear + 5, ])
@@ -919,11 +920,11 @@ reportPrices <- function(gdx, output=NULL, regionSubsetList=NULL,
                )
 
 
-  ## weights definition for FE prices region aggregation
+  ## add weights definition for region aggregation for FE prices that were added automatically
   if(length(pm_FEPrice_by_FE) > 0) {
-    margPriceVars <- getItems(out,3)[grep("Price|Final Energy|", getItems(out,3), fixed = TRUE)]
+    margPriceVars <- grep("Price|Final Energy|", getItems(out,3), fixed = TRUE, value = TRUE)
     margPriceVars <- setdiff(margPriceVars, names(int2ext))
-    vars <- gsub("US\\$2005/GJ","EJ/yr",gsub("Price\\|Final Energy\\|","FE|",margPriceVars))
+    vars <- gsub("US\\$2005/GJ", "EJ/yr", gsub("Price\\|Final Energy\\|","FE|",margPriceVars))
     names(vars) <- margPriceVars
     vars <- gsub("Efuel","Hydrogen",vars) ###warning FE variable should be renamed and this line should be removed in the future
     # for(var in vars){ # display price variables with no matching FE weight

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.111.1**
+R package **remind2**, version **1.111.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.111.1, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.111.2, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort},
   year = {2023},
-  note = {R package version 1.111.1},
+  note = {R package version 1.111.2},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/man/convGDX2MIF.Rd
+++ b/man/convGDX2MIF.Rd
@@ -9,7 +9,8 @@ convGDX2MIF(
   gdx_ref = NULL,
   file = NULL,
   scenario = "default",
-  t = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150)
+  t = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150),
+  gdx_refprices = NULL
 )
 }
 \arguments{
@@ -25,6 +26,8 @@ returned}
 
 \item{t}{temporal resolution of the reporting, default:
 t=c(seq(2005,2060,5),seq(2070,2110,10),2130,2150)}
+
+\item{gdx_refprices}{reference-gdx for < cm_startyear, used for fixing the prices to this scenario}
 }
 \description{
 Read in all information from GDX file and create

--- a/tests/testthat/test-convGDX2mif.R
+++ b/tests/testthat/test-convGDX2mif.R
@@ -42,6 +42,7 @@ checkIntegrity <- function(out, gdxPath = NULL) {
     warning("These variable names have wrong bars and spaces: ", paste(barspace, collapse = ", "))
   }
   NAvar <- grep("[\\|\\( ]NA[\\|\\) ]|^NA", unique(dt[["variable"]]), value = TRUE)
+  NAvar <- NAvar[! grepl("^Services and Products\\|Transport\\|non-LDV\\|S", NAvar)] # unit NA, but ok, see issue #408
   if (length(NAvar) > 0) {
     warning("These variables and units contain NA: ", paste(NAvar, collapse = ", "))
   }


### PR DESCRIPTION
- needs adaptation in remind such that the gdx_refprices is passed to convGDX2MIF.
- I was a bit unsure whether to rename `gdx_ref` to `gdx_refpolicycosts`  in order to be consistent, but I'm a bit afraid of breaking stuff… @LaviniaBaumstark / @Renato-Rodrigues, would you prefer that?
- accept `NA` in some LDV units (see #408), as suggested by @robertpietzcker
- improve explanations in reportPrices
- 