### PR TITLE
always name data dimension 'variable' in report functions

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '219696204'
+ValidationKey: '219760608'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.119.3
-date-released: '2023-09-28'
+version: 1.119.4
+date-released: '2023-10-02'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.119.3
-Date: 2023-09-28
+Version: 1.119.4
+Date: 2023-10-02
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportCapacity.R
+++ b/R/reportCapacity.R
@@ -316,5 +316,6 @@ reportCapacity <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5
   if (!is.null(regionSubsetList))
     tmp <- mbind(tmp, calc_regionSubset_sums(tmp, regionSubsetList))
 
+  getSets(tmp)[3] <- "variable"
   return(tmp)
 }

--- a/R/reportCapitalStock.R
+++ b/R/reportCapitalStock.R
@@ -127,5 +127,6 @@ reportCapitalStock <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),se
     if (!is.null(regionSubsetList))
       tmp <- mbind(tmp, calc_regionSubset_sums(tmp, regionSubsetList))
 
+    getSets(tmp)[3] <- "variable"
     return(tmp)
 }

--- a/R/reportCosts.R
+++ b/R/reportCosts.R
@@ -656,6 +656,7 @@ reportCosts <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,
   # add other region aggregations
   if (!is.null(regionSubsetList))
     tmp <- mbind(tmp, calc_regionSubset_sums(tmp, regionSubsetList))
-  
+
+  getSets(tmp)[3] <- "variable"
   return(tmp)
 }

--- a/R/reportCrossVariables.R
+++ b/R/reportCrossVariables.R
@@ -477,5 +477,6 @@ reportCrossVariables <- function(gdx, output = NULL, regionSubsetList = NULL,
             could not be calculated for this regional resolution")
   }
 
+  getSets(out)[3] <- "variable"
   return(out)
 }

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -2524,9 +2524,6 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
 
   out <- mbind(out, out.cumul)
 
-
-
-
+  getSets(out)[3] <- "variable"
   return(out)
-
 }

--- a/R/reportEmiAirPol.R
+++ b/R/reportEmiAirPol.R
@@ -618,5 +618,6 @@ reportEmiAirPol <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2
 
   } else {stop("not allowed AP-realization")}  
 
+  getSets(out)[3] <- "variable"
   return(out)
 }

--- a/R/reportEmployment.R
+++ b/R/reportEmployment.R
@@ -264,5 +264,6 @@ remFilter <- remFilter[, , c("New Cap|Electricity|Hydro", "Cap|Electricity|Hydro
 
   jobs <- mbind(jobsCi, jobsOm, jobsProd, jobsManf)
 
+  getSets(jobs)[3] <- "variable"
   return(jobs)
 }

--- a/R/reportEnergyInvestment.R
+++ b/R/reportEnergyInvestment.R
@@ -215,5 +215,6 @@ reportEnergyInvestment <- function(gdx, regionSubsetList = NULL, t = c(seq(2005,
   if (!is.null(regionSubsetList))
     tmp <- mbind(tmp, calc_regionSubset_sums(tmp, regionSubsetList))
 
+  getSets(tmp)[3] <- "variable"
   return(tmp)
 }

--- a/R/reportExtraction.R
+++ b/R/reportExtraction.R
@@ -282,5 +282,6 @@ grades[is.na(grades)] <- 0
   if (!is.null(regionSubsetList))
     out <- mbind(out, calc_regionSubset_sums(out, regionSubsetList))
 
+  getSets(out)[3] <- "variable"
   return(out)
 }

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -1741,5 +1741,6 @@ reportFE <- function(gdx, regionSubsetList = NULL,
     )
   }
 
+  getSets(out)[3] <- "variable"
   return(out)
 }

--- a/R/reportLCOE.R
+++ b/R/reportLCOE.R
@@ -1,7 +1,7 @@
 #' Read in GDX and calculate LCOE reporting used in convGDX2MIF_LCOE.
 #'
 #' This function provides a post-processing calculation of LCOE (Levelized Cost of Energy) for energy conversion technologies in REMIND.
