### PR TITLE
repair convGDX2MIF_REMIND2MAgPIE

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '224601900'
+ValidationKey: '224621680'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.135.5
+version: 1.135.6
 date-released: '2024-02-27'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.135.5
+Version: 1.135.6
 Date: 2024-02-27
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/convGDX2MIF_REMIND2MAgPIE.R
+++ b/R/convGDX2MIF_REMIND2MAgPIE.R
@@ -27,7 +27,7 @@ convGDX2MIF_REMIND2MAgPIE <- function(gdx, file = NULL, scenario = "default",
   # ADD EU-27 region aggregation if possible
   if("EUR" %in% names(regionSubsetList)){
     regionSubsetList <- c(regionSubsetList, list(
-      "EU27" = c("ENC", "EWN", "ECS", "ESC", "ECE", "FRA"," DEU", "ESW")
+      "EU27" = c("ENC", "EWN", "ECS", "ESC", "ECE", "FRA","DEU", "ESW")
     ))
   }
 

--- a/R/convGDX2MIF_REMIND2MAgPIE.R
+++ b/R/convGDX2MIF_REMIND2MAgPIE.R
@@ -31,9 +31,21 @@ convGDX2MIF_REMIND2MAgPIE <- function(gdx, file = NULL, scenario = "default",
     ))
   }
 
-  # reporting of variables that need variables from different other report functions
+  output <- NULL
+  message("running reportMacroEconomy...")
+  output <- mbind(output,reportMacroEconomy(gdx,regionSubsetList,t)[,t,])
+  message("running reportPE...")
+  output <- mbind(output,reportPE(gdx,regionSubsetList,t)[,t,])
+  message("running reportSE...")
+  output <- mbind(output,reportSE(gdx,regionSubsetList,t)[,t,])
+  message("running reportFE...")
+  output <- mbind(output,reportFE(gdx,regionSubsetList,t))
+  message("running reportExtraction...")
+  output <- mbind(output,reportExtraction(gdx,regionSubsetList,t)[,t,])
+  message("running reportEmi...")
+  output <- mbind(output,reportEmi(gdx,output,regionSubsetList,t)[,t,])    # needs output from reportFE
   message("running reportPrices...")
-  output <- reportPrices(gdx = gdx, regionSubsetList = regionSubsetList, t = t)[, t, ] # needs output from reportSE, reportFE, reportEmi, reportExtraction, reportMacroEconomy
+  output <- mbind(output,reportPrices(gdx,output,regionSubsetList,t)[,t,]) # needs output from reportSE, reportFE, reportEmi, reportExtraction, reportMacroEconomy
 
   # Add dimension names "scenario.model.variable"
   magclass::getSets(output)[3] <- "variable"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.135.5**
+R package **remind2**, version **1.135.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.135.5, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.135.6, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann},
   year = {2024},
-  note = {R package version 1.135.5},
+  note = {R package version 1.135.6},
   url = {https://github.com/pik-piam/remind2},
 }
 ```


### PR DESCRIPTION
- further variables are needed for MAgPIE, particular from `reportExtraction`
- As `reportPrices` was running these reports anyway, it does not actually do harm in terms of runtime