### PR TITLE
remove outdated 'Price|Light Fuel Oil|Secondary Level'

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '225168542'
+ValidationKey: '225211088'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.137.1
-date-released: '2024-03-20'
+version: 1.137.2
+date-released: '2024-03-22'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.137.1
-Date: 2024-03-20
+Version: 1.137.2
+Date: 2024-03-22
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/createVarListHtml.R
+++ b/R/createVarListHtml.R
@@ -76,7 +76,7 @@ renderVarListAsHtml <- function(varList, outFileName, title, htmlBefore) {
 #'   readr::read_delim(
 #'     paste0(
 #'       "https://raw.githubusercontent.com/pik-piam/",
-#'       "piamInterfaces/master/inst/templates/mapping_template_AR6.csv"),
+#'       "piamInterfaces/master/inst/mappings/mapping_AR6.csv"),
 #'     delim = ";",
 #'     col_select = c(r21m42, Definition)
 #'   ) %>%

--- a/R/reportCrossVariables.R
+++ b/R/reportCrossVariables.R
@@ -51,37 +51,19 @@ reportCrossVariables <- function(gdx, output = NULL, regionSubsetList = NULL,
   pm_ts          <- readGDX(gdx,name='pm_ts',format="first_found",restore_zeros=FALSE)
   ## equations
   sebal.m        <- readGDX(gdx,name=c("q_balSe","q_sebal"),types="equations",field="m",format="first_found")
-  budget.m       <- readGDX(gdx,name='qm_budget',types = "equations",field = "m",format = "first_found") # Alternative: calcPrice
   demPE  <- readGDX(gdx,name=c("vm_demPe","v_pedem"),field="l",restore_zeros=FALSE,format="first_found") * TWa_2_EJ
   demPE  <- demPE[pe2se]
   ####### calculate minimal temporal and regional resolution #####
   y <- Reduce(intersect,list(getYears(output),getYears(sebal.m)))
   r <- Reduce(intersect,list(getRegions(output),getRegions(sebal.m)))
   output   <- output[,y,]
-  budget.m <- budget.m[,y,]
-  sebal.m  <- sebal.m[,y,]
-  pm_ts    <- pm_ts[,y,]
   ####### calculate reporting parameters ############
   tmp <- NULL
-  #"light fuel oil" is output of refineries, thus the price should include refinery costs => use sebal, not pebal, use average of sepet and sedie price.
-  if ("seliq" %in% pe2se$all_enty1) {
-    tmp <- mbind(tmp,setNames(sebal.m[,,"seliq"]/(budget.m+1e-10) * tdptwyr2dpgj,  "Price|Light Fuel Oil|Secondary Level (US$2005/GJ)" ))
-  } else if ("sepet" %in% sety) {
-    tmp <- mbind(tmp,setNames(
-      ( sebal.m[,,"sepet"] * output[r,,"SE|Liquids|sepet (EJ/yr)"]  + sebal.m[,,"sedie"] * output[r,,"SE|Liquids|sedie (EJ/yr)"])
-      / ( output[r,,"SE|Liquids|sepet (EJ/yr)"] + output[r,,"SE|Liquids|sedie (EJ/yr)"])
-      / (budget.m / pm_ts + 1e-10) * tdptwyr2dpgj,           "Price|Light Fuel Oil|Secondary Level (US$2005/GJ)" ))
-  } else {
-    tmp <- mbind(tmp,setNames(
-      dimSums( sebal.m[,,"seliqbio"] * output[r,,"SE|Liquids|Biomass (EJ/yr)"]  + sebal.m[,,"seliqfos"] * output[r,,"SE|Liquids|Fossil (EJ/yr)"])
-      / dimSums( output[r,,"SE|Liquids|Biomass (EJ/yr)"] + output[r,,"SE|Liquids|Fossil (EJ/yr)"])
-      / (budget.m / pm_ts + 1e-10) * tdptwyr2dpgj,           "Price|Light Fuel Oil|Secondary Level (US$2005/GJ)" ))
-  }
-
   tmp <- mbind(tmp,setNames(
                    output[r,,"SE|Electricity|Biomass (EJ/yr)"]
                  * output[r,,"PE|Biomass|Energy Crops (EJ/yr)"]
                  / dimSums(mselect(demPE,all_enty="pebiolc"),dim=3),   "SE|Electricity|Biomass|Energy Crops (EJ/yr)"))
+  getSets(tmp) <- c("all_regi", "ttot", "variable")
   tmp <- mbind(tmp,setNames(
                    output[r,,"SE|Electricity|Biomass (EJ/yr)"]
                  * output[r,,"PE|Biomass|Residues (EJ/yr)"]
@@ -137,8 +119,6 @@ reportCrossVariables <- function(gdx, output = NULL, regionSubsetList = NULL,
 
   # correct global values for intensive variables (prices, LCOES, Capacity factors)
   map <- data.frame(region=getRegions(tmp["GLO",,,invert=TRUE]),world="GLO",stringsAsFactors=FALSE)
-  tmp["GLO",,"Price|Light Fuel Oil|Secondary Level (US$2005/GJ)"] <-
-            speed_aggregate(tmp[map$region,,"Price|Light Fuel Oil|Secondary Level (US$2005/GJ)"],map,weight=output[map$region,,"SE|Liquids|Fossil|Oil (EJ/yr)"])
   tmp["GLO",,"Capacity Factor|Electricity|Gas (%)"] <-
     speed_aggregate(tmp[map$region,,"Capacity Factor|Electricity|Gas (%)"],map,weight=output[map$region,,"Cap|Electricity|Gas (GW)"])
   tmp["GLO",,"Real Capacity Factor|Electricity|Wind (%)"] <-
@@ -154,7 +134,6 @@ reportCrossVariables <- function(gdx, output = NULL, regionSubsetList = NULL,
   if (!is.null(regionSubsetList)){
     for (region in names(regionSubsetList)){
       map <- data.frame(region=regionSubsetList[[region]],parentRegion=region,stringsAsFactors=FALSE)
-      tmp[region,,"Price|Light Fuel Oil|Secondary Level (US$2005/GJ)"] <- speed_aggregate(tmp[regionSubsetList[[region]],,"Price|Light Fuel Oil|Secondary Level (US$2005/GJ)"],map,weight=output[regionSubsetList[[region]],,"SE|Liquids|Fossil|Oil (EJ/yr)"])
       tmp[region,,"Capacity Factor|Electricity|Gas (%)"] <- speed_aggregate(tmp[regionSubsetList[[region]],,"Capacity Factor|Electricity|Gas (%)"],map,weight=output[regionSubsetList[[region]],,"Cap|Electricity|Gas (GW)"])
       tmp[region,,"Real Capacity Factor|Electricity|Wind (%)"] <- speed_aggregate(tmp[regionSubsetList[[region]],,"Real Capacity Factor|Electricity|Wind (%)"],map,weight=output[regionSubsetList[[region]],,"Cap|Electricity|Wind (GW)"])
       tmp[region,,"Theoretical Capacity Factor|Electricity|Wind (%)"] <- speed_aggregate(tmp[regionSubsetList[[region]],,"Theoretical Capacity Factor|Electricity|Wind (%)"],map,weight=output[regionSubsetList[[region]],,"Cap|Electricity|Wind (GW)"])
@@ -225,7 +204,7 @@ reportCrossVariables <- function(gdx, output = NULL, regionSubsetList = NULL,
         #   natural inflows)
       / ( output[,,"SE|Electricity (EJ/yr)"]
           # default net imports to zero if not present in data
-        + dimSums(mselect(tmp, list(d3 = 'SE|Electricity|Net Imports (EJ/yr)')),
+        + dimSums(mselect(tmp, list(variable = 'SE|Electricity|Net Imports (EJ/yr)')),
                   dim = 3)
         ),
       "Secondary Energy|Electricity|Share of renewables in gross demand|Estimation (Percent)"))

--- a/R/reportLCOE.R
+++ b/R/reportLCOE.R
@@ -1187,7 +1187,7 @@ df.co2price.weighted <- df.pomeg.expand %>%
 ### Read SE Tax for Electrolysis ----
 
     # read SE tax for electrolysis from GDX
-    v21_tau_SE_tax <- readGDX(gdx, "v21_tau_SE_tax", field = "l", restore_zeros = F)
+    v21_tau_SE_tax <- readGDX(gdx, "v21_tau_SE_tax", field = "l", restore_zeros = F, react = "silent")
     # if not SE tax in run, set to 0
     if(is.null(v21_tau_SE_tax)) {
       v21_tau_SE_tax <- vm_costTeCapital

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.137.1**
+R package **remind2**, version **1.137.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.137.1, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.137.2, <URL: https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann},
   year = {2024},
-  note = {R package version 1.137.1},
+  note = {R package version 1.137.2},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/man/createVarListHtml.Rd
+++ b/man/createVarListHtml.Rd
@@ -43,7 +43,7 @@ detailsAR6 <-
   readr::read_delim(
     paste0(
       "https://raw.githubusercontent.com/pik-piam/",
-      "piamInterfaces/master/inst/templates/mapping_template_AR6.csv"),
+      "piamInterfaces/master/inst/mappings/mapping_AR6.csv"),
     delim = ";",
     col_select = c(r21m42, Definition)
   ) \%>\%


### PR DESCRIPTION
- is not in line with our moving averages etc.
- a bit dubious calculation
- not needed anymore in AR6 reporting etc.
- plus two small fixes