### PR TITLE
Update reporting after refactoring the CDR module (portfolio)

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '217728081'
+ValidationKey: '217876120'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.113.3
-date-released: '2023-07-19'
+version: 1.114.0
+date-released: '2023-07-20'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.113.3
-Date: 2023-07-19
+Version: 1.114.0
+Date: 2023-07-20
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportCosts.R
+++ b/R/reportCosts.R
@@ -102,7 +102,6 @@ reportCosts <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,
   v_costom         <- readGDX(gdx,name=c("v_costOM","v_costom"),         field="l",                    format="first_found")
   v_costin         <- readGDX(gdx,name=c("v_costInv","v_costin"),         field = "l",format = "first_found")
   vm_omcosts_cdr   <- readGDX(gdx,name=c("vm_omcosts_cdr"),   field="l",                  format="first_found")
-  vm_otherFEdemand <- readGDX(gdx,name=c("vm_otherFEdemand"), field="l",restore_zeros=FALSE,format="first_found")
   v_investcost     <- readGDX(gdx,name=c("vm_costTeCapital","v_costTeCapital","v_investcost"),     field="l",format="first_found")
   vm_cap           <- readGDX(gdx,name=c("vm_cap"),           field="l",format="first_found")
   vm_cap[is.na(vm_cap)]    <- 0
@@ -110,8 +109,14 @@ reportCosts <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,
   vm_prodFe        <- readGDX(gdx,name=c("vm_prodFe"),        field="l",restore_zeros=FALSE,format="first_found")
   cost_emu         <- readGDX(gdx,name=c("v30_pebiolc_costs"),field="l",format="first_found")
   bio_cost_adjfac  <- readGDX(gdx,name=c("v30_multcost"),field="l",format="first_found")
