### PR TITLE
fix logging for refpolicycost, run one of the tests with refpolicycost = NULL

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '224502642'
+ValidationKey: '224601900'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.135.4
-date-released: '2024-02-20'
+version: 1.135.5
+date-released: '2024-02-27'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.135.4
-Date: 2024-02-20
+Version: 1.135.5
+Date: 2024-02-27
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/convGDX2MIF.R
+++ b/R/convGDX2MIF.R
@@ -96,8 +96,12 @@ convGDX2MIF <- function(gdx, gdx_ref = NULL, file = NULL, scenario = "default",
     gdp_scen_ref <- try(readGDX(gdx_refpolicycost, "cm_GDPscen", react = "error"), silent = TRUE)
     if (! inherits(gdp_scen, "try-error") && ! inherits(gdp_scen_ref, "try-error")) {
       if (gdp_scen[1] == gdp_scen_ref[1]) {
-        file_refpolicycost <- paste0(basename(dirname(gdx_refpolicycost)), "/", basename(gdx_refpolicycost))
-        message("running reportPolicyCosts, comparing to ", file_refpolicycost, "...")
+        if (gdx == gdx_refpolicycost) {
+          msg_refpc <- "reporting 0 everywhere"
+        } else {
+          msg_refpc <- paste0("comparing to ", basename(dirname(gdx_refpolicycost)), "/", basename(gdx_refpolicycost), "...")
+        }
+        message("running reportPolicyCosts, ", msg_refpc)
         output <- mbind(output, reportPolicyCosts(gdx, gdx_refpolicycost, regionSubsetList, t)[,t,])
       } else {
         warning("The GDP scenario differs from that of the reference run. Did not execute 'reportPolicyCosts'! ",
@@ -106,7 +110,7 @@ convGDX2MIF <- function(gdx, gdx_ref = NULL, file = NULL, scenario = "default",
     } else {
       warning("A comparison of the GDP scenarios between this run and its reference run wasn't possible (old remind version). ",
               "Therefore to avoid reporting unsensible policy costs, 'reportPolicyCosts' was not executed. ",
-              "If a policy costs reporting is required, please use the  'policyCosts' output.R script.")
+              "If a policy costs reporting is required, please use the 'policyCosts' output.R script.")
     }
   } else {
     warning(paste0("File ", gdx_refpolicycost, " not found. Did not execute 'reportPolicyCosts'! ",

--- a/R/reportPrices.R
+++ b/R/reportPrices.R
@@ -552,8 +552,8 @@ reportPrices <- function(gdx, output=NULL, regionSubsetList=NULL,
     "indst.fehos", "indst.fesos", "indst.feels", "indst.feh2s", "indst.fegas",
     "build.fepet", "indst.fepet"
   )
-  pm_tau_fe_tax <- readGDX(gdx, c("p21_tau_fe_tax","pm_tau_fe_tax"))[, YearsFrom2005, entyFe2Sector] # [tr USD2005/TWa]
-  pm_tau_fe_sub <- readGDX(gdx, c("p21_tau_fe_sub","pm_tau_fe_sub"))[, YearsFrom2005, entyFe2Sector] # [tr USD2005/TWa]
+  pm_tau_fe_tax <- readGDX(gdx, c("p21_tau_fe_tax","pm_tau_fe_tax"), format="first_found")[, YearsFrom2005, entyFe2Sector] # [tr USD2005/TWa]
+  pm_tau_fe_sub <- readGDX(gdx, c("p21_tau_fe_sub","pm_tau_fe_sub"), format="first_found")[, YearsFrom2005, entyFe2Sector] # [tr USD2005/TWa]
   price.tax <- (pm_tau_fe_tax + pm_tau_fe_sub) / s_twa2mwh / 3.6 * 1e12 # [USD2005/GJ]
 
   out <- mbind(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.135.4**
+R package **remind2**, version **1.135.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.135.4, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.135.5, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann},
   year = {2024},
-  note = {R package version 1.135.4},
+  note = {R package version 1.135.5},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/tests/testthat/test-convGDX2mif.R
+++ b/tests/testthat/test-convGDX2mif.R
@@ -61,7 +61,7 @@ test_that("Test if REMIND reporting is produced as it should and check data inte
   }
 
   checkPiamTemplates <- function(computedVariables) {
-    templates <- c("AR6", "AR6_NGFS", "NAVIGATE", "SHAPE", "ELEVATE")
+    templates <- c("AR6", "AR6_NGFS", "ELEVATE", "NAVIGATE", "SHAPE")
     for (template in templates) {
       templateVariables <- template %>%
         piamInterfaces::getREMINDTemplateVariables() %>%
@@ -91,7 +91,8 @@ test_that("Test if REMIND reporting is produced as it should and check data inte
     numberOfMifs <- numberOfMifs + 1
 
     message("Running convGDX2MIF(", gdxPath, ")...")
-    mifContent <- convGDX2MIF(gdxPath, gdx_refpolicycost = gdxPath, testthat = TRUE)
+    refpolicycost <- if (gdxPath == gdxPaths[[1]]) gdxPath else NULL
+    mifContent <- convGDX2MIF(gdxPath, gdx_refpolicycost = refpolicycost, testthat = TRUE)
 
     expect_no_warning(checkVariableNames(getNames(mifContent, dim = 3)))
 


### PR DESCRIPTION
- add first_found to reportPrices. The variable was renamed recently ([this commit](https://github.com/pik-piam/remind2/commit/32059707b3059e53478711c761048877c3257eca))
- fix logging for refpolicycost and don't show inconsistent information. Also run test with refpolicycost=NULL, at least on the cluster, to make sure both with and without is tested. Would have avoided https://github.com/pik-piam/remind2/pull/543. ([this commit](https://github.com/pik-piam/remind2/commit/9ee4a5a86d4351b2ac4499b6f6adc974e405e600))