### PR TITLE
print failing summation checks in test

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,10 +1,11 @@
-ValidationKey: '224299074'
+ValidationKey: '224378150'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'
 - .*qpdf.* is needed for checks on size reduction of PDFs
 - .*following variables are expected in the piamInterfaces.*
-- Summation checks have revealed some gaps!*
+- Summation checks have revealed some gaps.*
+- .*to check if summation groups add up.*
 AcceptedNotes:
 - Imports includes .* non-default packages.
 - unable to verify current time

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.134.6
+version: 1.135.0
 date-released: '2024-02-16'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.134.6
+Version: 1.135.0
 Date: 2024-02-16
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/convGDX2MIF.R
+++ b/R/convGDX2MIF.R
@@ -13,6 +13,7 @@
 #' @param t temporal resolution of the reporting, default:
 #' t=c(seq(2005,2060,5),seq(2070,2110,10),2130,2150)
 #' @param gdx_refpolicycost reference-gdx for policy costs, a GDX as created by readGDX, or the file name of a gdx
+#' @param testthat boolean whether called by tests, turns some messages into warnings
 #' @author Lavinia Baumstark
 #' @examples
 #'
@@ -27,7 +28,7 @@
 
 convGDX2MIF <- function(gdx, gdx_ref = NULL, file = NULL, scenario = "default",
                         t = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150),
-                        gdx_refpolicycost = gdx_ref) {
+                        gdx_refpolicycost = gdx_ref, testthat = FALSE) {
 
   # Define region subsets
   regionSubsetList <- toolRegionSubsets(gdx)
@@ -128,9 +129,11 @@ convGDX2MIF <- function(gdx, gdx_ref = NULL, file = NULL, scenario = "default",
 
   checkVariableNames(getNames(output, dim = 3))
 
-  .reportSummationErrors <- function(msg) {
-    if (!any(grepl('All summation checks were fine', msg)))
-      message(paste(msg, collapse = '\n'))
+  .reportSummationErrors <- function(msg, testthat) {
+    if (!any(grepl('All summation checks were fine', msg))) {
+      msgtext <- paste(msg, collapse = '\n')
+      if (isTRUE(testthat)) warning(msgtext) else message(msgtext)
+    }
   }
 
   capture.output(
@@ -141,7 +144,7 @@ convGDX2MIF <- function(gdx, gdx_ref = NULL, file = NULL, scenario = "default",
     ) %>%
       filter(abs(.data$diff) >= 1.5e-8),
     type = 'message') %>%
-    .reportSummationErrors()
+    .reportSummationErrors(testthat = testthat)
 
   capture.output(sumChecks <- checkSummations(
     mifFile = output, dataDumpFile = NULL, outputDirectory = NULL,
@@ -152,7 +155,7 @@ convGDX2MIF <- function(gdx, gdx_ref = NULL, file = NULL, scenario = "default",
       bind_rows(sumChecks),
     type = 'message'
   ) %>%
-    .reportSummationErrors()
+    .reportSummationErrors(testthat = testthat)
 
   # either write the *.mif or return the magpie object
   if (!is.null(file)) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.134.6**
+R package **remind2**, version **1.135.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.134.6, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.135.0, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann},
   year = {2024},
-  note = {R package version 1.134.6},
+  note = {R package version 1.135.0},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/man/convGDX2MIF.Rd
+++ b/man/convGDX2MIF.Rd
@@ -10,7 +10,8 @@ convGDX2MIF(
   file = NULL,
   scenario = "default",
   t = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150),
-  gdx_refpolicycost = gdx_ref
+  gdx_refpolicycost = gdx_ref,
+  testthat = FALSE
 )
 }
 \arguments{
@@ -28,6 +29,8 @@ returned}
 t=c(seq(2005,2060,5),seq(2070,2110,10),2130,2150)}
 
 \item{gdx_refpolicycost}{reference-gdx for policy costs, a GDX as created by readGDX, or the file name of a gdx}
+
+\item{testthat}{boolean whether called by tests, turns some messages into warnings}
 }
 \description{
 Read in all information from GDX file and create

--- a/tests/testthat/test-convGDX2mif.R
+++ b/tests/testthat/test-convGDX2mif.R
@@ -91,7 +91,7 @@ test_that("Test if REMIND reporting is produced as it should and check data inte
     numberOfMifs <- numberOfMifs + 1
 
     message("Running convGDX2MIF(", gdxPath, ")...")
-    mifContent <- convGDX2MIF(gdxPath, gdx_refpolicycost = gdxPath)
+    mifContent <- convGDX2MIF(gdxPath, gdx_refpolicycost = gdxPath, testthat = TRUE)
 
     expect_no_warning(checkVariableNames(getNames(mifContent, dim = 3)))
 


### PR DESCRIPTION
- close #536
- add `testthat` boolean to `convGDX2MIF`. If set to `TRUE`, the failing summation message is turned into a warning and therefore visible after running `make test`. Don't break on this warning though.