### PR TITLE
make sure cs2 shows FE prices with reporting versions before Rawdata PR

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '217006800'
+ValidationKey: '217193130'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.3.2.9007
+    rev: v0.3.2.9013
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.112.0
-date-released: '2023-06-07'
+version: 1.112.1
+date-released: '2023-06-22'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.112.0
-Date: 2023-06-07
+Version: 1.112.1
+Date: 2023-06-22
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,9 @@ HELP_PARSING = 'm <- readLines("Makefile");\
 help:           ## Show this help.
 	@Rscript -e $(HELP_PARSING)
 
-build:          ## Build the package using lucode2::buildLibrary().
-	Rscript -e 'lucode2::buildLibrary()'
+build:          ## Build the package using lucode2::buildLibrary(). You can pass the
+                ## updateType with 'make build u=3'
+	Rscript -e 'lucode2::buildLibrary(updateType = "$(u)")'
 
 check:          ## Build documentation and vignettes, run testthat tests,
                 ## and check if code etiquette is followed using lucode2::check().

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.112.0**
+R package **remind2**, version **1.112.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.112.0, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.112.1, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort},
   year = {2023},
-  note = {R package version 1.112.0},
+  note = {R package version 1.112.1},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/inst/markdown/compareScenarios2/cs2_02_macro.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_02_macro.Rmd
@@ -126,20 +126,25 @@ showAreaAndBarPlots(data, items, tot, scales = "fixed")
 
 ```{r Prices preprocessing}
 # Local (this subsection) preprocessing for all price variables.
-dPrice <-
+dAllPrices <-
   data %>%
     filter(scenario != "historical") %>%
     filter(str_starts(variable, "Price")) %>%
     filter(period >= 2010) %>% # 2005 values are invalid
     droplevels()
 
-# instead of post-processing variables, use Rawdata if available
-rawdata <- grep("\\|Rawdata$", levels(dPrice$variable), value = TRUE)
-dPrice <-
-  dPrice %>%
-    filter(! variable %in% gsub("\\|Rawdata$", "", rawdata)) %>%
-    mutate(variable = gsub("\\|Rawdata$", "", variable)) %>%
-    droplevels()
+# instead of post-processing variables, use Rawdata if available in each scenario
+dPrice <- NULL
+for (s in levels(dAllPrices$scenario)) {
+  rawdata <- grep("\\|Rawdata$", levels(filter(dAllPrices, .data$scenario == s)$variable), value = TRUE)
+  dPricescen <-
+    dAllPrices %>%
+      filter(.data$scenario == s) %>%
+      filter(! variable %in% gsub("\\|Rawdata$", "", rawdata)) %>%
+      mutate(variable = factor(gsub("\\|Rawdata$", "", variable))) %>%
+      droplevels()
+  dPrice <- rbind(dPrice, dPricescen)
+}
 ```
 
 ### PE Prices


### PR DESCRIPTION
- the old script dropped too many variables if called with old reporting versions before https://github.com/pik-piam/remind2/pull/402, and particularly messed up everything if the scenarios were done with different reportings. Therefore, do the selection per scenario.