-  vm_cesIO         <- readGDX(gdx, name = c('vm_cesIO'), field = 'l', 
+  vm_cesIO         <- readGDX(gdx, name = c('vm_cesIO'), field = 'l',
                               restore_zeros = FALSE)
+
+  v33_FEdemand     <- readGDX(gdx, name=c("v33_FEdemand"), field="l", restore_zeros=FALSE, format="first_found", react="silent")
+  CDR_FEdemand     <- dimSums(v33_FEdemand, dim=c(3.2, 3.3))
+  if (is.null(v33_FEdemand)) { # compatibility with the CDR module before the portfolio was added
+    CDR_FEdemand <- readGDX(gdx, name=c("vm_otherFEdemand"), field="l", restore_zeros=FALSE, format="first_found")
+  }
   
   # Equations
   finenbal     <- readGDX(gdx,name=c("fe2ppfEn","finenbal"),  types="sets",format="first_found")
@@ -155,7 +160,7 @@ reportCosts <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,
   v_costfu         <- v_costfu[,y,]
   v_costom         <- v_costom[,y,]
   v_costin         <- v_costin[,y,]
-  vm_otherFEdemand <- vm_otherFEdemand[,y,]
+  CDR_FEdemand     <- CDR_FEdemand[,y,]
   v_investcost     <- v_investcost[,y,]
   vm_cap           <- vm_cap[,y,]       
   vm_prodSe        <- vm_prodSe[,y,]
@@ -415,15 +420,15 @@ reportCosts <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,
   
   price_fedie <- abs(febalForUe.m[,,"fedie"]/(budget.m+1e-10)) * 1000 / pm_conv_TWa_EJ # "Price|Final Energy|Diesel (US$2005/GJ)")
   
-  tmp  <- mbind(tmp,setNames(price_feeli * vm_otherFEdemand[,,"feels"] * pm_conv_TWa_EJ , "Energy costs CDR|Electricity (billion US$2005/yr)"))   
-  tmp  <- mbind(tmp,setNames(price_fedie * vm_otherFEdemand[,,"fedie"] * pm_conv_TWa_EJ, "Energy costs CDR|Diesel (billion US$2005/yr)"))
-  tmp  <- mbind(tmp,setNames(price_fegai * vm_otherFEdemand[,,"fegas"] * pm_conv_TWa_EJ + 
-                               price_feh2i * vm_otherFEdemand[,,"feh2s"] * pm_conv_TWa_EJ, "Energy costs CDR|Heat (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(price_feeli * CDR_FEdemand[,,"feels"] * pm_conv_TWa_EJ , "Energy costs CDR|Electricity (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(price_fedie * CDR_FEdemand[,,"fedie"] * pm_conv_TWa_EJ, "Energy costs CDR|Diesel (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(price_fegai * CDR_FEdemand[,,"fegas"] * pm_conv_TWa_EJ +
+                               price_feh2i * CDR_FEdemand[,,"feh2s"] * pm_conv_TWa_EJ, "Energy costs CDR|Heat (billion US$2005/yr)"))
   
-  tmp  <- mbind(tmp,setNames(price_feeli * vm_otherFEdemand[,,"feels"] * pm_conv_TWa_EJ +
-                               price_fedie * vm_otherFEdemand[,,"fedie"] * pm_conv_TWa_EJ +
-                               price_fegai * vm_otherFEdemand[,,"fegas"] * pm_conv_TWa_EJ +
-                               price_feh2i * vm_otherFEdemand[,,"feh2s"] * pm_conv_TWa_EJ,
+  tmp  <- mbind(tmp,setNames(price_feeli * CDR_FEdemand[,,"feels"] * pm_conv_TWa_EJ +
+                               price_fedie * CDR_FEdemand[,,"fedie"] * pm_conv_TWa_EJ +
+                               price_fegai * CDR_FEdemand[,,"fegas"] * pm_conv_TWa_EJ +
+                               price_feh2i * CDR_FEdemand[,,"feh2s"] * pm_conv_TWa_EJ,
                              "Energy costs CDR (billion US$2005/yr)"))
 
   #######################################

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -152,15 +152,23 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
   ### Carbon management variables
   # total captured CO2
   vm_co2capture <- readGDX(gdx, "vm_co2capture", field = "l", restore_zeros = F)[, t, ]
-  # captured CO2 by DAC
-  v33_emiDAC <- readGDX(gdx, "v33_emiDAC", field = "l", restore_zeros = F, react = "silent")[, t, ]
-  if (is.null(v33_emiDAC)) {
-    v33_emiDAC <- new.magpie(getItems(vm_co2capture, "all_regi"), getItems(vm_co2capture, "ttot"), fill = 0)
-  }
-  # captured CO2 by Enhanced Weathering
-  v33_emiEW <- readGDX(gdx, "v33_emiEW", field = "l", restore_zeros = F, react = "silent")[, t, ]
-  if (is.null(v33_emiEW)) {
-    v33_emiEW <- new.magpie(getItems(vm_co2capture, "all_regi"), getItems(vm_co2capture, "ttot"), fill = 0)
+
+  v33_emi <- readGDX(gdx, "v33_emi", field = "l", restore_zeros = F, react = "silent")[, t, ]
+
+  if (is.null(v33_emi)) { # compatibility with the CDR module before the portfolio was added
+    # captured CO2 by DAC
+    v33_emiDAC <- readGDX(gdx, "v33_emiDAC", field = "l", restore_zeros = F, react = "silent")[, t, ]
+    if (is.null(v33_emiDAC)) {
+      v33_emiDAC <- new.magpie(getItems(vm_co2capture, "all_regi"), getItems(vm_co2capture, "ttot"), fill = 0)
+    }
+    # captured CO2 by Enhanced Weathering
+    v33_emiEW <- readGDX(gdx, "v33_emiEW", field = "l", restore_zeros = F, react = "silent")[, t, ]
+    if (is.null(v33_emiEW)) {
+      v33_emiEW <- new.magpie(getItems(vm_co2capture, "all_regi"), getItems(vm_co2capture, "ttot"), fill = 0)
+    }
+    # variable used in the rest of the reporting
+    v33_emi <- mbind(v33_emiDAC, v33_emiEW)
+    v33_emi <- setNames(v33_emi, c("dac", "weathering"))
   }
   # stored CO2
   vm_co2CCS <- readGDX(gdx, "vm_co2CCS", field = "l", restore_zeros = F)[, t, ]
@@ -810,7 +818,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
                  # vm_emiTeMkt is variable in REMIND closest to energy co2 emissions
                  (dimSums(sel_vm_emiTeMkt_co2, dim = 3)
                   # subtract non-BECCS CCU CO2 (i.e., non-CCS part of DAC)
-                  - (1 - p_share_CCS) * (-v33_emiDAC)
+                  - (1 - p_share_CCS) * (-v33_emi[, , "dac"])
                   # deduce co2 captured by industrial processes which is not stored but used for CCU
                   # -> gets accounted in industrial process emissions
                   - vm_emiIndCCS[, , "co2cement_process"]*(1-p_share_CCS)) * GtC_2_MtCO2,
@@ -846,7 +854,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
                  setNames(dimSums(vm_emiMacSector[, , "co2luc"], dim = 3) * GtC_2_MtCO2,
                           "Emi|CO2|+|Land-Use Change (Mt CO2/yr)"),
                  # negative emissions from (non-BECCS) CDR (DACCS, EW)
-                 setNames((v33_emiEW + v33_emiDAC * p_share_CCS) * GtC_2_MtCO2,
+                 setNames((v33_emi[, , "weathering"] + v33_emi[, , "dac"] * p_share_CCS) * GtC_2_MtCO2,
                           "Emi|CO2|+|non-BECCS CDR (Mt CO2/yr)")
     )
 
@@ -872,7 +880,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
                  setNames(dimSums(vm_emiMacSector[, , "co2luc"], dim = 3) * GtC_2_MtCO2,
                           "Emi|CO2|+|Land-Use Change (Mt CO2/yr)"),
                  # negative emissions from (non-BECCS) CDR (DACCS, EW)
-                 setNames((v33_emiEW + v33_emiDAC * p_share_CCS) * GtC_2_MtCO2,
+                 setNames((v33_emi[, , "weathering"] + v33_emi[, , "dac"] * p_share_CCS) * GtC_2_MtCO2,
                           "Emi|CO2|+|non-BECCS CDR (Mt CO2/yr)")
     )
 
@@ -1057,7 +1065,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
                setNames(dimSums(vm_emiIndCCS[, , "co2cement_process"], dim = 3) * GtC_2_MtCO2,
                           "Carbon Management|Carbon Capture|Industry Process|+|Cement (Mt CO2/yr)"),
                # total co2 captured by DAC
-               setNames(-v33_emiDAC * GtC_2_MtCO2,
+               setNames(-v33_emi[, , "dac"] * GtC_2_MtCO2,
                           "Carbon Management|Carbon Capture|+|DAC (Mt CO2/yr)"),
                # total co2 captured
                setNames(vm_co2capture * GtC_2_MtCO2,
@@ -1358,7 +1366,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
                         "Emi|CO2|CDR|DACCS (Mt CO2/yr)"),
                # total EW
                # total co2 captured by EW
-               setNames(v33_emiEW * GtC_2_MtCO2,
+               setNames(v33_emi[, , "weathering"] * GtC_2_MtCO2,
                         "Emi|CO2|CDR|EW (Mt CO2/yr)"))
 
   out <- mbind(out,
@@ -1454,9 +1462,6 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
                setNames(out[, , "Emi|CO2|Gross|Energy|+|Supply (Mt CO2/yr)"]
                         - out[, , "Emi|CO2|Gross|Energy|Supply|+|Electricity (Mt CO2/yr)"],
                         "Emi|CO2|Gross|Energy|Supply|Non-electric (Mt CO2/yr)"))
-
-
-
 
 
   ## 5. Non-CO2 GHG Emissions ----
@@ -1966,7 +1971,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
                  # CDR energy-related emissions
                  (dimSums(mselect(EmiFeCarrier[, , "ETS"], emi_sectors = "CDR"), dim = 3)
                   # Captured CO2 by non-BECCS capture technologies
-                  + (v33_emiEW + v33_emiDAC * p_share_CCS)) * GtC_2_MtCO2,
+                  + (v33_emi[, , "weathering"] + v33_emi[, , "dac"] * p_share_CCS)) * GtC_2_MtCO2,
                  "Emi|GHG|ETS|+|non-BECCS CDR (Mt CO2eq/yr)"),
 
                # Extraction

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -1258,7 +1258,29 @@ reportFE <- function(gdx, regionSubsetList = NULL,
 
   #--- CDR ---
 
-  if(cdr_mod != "off"){
+  if(cdr_mod == "portfolio") {
+    v33_FEdemand  <- readGDX(gdx, name=c("v33_FEdemand"), field="l", restore_zeros=F)[,t,] * TWa_2_EJ
+    # KK: Mappings from gams set names to names in mifs. If new CDR methods are added to REMIND, please add
+    # the method to CDR_te_list: "<method name in REMIND>"="<method name displayed in reporting>"
+    # If a final energy carrier not included in CDR_FE_list is used, please also add it to the list.
+    CDR_te_list <- list("dac"="DAC", "weathering"="EW")
+    CDR_FE_list <- list("feels"="Electricity", "fegas"="Gases", "fehes"="Heat", "feh2s"="Hydrogen", "fedie"="Diesel")
+
+    # loop to compute variables "FE|CDR|++|<CDR technology> (EJ/yr)" and "FE|CDR|<CDR technology>|+|<FE type> (EJ/yr)",
+    # e.g., "FE|CDR|++|DAC (EJ/yr)" and "FE|CDR|DAC|+|Electricity (EJ/yr)"
+    for (CDR_te in getItems(v33_FEdemand, dim="all_te")) {
+      out <- mbind(out, setNames(dimSums(mselect(v33_FEdemand, all_te=CDR_te)),
+                                 sprintf("FE|CDR|++|%s (EJ/yr)", CDR_te_list[[CDR_te]])))
+      # loop over all FE technologies used by a given CDR technology CDR_te
+      for (CDR_FE in getItems(mselect(v33_FEdemand, all_te=CDR_te), dim="all_enty")) {
+        variable_name <- sprintf("FE|CDR|%s|+|%s (EJ/yr)", CDR_te_list[[CDR_te]], CDR_FE_list[[CDR_FE]])
+        out <- mbind(out, setNames(dimSums(mselect(v33_FEdemand, all_te=CDR_te, all_enty=CDR_FE)),
+                                   variable_name))
+      }
+    }
+  }
+
+  if(cdr_mod != "off" && cdr_mod != "portfolio"){ # compatibility with the CDR module before portfolio was added
     vm_otherFEdemand  <- readGDX(gdx,name=c("vm_otherFEdemand"),field="l",format="first_found")[,t,]*TWa_2_EJ
 
     s33_rockgrind_fedem <- readGDX(gdx,"s33_rockgrind_fedem", react = "silent")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.113.3**
+R package **remind2**, version **1.114.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.113.3, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.114.0, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort},
   year = {2023},
-  note = {R package version 1.113.3},
+  note = {R package version 1.114.0},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
Report CDR after introducing a new CDR module (one realization `portfolio`, in which options are chosen by switches instead of module realizations) [REMIND #1154](https://github.com/remindmodel/remind/pull/1154).