-#' In incluldes most technologies that generate secondary energy and the distribution technologies which convert secondary energy to final energy.
+#' It includes most technologies that generate secondary energy and the distribution technologies which convert secondary energy to final energy.
 #' This script calculates two different types of LCOE: average LCOE (standing system) and marginal LCOE (new plant).
 #' The average LCOE reflect the total cost incurred by the technology deployment in a specific time step divided by its energy output.
 #' The marginal LCOE estimate the per-unit lifetime cost of the output if the model added another capacity of that technology in the respective time step.
@@ -1599,8 +1599,3 @@ reportLCOE <- function(gdx, output.type = "both"){
 
  return(LCOE.out)
 }
-
-
-
-
-

--- a/R/reportMacroEconomy.R
+++ b/R/reportMacroEconomy.R
@@ -403,5 +403,6 @@ reportMacroEconomy <- function(gdx, regionSubsetList = NULL,
   }
   # add interest rate
   out <- mbind(out, inteRate)
+  getSets(out)[3] <- "variable"
   return(out)
 }

--- a/R/reportPE.R
+++ b/R/reportPE.R
@@ -194,6 +194,7 @@ reportPE <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2070,211
   # add other region aggregations
   if (!is.null(regionSubsetList))
     out <- mbind(out, calc_regionSubset_sums(out, regionSubsetList))
-  
+
+  getSets(out)[3] <- "variable"
   return(out)
 }

--- a/R/reportPolicyCosts.R
+++ b/R/reportPolicyCosts.R
@@ -94,6 +94,7 @@ reportPolicyCosts <- function(gdx,gdx_ref,regionSubsetList=NULL,t=c(seq(2005,206
   # add other region aggregations
   if (!is.null(regionSubsetList))
     tmp <- mbind(tmp, calc_regionSubset_sums(tmp, regionSubsetList))
-  
+
+  getSets(tmp)[3] <- "variable"
   return(tmp)
 }

--- a/R/reportPrices.R
+++ b/R/reportPrices.R
@@ -1129,5 +1129,6 @@ reportPrices <- function(gdx, output=NULL, regionSubsetList=NULL,
   #   out <- mbind(out, tmp2)
   # }
 
+  getSets(out)[3] <- "variable"
   return(out)
 }

--- a/R/reportSDPVariables.R
+++ b/R/reportSDPVariables.R
@@ -221,6 +221,6 @@ reportSDPVariables <- function(
   output <- mbind(output,addUEperCapForBuildings(output))
   output <- mbind(output,addIntensityUE(output))
 
-
+  getSets(output)[3] <- "variable"
   return(output)
 }

--- a/R/reportSE.R
+++ b/R/reportSE.R
@@ -490,5 +490,6 @@ reportSE <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq
   if (!is.null(regionSubsetList))
     out <- mbind(out, calc_regionSubset_sums(out, regionSubsetList))
 
+  getSets(out)[3] <- "variable"
   return(out)
 }

--- a/R/reportTax.R
+++ b/R/reportTax.R
@@ -312,5 +312,6 @@ reportTax <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,5)
   out["GLO",,vars] <- NA
   out[names(regionSubsetList),,vars] <- NA
 
+  getSets(out)[3] <- "variable"
   return(out)
 }

--- a/R/reportTechnology.R
+++ b/R/reportTechnology.R
@@ -385,5 +385,6 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(
 
   tmp[is.na(tmp)] <- 0  # tmp is NA if weight is zero for all regions within the GLO or the specific region aggregation. Therefore, we replace all NAs with zeros.
 
+  getSets(tmp)[3] <- "variable"
   return(tmp)
 }

--- a/R/reportTrade.R
+++ b/R/reportTrade.R
@@ -132,13 +132,8 @@ reportTrade <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2070,
   tmp <- mbind(tmp,setNames(trade[,,"perm"] * price[,,"perm"] * 1000,                         "Trade|Emi Allowances|Value (billion US$2005/yr)"))
   tmp <- mbind(tmp,setNames(dimSums( trade[,,set_trade] * price[,,set_trade],dim = 3) * 1000, "Trade|All|Value (billion US$2005/yr)"))
   tmp <- mbind(tmp,setNames(dimSums( trade[,,set_trade] * price[,,set_trade],dim = 3),        "Current Account (billion US$2005/yr)"))
