### PR TITLE
remove Final Energy|Share of renewables in gross demand|Rough estimation as it is wrong

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '218157654'
+ValidationKey: '218199520'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.114.3
-date-released: '2023-08-09'
+version: 1.114.4
+date-released: '2023-08-11'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.114.3
-Date: 2023-08-09
+Version: 1.114.4
+Date: 2023-08-11
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportCrossVariables.R
+++ b/R/reportCrossVariables.R
@@ -216,9 +216,6 @@ reportCrossVariables <- function(gdx, output = NULL, regionSubsetList = NULL,
   tmp <- mbind(tmp,setNames(       # assume 8% for transmission losses and autoconsumption of power plants
     100 * (output[,,"SE|Electricity|Non-Biomass Renewables (EJ/yr)"] + output[,,"SE|Electricity|Biomass (EJ/yr)"])
     / 1.08 / output[,,"FE|Electricity (EJ/yr)"],    "Secondary Energy|Electricity|Share of renewables in gross demand|Estimation (Percent)"))
-  tmp <- mbind(tmp,setNames(       # divide biomass by 2 to roughly account for conversion losses
-    100 * (output[,,"PE|Non-Biomass Renewables (EJ/yr)"] + output[,,"PE|Biomass (EJ/yr)"]/2)
-    / output[,,"FE (EJ/yr)"],    "Final Energy|Share of renewables in gross demand|Rough estimation (Percent)"))
 
   # Energy expenditures
   tmp <- mbind(tmp,setNames(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.114.3**
+R package **remind2**, version **1.114.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.114.3, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.114.4, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort},
   year = {2023},
-  note = {R package version 1.114.3},
+  note = {R package version 1.114.4},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/inst/markdown/compareScenarios2/cs2_08_sdp.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_08_sdp.Rmd
@@ -56,6 +56,7 @@ walk(items, showLinePlots, data = data)
 ```
 
 \newpage
+
 ## SDG 7
 
 ### access
@@ -93,7 +94,6 @@ walk(items, showLinePlots, data = data)
 items <- c(
   "PE|Non-Biomass Renewables",
   "SE|Electricity|Non-Biomass Renewables",
-  "FE|Share of renewables in gross demand",
   "Secondary Energy|Electricity|Share of renewables in gross demand|Estimation")
 walk(items, showLinePlots, data = data)
 ```
@@ -141,6 +141,7 @@ walk(items, showLinePlots, data = data)
 ```
 
 \newpage
+
 ## SDG 12
 
 ```{r SDG 12}
@@ -164,7 +165,6 @@ items <- c(
   "Natural Land Transformation|Electricity")
 walk(items, showLinePlots, data = data)
 ```
-
 
 ## SDG 13
 


### PR DESCRIPTION
@bs538, this also removes `FE|Share of renewables in gross demand` from "SDG 7 clean" in the compare scenarios PDF.  No idea if that variable ever existed, but it does not now in `remind2` and was silently ignored by the compare scenarios scripts.