### PR TITLE
activate piamInterfaces tests

### DIFF
--- a/tests/testthat/test-piamInterfaces-Ariadne.R
+++ b/tests/testthat/test-piamInterfaces-Ariadne.R
@@ -1,4 +1,3 @@
-skip()
 library(gdx)
 
 test_that("Test if REMIND reporting produces mandatory variables for Ariadne reporting", {

--- a/tests/testthat/test-piamInterfaces-NAVIGATE.R
+++ b/tests/testthat/test-piamInterfaces-NAVIGATE.R
@@ -1,4 +1,3 @@
-skip()
 library(gdx)
 
 test_that("Test if REMIND reporting produces mandatory variables for NAVIGATE reporting", {

--- a/tests/testthat/test-piamInterfaces-NGFS.R
+++ b/tests/testthat/test-piamInterfaces-NGFS.R
@@ -1,4 +1,3 @@
-skip()
 library(gdx)
 
 test_that("Test if REMIND reporting produces mandatory variables for NGFS reporting", {

--- a/tests/testthat/test-piamInterfaces-SHAPE.R
+++ b/tests/testthat/test-piamInterfaces-SHAPE.R
@@ -1,4 +1,3 @@
-skip()
 library(gdx)
 
 test_that("Test if REMIND reporting produces mandatory variables for SHAPE reporting", {


### PR DESCRIPTION
Bring back piamInterfaces tests, as they seem to work as expected.

When running buildLibrary locally, they give warnings about reporting variables expected in project-specific mappings that seem to be missing in remind2 reporting, without cancelling the build process. In tests on the cluster, these tests are skipped as gdxrrw is not available.


Current local output

```
> testthat::test_local("tests/testthat/test-piamInterfaces-Ariadne.R")
Starting 2 test processes
✔ | F W S  OK | Context
✔ |        14 | compareScenConf                                                                                                 
✔ |         1 | convGDX2mif [167.3s]                                                                                            
✔ |         1 | piamInterfaces-Ariadne [233.6s]                                                                                 
✔ |   1     1 | piamInterfaces-NAVIGATE [160.4s]                                                                                
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Warning (test-piamInterfaces-NAVIGATE.R:26:5): Test if REMIND reporting produces mandatory variables for NAVIGATE reporting
The following variables are expected in the piamInterfaces package,
          but cannot be found in the reporting generated:
 Emi|CO2|Transport|Pass|Road|LDV|Demand (Mt CO2/yr),
 FE|Transport|LDV|Electricity (EJ/yr),
 FE|Transport|LDV|Gases (EJ/yr),
 FE|Transport|LDV|Hydrogen (EJ/yr)
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
✔ |         1 | piamInterfaces-NGFS [168.8s]                                                                                    
✔ |         1 | piamInterfaces-SHAPE [123.8s]                                                                                   
                                                                                                                                
══ Results ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Duration: 456.7 s

[ FAIL 0 | WARN 1 | SKIP 0 | PASS 19 ]
```