-  
-  
-  
-  
-  
-  # rename dimensions in the magpie object 
-  names(dimnames(tmp))[3] = 'variable'
-  
+
+  # rename dimensions in the magpie object
+  getSets(tmp)[3] <- "variable"
   return(tmp)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.119.3**
+R package **remind2**, version **1.119.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.119.3, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.119.4, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann},
   year = {2023},
-  note = {R package version 1.119.3},
+  note = {R package version 1.119.4},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/man/reportLCOE.Rd
+++ b/man/reportLCOE.Rd
@@ -19,7 +19,7 @@ MAgPIE object - LCOE calculated by model post-processing. Two types a) standing 
 }
 \description{
 This function provides a post-processing calculation of LCOE (Levelized Cost of Energy) for energy conversion technologies in REMIND.
-In incluldes most technologies that generate secondary energy and the distribution technologies which convert secondary energy to final energy.
+It includes most technologies that generate secondary energy and the distribution technologies which convert secondary energy to final energy.
 This script calculates two different types of LCOE: average LCOE (standing system) and marginal LCOE (new plant).
 The average LCOE reflect the total cost incurred by the technology deployment in a specific time step divided by its energy output.
 The marginal LCOE estimate the per-unit lifetime cost of the output if the model added another capacity of that technology in the respective time step.


### PR DESCRIPTION
- for consistency
- to make sure `as.quitte(reportFE(gdx))` et al. successfully finds variables and units because we go into [this part of the code](https://github.com/pik-piam/quitte/blob/55010a975bc8f2703ddc29404e51837977cb4544/R/as.quitte.R#L151-L158)

old:
```
# A tibble: 92,872 × 8
   model     scenario  region variable  unit      period value data
   <fct>     <fct>     <fct>  <fct>     <fct>      <int> <dbl> <fct>
 1 (Missing) (Missing) LAM    (Missing) (Missing)   2005 22.0  FE (EJ/yr)
 2 (Missing) (Missing) OAS    (Missing) (Missing)   2005 27.8  FE (EJ/yr)
 3 (Missing) (Missing) SSA    (Missing) (Missing)   2005 14.5  FE (EJ/yr)
 4 (Missing) (Missing) EUR    (Missing) (Missing)   2005 56.5  FE (EJ/yr)
 5 (Missing) (Missing) NEU    (Missing) (Missing)   2005  5.40 FE (EJ/yr)
 6 (Missing) (Missing) MEA    (Missing) (Missing)   2005 20.5  FE (EJ/yr)
 7 (Missing) (Missing) REF    (Missing) (Missing)   2005 27.2  FE (EJ/yr)
 8 (Missing) (Missing) CAZ    (Missing) (Missing)   2005 11.9  FE (EJ/yr)
 9 (Missing) (Missing) CHA    (Missing) (Missing)   2005 58.6  FE (EJ/yr)
10 (Missing) (Missing) IND    (Missing) (Missing)   2005 14.7  FE (EJ/yr)
# ℹ 92,862 more rows
```
new: 
```
# A tibble: 92,872 × 7
   model     scenario  region variable unit  period value
   <fct>     <fct>     <fct>  <fct>    <fct>  <int> <dbl>
 1 (Missing) (Missing) LAM    FE       EJ/yr   2005 22.0
 2 (Missing) (Missing) OAS    FE       EJ/yr   2005 27.8
 3 (Missing) (Missing) SSA    FE       EJ/yr   2005 14.5
 4 (Missing) (Missing) EUR    FE       EJ/yr   2005 56.5
 5 (Missing) (Missing) NEU    FE       EJ/yr   2005  5.40
 6 (Missing) (Missing) MEA    FE       EJ/yr   2005 20.5
 7 (Missing) (Missing) REF    FE       EJ/yr   2005 27.2
 8 (Missing) (Missing) CAZ    FE       EJ/yr   2005 11.9
 9 (Missing) (Missing) CHA    FE       EJ/yr   2005 58.6
10 (Missing) (Missing) IND    FE       EJ/yr   2005 14.7
# ℹ 92,862 more rows
```