### PR TITLE
adding overlapped regional tech cost plots as a function of cumulative capacity for learning tech

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '223889229'
+ValidationKey: '224078400'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.133.1
-date-released: '2024-02-06'
+version: 1.134.0
+date-released: '2024-02-07'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.133.1
-Date: 2024-02-06
+Version: 1.134.0
+Date: 2024-02-07
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.133.1**
+R package **remind2**, version **1.134.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.133.1, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.134.0, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann},
   year = {2024},
-  note = {R package version 1.133.1},
+  note = {R package version 1.134.0},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/inst/markdown/compareScenarios2/cs2_01_summary.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_01_summary.Rmd
@@ -4,7 +4,7 @@
 
 ## GHG Emissions
 
-```{r summary GHG emissions}
+```{r GHG emissions}
 tot <- "Emi|GHG"
 items <- c(
   "Emi|CO2|Energy",
@@ -17,9 +17,9 @@ items <- c(
 showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
-## GHG by sector (w/ gross emissions, excl. negative emissions from CCS of non-fossil carbon)
+## GHG by sector
 
-```{r summary GHG by sector}
+```{r GHG by sector (w/ gross emissions, excl. negative emissions from CCS of non-fossil carbon)}
 tot <- "Emi|GHG"
 items <- c(
   "Emi|GHG|Gross|Energy|Supply|Electricity",
@@ -45,9 +45,9 @@ showAreaAndBarPlots(data, items, tot, scales = "fixed")
 showAreaAndBarPlots(data, paste(items, "pCap"), paste(tot, "pCap"), scales = "fixed")
 ```
 
-## CO2 by sector (w/ gross emissions, excl. negative emissions from CCS of non-fossil carbon)
+## CO2 by sector
 
-```{r CO2 by sector}
+```{r CO2 by sector (w/ gross emissions, excl. negative emissions from CCS of non-fossil carbon)}
 tot <- "Emi|CO2"
 items <- c(
   "Emi|CO2|Land-Use Change",
@@ -72,9 +72,9 @@ showAreaAndBarPlots(data, paste(items, "pCap"), paste(tot, "pCap"), scales = "fi
 ```
 
 
-###  CO2 cumulated by sector (w/ gross emissions, excl. negative emissions from CCS of non-fossil carbon)
+###  CO2 cumulated by sector
 
-```{r CO2 cumulated by sector}
+```{r CO2 cumulated by sector (w/ gross emissions, excl. negative emissions from CCS of non-fossil carbon)}
 tot <- "Emi|CO2|Cumulated"
 items <- c(
   "Emi|CO2|Cumulated|Land-Use Change",
@@ -106,7 +106,7 @@ showAreaAndBarPlots(data, items, scales = "fixed")
 
 ## FE per capita (by sector, time domain, area plot)
 
-```{r FE per capita area plot}
+```{r FE per capita (by sector, time domain, area plot)}
 items <- c(
   "FE|Transport pCap",
   "FE|Buildings pCap",
@@ -116,7 +116,7 @@ showAreaAndBarPlots(data, items, scales = "fixed")
 
 ## FE per capita (by sector, time domain, line graph)
 
-```{r FE per capita line plot}
+```{r FE per capita (by sector, time domain, line graph)}
 dIea <- data %>%
   # To make the plots less crowded, show only IEA historical data.
   filter(scenario != "historical" | model == "IEA")
@@ -130,16 +130,17 @@ showMultiLinePlots(dIea, items, scales = "fixed")
 
 ## FE per capita (by sector, GDP)
 
-```{r FE per capita}
+```{r FE per capita (by sector, GDP)}
 dIea <- data %>%
   # To make the plots less crowded, show only IEA historical data.
   filter(scenario != "historical" | model == "IEA")
-showMultiLinePlotsByVariable(dIea, "FE pCap", "GDP|PPP pCap")
+showMultiLinePlotsByVariable(dIea, "FE pCap", "GDP|PPP pCap", showGlobal = TRUE)
 items <- c(
   "FE|Transport pCap",
   "FE|Buildings pCap",
   "FE|Industry pCap")
-showMultiLinePlotsByVariable(dIea, items, "GDP|PPP pCap", scales = "fixed")
+showMultiLinePlotsByVariable(dIea, items, "GDP|PPP pCap", scales = "fixed", showGlobal = TRUE)
+
 ```
 
 ## FE by carrier
@@ -184,7 +185,7 @@ showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
 
 ## FE Industry by carrier (incl. non-energy use)
 
-```{r FE Industry by carrier}
+```{r FE Industry by carrier (incl. non-energy use)}
 items <- c(
   "FE|Industry|Electricity",
   "FE|Industry|Hydrogen",

--- a/inst/markdown/compareScenarios2/cs2_02_macro.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_02_macro.Rmd
@@ -204,9 +204,9 @@ vars <-
 walk(vars, showLinePlots, data = data)
 ```
 
-## FE intensity of GDP_PPP
+## FE intensity of GDP_PPP, area plot
 
-```{r FE intensity of GDP_PPP}
+```{r FE intensity of GDP_PPP, area plot (by sector)}
 items <- c(
   "FE|Transport pGDP_PPP",
   "FE|Buildings pGDP_PPP",
@@ -214,9 +214,9 @@ items <- c(
 showAreaAndBarPlots(data, items, scales = "fixed")
 ```
 
-## FE intensity of GDP_PPP, linegraph
+## FE intensity of GDP_PPP, line plot
 
-```{r FE intensity of GDP_PPP, linegraph}
+```{r FE intensity of GDP_PPP, line plot (by sector)}
 dIea <-
   data %>%
   # To make the plots less crowded, show only IEA historical data.
@@ -288,7 +288,7 @@ kayaRel <-
 ### Absolute
 
 ```{r Kaya Decomposition Absolute}
-showMultiLinePlots(kaya, kayaVars)
+showMultiLinePlots(kaya, kayaVars, NROW_NUM = 2)
 walk(kayaVars, showRegiLinePlots, data = kaya)
 ```
 
@@ -297,7 +297,7 @@ cat("### Relative to ", refYear, "\n")
 ```
 
 ```{r Kaya Decomposition Relative}
-showMultiLinePlots(kayaRel, kayaVars)
+showMultiLinePlots(kayaRel, kayaVars, NROW_NUM = 2)
 walk(kayaVars, showRegiLinePlots, data = kayaRel)
 ```
 

--- a/inst/markdown/compareScenarios2/cs2_02_macro.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_02_macro.Rmd
@@ -204,7 +204,7 @@ vars <-
 walk(vars, showLinePlots, data = data)
 ```
 
-## FE intensity of GDP
+## FE intensity of GDP_PPP
 
 ```{r FE intensity of GDP_PPP}
 items <- c(
@@ -214,7 +214,7 @@ items <- c(
 showAreaAndBarPlots(data, items, scales = "fixed")
 ```
 
-## FE intensity of GDP_PPP, linegraph (by pGDP_PPP)
+## FE intensity of GDP_PPP, linegraph
 
 ```{r FE intensity of GDP_PPP, linegraph}
 dIea <-

--- a/inst/markdown/compareScenarios2/cs2_06_energy_services.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_06_energy_services.Rmd
@@ -68,13 +68,17 @@ showAreaAndBarPlots(data, items, tot, orderVars = "user", scales = "fixed")
 items <- c(
   "FE|Buildings|Heating",
   "FE|Buildings|Appliances and Light",
-  "FE|Buildings|Cooking and Water",
+  "FE|Buildings|Cooking and Water")
+
+showMultiLinePlots(data, items)
+showMultiLinePlotsByVariable(data, items, "GDP|PPP pCap")
+
+items <- c(
   "FE|Buildings|Space Cooling",
   "FE|Buildings|Space Heating")
-showMultiLinePlots(data, items[1:3])
-showMultiLinePlots(data, items[4:5])
-showMultiLinePlotsByVariable(data, items[1:3], "GDP|PPP pCap")
-showMultiLinePlotsByVariable(data, items[4:5], "GDP|PPP pCap")
+
+showMultiLinePlots(data, items)
+showMultiLinePlotsByVariable(data, items, "GDP|PPP pCap")
 ```
 
 

--- a/inst/markdown/compareScenarios2/cs2_10_tech_cost.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_10_tech_cost.Rmd
@@ -10,6 +10,21 @@ showLinePlots(data, "Tech|Electricity|Storage|Battery|For PV|Capital Costs")
 showLinePlots(data, "Tech|Electricity|Nuclear|Capital Costs")
 ```
 
+### Learning renewables and storage
+```{r Learning renewables and storage}
+showLinePlots(data, )
+showLinePlots(data, "Tech|Electricity|Wind|Onshore|Capital Costs")
+showLinePlots(data, "Tech|Electricity|Wind|Offshore|Capital Costs")
+showLinePlots(data, "Tech|Electricity|Storage|Battery|For PV|Capital Costs")
+showMultiLinePlotsByVariable(data, "Tech|Electricity|Solar|PV|Capital Costs", "Cumulative Cap|Electricity|Solar", scales = "fixed")
+
+showMultiLinePlotsByVariable(data, "Tech|Electricity|Wind|Onshore|Capital Costs", "Cumulative Cap|Electricity|Wind|Onshore", scales = "fixed", showHistorical = FALSE)
+
+showMultiLinePlotsByVariable(data, "Tech|Electricity|Wind|Offshore|Capital Costs", "Cumulative Cap|Electricity|Wind|Offshore", scales = "fixed", showHistorical = FALSE)
+
+showMultiLinePlotsByVariable(data, "Tech|Electricity|Storage|Battery|For PV|Capital Costs", "Cumulative Cap|Electricity|Storage|Battery|For PV", scales = "fixed", showHistorical = FALSE)
+```
+
 ### Direct and indirect electrifications
 ```{r Direct and indirect electrifications}
 showLinePlots(data, "Tech|Heat|Electricity|Heat Pump|Capital Costs")

--- a/inst/markdown/compareScenarios2/cs2_10_tech_cost.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_10_tech_cost.Rmd
@@ -12,16 +12,9 @@ showLinePlots(data, "Tech|Electricity|Nuclear|Capital Costs")
 
 ### Learning renewables and storage
 ```{r Learning renewables and storage}
-showLinePlots(data, )
-showLinePlots(data, "Tech|Electricity|Wind|Onshore|Capital Costs")
-showLinePlots(data, "Tech|Electricity|Wind|Offshore|Capital Costs")
-showLinePlots(data, "Tech|Electricity|Storage|Battery|For PV|Capital Costs")
 showMultiLinePlotsByVariable(data, "Tech|Electricity|Solar|PV|Capital Costs", "Cumulative Cap|Electricity|Solar", scales = "fixed")
-
 showMultiLinePlotsByVariable(data, "Tech|Electricity|Wind|Onshore|Capital Costs", "Cumulative Cap|Electricity|Wind|Onshore", scales = "fixed", showHistorical = FALSE)
-
 showMultiLinePlotsByVariable(data, "Tech|Electricity|Wind|Offshore|Capital Costs", "Cumulative Cap|Electricity|Wind|Offshore", scales = "fixed", showHistorical = FALSE)
-
 showMultiLinePlotsByVariable(data, "Tech|Electricity|Storage|Battery|For PV|Capital Costs", "Cumulative Cap|Electricity|Storage|Battery|For PV", scales = "fixed", showHistorical = FALSE)
 ```
 

--- a/inst/markdown/compareScenarios2/cs2_10_tech_cost.Rmd
+++ b/inst/markdown/compareScenarios2/cs2_10_tech_cost.Rmd
@@ -1,6 +1,6 @@
 # Technology capital costs
 
-## Electricity generating technology capital costs
+## Electricity generating technology capital costs vs. time (by regions)
 ### Renewables, storage and nuclear
 ```{r Renewables, storage and nuclear}
 showLinePlots(data, "Tech|Electricity|Solar|PV|Capital Costs")
@@ -8,14 +8,6 @@ showLinePlots(data, "Tech|Electricity|Wind|Onshore|Capital Costs")
 showLinePlots(data, "Tech|Electricity|Wind|Offshore|Capital Costs")
 showLinePlots(data, "Tech|Electricity|Storage|Battery|For PV|Capital Costs")
 showLinePlots(data, "Tech|Electricity|Nuclear|Capital Costs")
-```
-
-### Learning renewables and storage
-```{r Learning renewables and storage}
-showMultiLinePlotsByVariable(data, "Tech|Electricity|Solar|PV|Capital Costs", "Cumulative Cap|Electricity|Solar", scales = "fixed")
-showMultiLinePlotsByVariable(data, "Tech|Electricity|Wind|Onshore|Capital Costs", "Cumulative Cap|Electricity|Wind|Onshore", scales = "fixed", showHistorical = FALSE)
-showMultiLinePlotsByVariable(data, "Tech|Electricity|Wind|Offshore|Capital Costs", "Cumulative Cap|Electricity|Wind|Offshore", scales = "fixed", showHistorical = FALSE)
-showMultiLinePlotsByVariable(data, "Tech|Electricity|Storage|Battery|For PV|Capital Costs", "Cumulative Cap|Electricity|Storage|Battery|For PV", scales = "fixed", showHistorical = FALSE)
 ```
 
 ### Direct and indirect electrifications
@@ -32,14 +24,12 @@ showLinePlots(data, "Tech|CO2 Storage|Capital Costs|w/ Adj Costs")
 showLinePlots(data, "Tech|DAC|Capital Costs|w/ Adj Costs")
 ```
 
-
 ### Gas technologies
 ```{r Gas technologies}
 showLinePlots(data, "Tech|Electricity|Gas|Combined Cycle w/ CC|Capital Costs")
 showLinePlots(data, "Tech|Electricity|Gas|Gas Turbine|Capital Costs")
 showLinePlots(data, "Tech|Electricity|Gas|Combined Heat and Power w/o CC|Capital Costs")
 ```
-
 
 ### Coal technologies
 ```{r Coal technologies}
@@ -49,4 +39,36 @@ showLinePlots(data, "Tech|Electricity|Coal|Combined Heat and Power w/o CC|Capita
 showLinePlots(data, "Tech|Heat|Coal|Capital Costs")
 ```
 
+## Learning renewables and storage vs. cumulative capacity (regional comparison)
+```{r Learning renewables and storage vs. cumulative capacity (regional comparison)}
+showMultiLinePlotsByVariable(data, "Tech|Electricity|Solar|PV|Capital Costs", "Cumulative Cap|Electricity|Solar", scales = "fixed")
+showMultiLinePlotsByVariable(data, "Tech|Electricity|Wind|Onshore|Capital Costs", "Cumulative Cap|Electricity|Wind|Onshore", scales = "fixed", showHistorical = FALSE)
+showMultiLinePlotsByVariable(data, "Tech|Electricity|Wind|Offshore|Capital Costs", "Cumulative Cap|Electricity|Wind|Offshore", scales = "fixed", showHistorical = FALSE)
+showMultiLinePlotsByVariable(data, "Tech|Electricity|Storage|Battery|For PV|Capital Costs", "Cumulative Cap|Electricity|Storage|Battery|For PV", scales = "fixed", showHistorical = FALSE)
+```
 
+## Capital cost of non-renewables vs. years (regional comparison)
+```{r Capital cost of non-renewables vs. years (regional comparison)}
+items1 <- c(
+"Tech|Heat|Electricity|Heat Pump|Capital Costs",
+"Tech|Hydrogen|Electricity|Capital Costs",
+"Tech|Liquids|Hydrogen|Capital Costs",
+"Tech|Hydrogen|Gas|w/ CC|Capital Costs",
+"Tech|CO2 Storage|Capital Costs|w/ Adj Costs",
+"Tech|DAC|Capital Costs|w/ Adj Costs",
+NULL)
+
+showMultiLinePlots(data, items1, NROW_NUM = 3)
+
+items2 <- c(
+"Tech|Electricity|Gas|Combined Cycle w/ CC|Capital Costs",
+"Tech|Electricity|Gas|Gas Turbine|Capital Costs",
+"Tech|Electricity|Gas|Combined Heat and Power w/o CC|Capital Costs",
+"Tech|Electricity|Coal|Pulverised Coal w/ CC|Capital Costs",
+"Tech|Electricity|Coal|Gasification Combined Cycle w/o CC|Capital Costs",
+"Tech|Electricity|Coal|Combined Heat and Power w/o CC|Capital Costs",
+"Tech|Heat|Coal|Capital Costs",
+NULL)
+showMultiLinePlots(data, items2, NROW_NUM = 3)
+
+```


### PR DESCRIPTION
![image](https://github.com/pik-piam/remind2/assets/20283904/9c116584-a4d9-466e-acbf-bf628c576893)

note: regions with small cumulative capacity benefits from global spillover under the default scenario of one price globally and global learning