### PR TITLE
remove pcc from remind2 reporting to fix summation checks

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '218987850'
+ValidationKey: '219018626'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.117.0
-date-released: '2023-09-05'
+version: 1.117.1
+date-released: '2023-09-06'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.117.0
-Date: 2023-09-05
+Version: 1.117.1
+Date: 2023-09-06
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportSE.R
+++ b/R/reportSE.R
@@ -179,9 +179,8 @@ reportSE <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq
     se.prod(vm_prodSe, dataoc, oc2te, entySe, "pecoal", "seel", te = "igcc",    name = "SE|Electricity|Coal|++|Gasification Combined Cycle w/o CC (EJ/yr)"),
     se.prod(vm_prodSe, dataoc, oc2te, entySe, "pecoal", "seel", te = "igccc",   name = "SE|Electricity|Coal|++|Gasification Combined Cycle w/ CC (EJ/yr)"),
     se.prod(vm_prodSe, dataoc, oc2te, entySe, "pecoal", "seel", te = "pc",      name = "SE|Electricity|Coal|++|Pulverised Coal w/o CC (EJ/yr)"),
-    se.prod(vm_prodSe, dataoc, oc2te, entySe, "pecoal", "seel", te = "pcc",     name = "SE|Electricity|Coal|++|Pulverised Coal w/ CC (EJ/yr)"),
     se.prod(vm_prodSe, dataoc, oc2te, entySe, "pecoal", "seel", te = "coalchp", name = "SE|Electricity|Coal|++|Combined Heat and Power w/o CC (EJ/yr)"),
-    se.prod(vm_prodSe, dataoc, oc2te, entySe, "pecoal", "seel", te = setdiff(pe2se$all_te, c("igcc", "igccc", "pcc", "pc", "coalchp")),
+    se.prod(vm_prodSe, dataoc, oc2te, entySe, "pecoal", "seel", te = setdiff(pe2se$all_te, c("igcc", "igccc", "pc", "coalchp")),
                                                                                 name = "SE|Electricity|Coal|++|Other (EJ/yr)"),
 
     se.prod(vm_prodSe, dataoc, oc2te, entySe, "pegas", "seel",                  name = "SE|Electricity|+|Gas (EJ/yr)"),

--- a/R/reportTechnology.R
+++ b/R/reportTechnology.R
@@ -105,7 +105,6 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(
     "biochp" = "Electricity|Biomass|Combined Heat and Power w/o CC",
     "igccc" = "Electricity|Coal|Gasification Combined Cycle w/ CC",
     "igcc" = "Electricity|Coal|Gasification Combined Cycle w/o CC",
-    "pcc" = "Electricity|Coal|Pulverised Coal w/ CC",
     "pc" = "Electricity|Coal|Pulverised Coal w/o CC",
     "coalchp" = "Electricity|Coal|Combined Heat and Power w/o CC",
     "ngccc" = "Electricity|Gas|Combined Cycle w/ CC",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.117.0**
+R package **remind2**, version **1.117.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.117.0, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.117.1, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort},
   year = {2023},
-  note = {R package version 1.117.0},
+  note = {R package version 1.117.1},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
- was mentioned before: https://github.com/pik-piam/remind2/issues/378
- `pcc` is an ["outdated technology"](https://github.com/remindmodel/remind/blob/d37cee2ff75e7182257eead20690bb29972ca0ef/core/sets.gms#L333) not covered by REMIND anymore
- still, somehow [it was reported in reportSE](https://github.com/pik-piam/remind2/blob/b4a9045c0146fc0efa0088b4fa2741df4d554765/R/reportSE.R#L182) anyway as `SE|Electricity|Coal|++|Pulverised Coal w/ CC (EJ/yr)`
- This broke the summation group because it was not part of `pe2se$all_te` anymore and was therefore not added to `SE|Electricity|+|Coal`
```
SE|Electricity|+|Coal <
   + SE|Electricity|Coal|++|Gasification Combined Cycle w/o CC
   + SE|Electricity|Coal|++|Gasification Combined Cycle w/ CC
   + SE|Electricity|Coal|++|Pulverised Coal w/o CC
   + SE|Electricity|Coal|++|Pulverised Coal w/ CC
   + SE|Electricity|Coal|++|Combined Heat and Power w/o CC
   + SE|Electricity|Coal|++|Other
Relative difference between -321.83% and -0.00000608%, absolute difference up to 0.0000375 EJ/yr.
```
So let us kill it.