### PR TITLE
Fix DAC-related emissions

### DIFF
--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -1396,7 +1396,7 @@ if (!is.null(vm_plasticsCarbon)) {
                setNames(dimSums(vm_emiIndCCS[, , "co2cement_process"], dim = 3) * GtC_2_MtCO2,
                           "Carbon Management|Carbon Capture|Industry Process|+|Cement (Mt CO2/yr)"),
                # total co2 captured by DAC
-               setNames(-vm_emiCdrTeDetail[, , "dac"] * GtC_2_MtCO2,
+               setNames(dimSums(vm_ccs_cdr, na.rm = TRUE) * GtC_2_MtCO2,
                           "Carbon Management|Carbon Capture|+|DAC (Mt CO2/yr)"),
                # total co2 captured
                setNames(vm_co2capture * GtC_2_MtCO2,
@@ -1768,7 +1768,7 @@ if (!is.null(vm_plasticsCarbon)) {
                          "Emi|CO2|CDR|Materials|+|Plastics (Mt CO2/yr)"),
 
                # total DACCS
-               setNames(-out[, , "Carbon Management|Storage|+|DAC (Mt CO2/yr)"],
+               setNames(vm_emiCdrTeDetail[, , "dac"] * p_share_CCS * GtC_2_MtCO2,
                         "Emi|CO2|CDR|DACCS (Mt CO2/yr)"),
                # total EW
                # total co2 captured by EW


### PR DESCRIPTION
Captured emissions from using natural gas for DAC’s heat are accounted for twice: burning natural gas and released when using synfuels. It could be fixed by discounting them from `vm_emiTeMkt` and `vm_emiAllMkt` in the reporting. See #552.

The remaining summation errors are not CDR-related:
```
Emi|GHG|++|ESR <>                                                        	 
   + Emi|GHG|ESR|+|Industry                                           	 
   + Emi|GHG|ESR|+|Transport                                          	 
   + Emi|GHG|ESR|+|Buildings                                          	 
   + Emi|GHG|ESR|+|Agriculture                                        	 
   + Emi|GHG|ESR|+|Energy Waste                                       	 
   + Emi|GHG|ESR|+|Waste                                              	 
Relative difference between -1.4% and 0.0361%, absolute difference up to 31.8 Mt CO2eq/yr.

Emi|GHG|++|Outside ETS and ESR <>                                        	 
   + Emi|GHG|Outside ETS and ESR|+|Transport                          	 
   + Emi|GHG|Outside ETS and ESR|+|Land-Use Change                    	 
   + Emi|GHG|Outside ETS and ESR|+|F-Gases                            	 
Relative difference between -15519% and 14.8%, absolute difference up to 31.8 Mt CO2eq/yr.
```
