### PR TITLE
Fix issue when subsector variables not available

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -65,6 +65,8 @@ authors:
   given-names: Jessica
 - family-names: Verpoort
   given-names: Philipp
+- family-names: Abrahao
+  given-names: Gabriel
 license: LGPL-3.0
 repository-code: https://github.com/pik-piam/remind2
 

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -138,9 +138,16 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
   vm_demFeSector <- readGDX(gdx, "vm_demFeSector", field = "l", restore_zeros = F)[, t, ]
   # set NA values to 0,
   vm_demFeSector[is.na(vm_demFeSector)] <- 0
-  # FE demand per industry subsector
-  o37_demFeIndSub <- readGDX(gdx, "o37_demFeIndSub", restore_zeros = F)[, t, ]
-  if (!is.null(o37_demFeIndSub)) {
+  # FE demand per industry subsector. First read without subsetting to check if
+  # is was actually written
+  # o37_demFeIndSub <- readGDX(gdx, "o37_demFeIndSub", restore_zeros = F)[, t, ]
+  o37_demFeIndSub <- readGDX(gdx, "o37_demFeIndSub", restore_zeros = F)
+  # Does subsector information exist?
+  if (length(o37_demFeIndSub) != 0) {
+    hassubsectors <- TRUE
+    o37_demFeIndSub <- o37_demFeIndSub[,t,]
+  } else {
+    hassubsectors <- FALSE
     o37_demFeIndSub[is.na(o37_demFeIndSub)] <- 0
   }
 
@@ -555,7 +562,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
 
 
   # reporting if FE per industry subsector o37_demFeIndSub exists
-  if (!is.null(o37_demFeIndSub)) {
+  if (hassubsectors) {
 
     # relabel industry energy CC from CCS sectors to industry sectors
     vm_emiIndCCS_Mapped <- toolAggregate(
@@ -1231,7 +1238,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
         mbind())
   } else {
 
-    if (!is.null(o37_demFeIndSub)) {
+    if (hassubsectors) {
 
 
       # calculate bioenergy shares in industry solids, liquids and gases per subsector
@@ -2392,7 +2399,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(200
     "Emi|CO2|Gross|Energy|Demand|+|Transport (Mt CO2/yr)")
 
   # TODO: remove this if clause once the below variable are there for industry subsectors
-  if ((module2realisation["industry", 2] == "fixed_shares") | (!is.null(o37_demFeIndSub))) {
+  if ((module2realisation["industry", 2] == "fixed_shares") | hassubsectors) {
     # Note: this assumes that all bunker fuels are liquids
     emi.vars.wBunkers <- c(emi.vars.wBunkers,     "Emi|CO2|Energy|Demand|Transport|+|Liquids (Mt CO2/yr)",  "Emi|CO2|Energy|Demand|++|Liquids (Mt CO2/yr)")
 


### PR DESCRIPTION
This PR is motivated by the implementation of the AR6 climate assessment, and basically just improves `reportEmi`s handling of GDXs without subsector information. This used to be case for compatibility with the `fixed_shares` of the industry module, that has been stagnant for a while.

But it's also useful because it makes the function work with GDXs written after the loop but *before* the postsolve, which is necessary for evaluating climate outcomes between iterations before they are needed for the damage step of postsolve. Of course, the subsector variables are not written.

In the case of operating with pre-postsolve GDXs, this can also affect some summations, notably `Emi|CO2|Energy|+|Demand`. The function wasn't designed for this in mind anyway, but the totals relevant for the climate assessment seem to work. And since there's no CCS in `fixed_shares`, this shouldn't affect summations in that case.