### PR TITLE
Avoid writing to the package repository in compare scenario

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '219589802'
+ValidationKey: '219654192'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.119.1
-date-released: '2023-09-22'
+version: 1.119.2
+date-released: '2023-09-26'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.119.1
-Date: 2023-09-22
+Version: 1.119.2
+Date: 2023-09-26
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/compareScenarios2.R
+++ b/R/compareScenarios2.R
@@ -150,8 +150,15 @@ compareScenarios2 <- function(
   } else if (outputFormat == "rmd") {
     return(.compareScenarios2Rmd(yamlParams, outputDir, outputFile))
   }
+
+  # copy the template directory from the package to the outputDir because rmarkdown writes to the folder
+  # containing the template.
+  templateInOutputDir <- file.path(outputDir, "compareScenarios2", "cs2_main.Rmd")
+  file.copy(system.file("markdown/compareScenarios2/", package = "remind2"),
+            outputDir, recursive = TRUE)
+
   rmarkdown::render(
-    system.file("markdown/compareScenarios2/cs2_main.Rmd", package = "remind2"),
+    templateInOutputDir,
     intermediates_dir = outputDir,
     output_dir = outputDir,
     output_file = outputFile,
@@ -159,6 +166,7 @@ compareScenarios2 <- function(
     params = yamlParams,
     envir = envir,
     quiet = quiet)
+  unlink(file.path(outputDir, "compareScenarios2"), recursive = TRUE)
 }
 
 # Copies the CompareScenarios2-Rmds to the specified location and modifies

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.119.1**
+R package **remind2**, version **1.119.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.119.1, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P (2023). _remind2: The REMIND R package (2nd generation)_. R package version 1.119.2, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort},
   year = {2023},
-  note = {R package version 1.119.1},
+  note = {R package version 1.119.2},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
This is the same fix Mika did [here](https://github.com/pik-piam/edgeTransport/pull/214) to avoid fails in rendering a cs2 when the user is missing the rights to write in the package repo or if someone else is also rendering at the same time.

> With this PR, the template directory will instead be copied to the output directory and render() will be called on that, ensuring that we have exclusive access and the necessary rights. The templates are removed afterwards to not blow up the output directory unnecessarily.