### PR TITLE
windon replaces wind in reporting (still compatible with wind)

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '230815200'
+ValidationKey: '2308447384985'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2308447384985'
+ValidationKey: '231038160'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.155.0.9001
-date-released: '2024-09-19'
+version: 1.156.0
+date-released: '2024-09-20'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.155.0
-date-released: '2024-09-18'
+version: 1.155.0.9001
+date-released: '2024-09-19'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.155.0
-Date: 2024-09-18
+Version: 1.155.0.9001
+Date: 2024-09-19
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.155.0.9001
-Date: 2024-09-19
+Version: 1.156.0
+Date: 2024-09-20
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportCapacity.R
+++ b/R/reportCapacity.R
@@ -25,7 +25,6 @@
 #' @importFrom dplyr %>% filter mutate
 
 reportCapacity <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150)) {
-
   # read sets
   teall2rlf   <- readGDX(gdx, name = c("te2rlf", "teall2rlf"), format = "first_found")
   possibleRefineries <- c("refped", "refdip", "refliq")
@@ -33,7 +32,7 @@ reportCapacity <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5
   ttot        <- readGDX(gdx, name = "ttot")
 
   # read parameters
-  pm_eta_conv <- readGDX(gdx, "pm_eta_conv", field = "l", restore_zeros = F)
+  pm_eta_conv <- readGDX(gdx, "pm_eta_conv", field = "l", restore_zeros = FALSE)
   pm_prodCouple <- readGDX(gdx, c("pm_prodCouple", "p_prodCouple", "p_dataoc"), restore_zeros = FALSE, format = "first_found")
 
   # read variables
@@ -67,10 +66,10 @@ reportCapacity <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5
   tmp1 <- NULL
   tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("tnrs", "fnrs")], dim = 3),                                 "Cap|Electricity|Nuclear (GW)"))
   tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("spv", "csp")], dim = 3),                                   "Cap|Electricity|Solar (GW)"))
-  if ("windoff" %in% magclass::getNames(vm_cap, dim = 1)) {
-    tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("wind", "windoff")], dim = 3),                            "Cap|Electricity|Wind (GW)"))
+  if ("windon" %in% magclass::getNames(vm_cap, dim = 1)) {
+    tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("windon", "windoff")], dim = 3),                          "Cap|Electricity|Wind (GW)"))
   } else {
-    tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , "wind"], dim = 3),                                          "Cap|Electricity|Wind (GW)"))
+    tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("wind", "windoff")], dim = 3),                            "Cap|Electricity|Wind (GW)"))
   }
   tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , "hydro"], dim = 3),                                           "Cap|Electricity|Hydro (GW)"))
   tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , "dot"], dim = 3),                                             "Cap|Electricity|Oil (GW)"))
@@ -98,43 +97,48 @@ reportCapacity <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5
   tmp7 <- mbind(tmp7, setNames(dimSums(tmp7, dim = 3),                      "Cap|Hydrogen (GW)"))
 
   tmp <- NULL
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "igccc"], dim = 3),                        "Cap|Electricity|Coal|IGCC|w/ CC (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "igcc"], dim = 3),                         "Cap|Electricity|Coal|IGCC|w/o CC (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "igccc"], dim = 3),                        "Cap|Electricity|Coal|w/ CC (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "coalchp"], dim = 3),                      "Cap|Electricity|Coal|CHP (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "ngccc"], dim = 3),                        "Cap|Electricity|Gas|CC|w/ CC (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "ngcc"], dim = 3),                         "Cap|Electricity|Gas|CC|w/o CC (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "ngccc"], dim = 3),                        "Cap|Electricity|Gas|w/ CC (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "ngt"], dim = 3),                          "Cap|Electricity|Gas|GT (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "gaschp"], dim = 3),                       "Cap|Electricity|Gas|CHP (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("igcc", "pc", "coalchp")], dim = 3),     "Cap|Electricity|Coal|w/o CC (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("ngcc", "ngt", "gaschp")], dim = 3),     "Cap|Electricity|Gas|w/o CC (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("bioigccc")], dim = 3),                  "Cap|Electricity|Biomass|w/ CC (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("biochp", "bioigcc")], dim = 3),         "Cap|Electricity|Biomass|w/o CC (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "biochp"], dim = 3),                       "Cap|Electricity|Biomass|CHP (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "dot"], dim = 3),                          "Cap|Electricity|Oil|w/o CC (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "spv"], dim = 3),                          "Cap|Electricity|Solar|PV (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "csp"], dim = 3),                          "Cap|Electricity|Solar|CSP (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "igccc"], dim = 3),                          "Cap|Electricity|Coal|IGCC|w/ CC (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "igcc"], dim = 3),                           "Cap|Electricity|Coal|IGCC|w/o CC (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "igccc"], dim = 3),                          "Cap|Electricity|Coal|w/ CC (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "coalchp"], dim = 3),                        "Cap|Electricity|Coal|CHP (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "ngccc"], dim = 3),                          "Cap|Electricity|Gas|CC|w/ CC (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "ngcc"], dim = 3),                           "Cap|Electricity|Gas|CC|w/o CC (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "ngccc"], dim = 3),                          "Cap|Electricity|Gas|w/ CC (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "ngt"], dim = 3),                            "Cap|Electricity|Gas|GT (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "gaschp"], dim = 3),                         "Cap|Electricity|Gas|CHP (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("igcc", "pc", "coalchp")], dim = 3),       "Cap|Electricity|Coal|w/o CC (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("ngcc", "ngt", "gaschp")], dim = 3),       "Cap|Electricity|Gas|w/o CC (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("bioigccc")], dim = 3),                    "Cap|Electricity|Biomass|w/ CC (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("biochp", "bioigcc")], dim = 3),           "Cap|Electricity|Biomass|w/o CC (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "biochp"], dim = 3),                         "Cap|Electricity|Biomass|CHP (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "dot"], dim = 3),                            "Cap|Electricity|Oil|w/o CC (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "spv"], dim = 3),                            "Cap|Electricity|Solar|PV (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "csp"], dim = 3),                            "Cap|Electricity|Solar|CSP (GW)"))
   tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("biochp", "gaschp", "coalchp")], dim = 3), "Cap|Electricity|CHP (GW)"))
 
-  if ("windoff" %in% magclass::getNames(vm_cap, dim = 1)) {
-    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "wind"], dim = 3),                "Cap|Electricity|Wind|Onshore (GW)"))
-    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "windoff"], dim = 3),             "Cap|Electricity|Wind|Offshore (GW)"))
-    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "storwindoff"], dim = 3) * 1.2,   "Cap|Electricity|Storage|Battery|For Wind Offshore (GW)"))
+  if ("windon" %in% magclass::getNames(vm_cap, dim = 1)) {
+    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "windon"], dim = 3),                       "Cap|Electricity|Wind|Onshore (GW)"))
+    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "windoff"], dim = 3),                      "Cap|Electricity|Wind|Offshore (GW)"))
+    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "storwindon"], dim = 3) * 1.2,             "Cap|Electricity|Storage|Battery|For Wind (GW)"))
+    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "storwindoff"], dim = 3) * 1.2,            "Cap|Electricity|Storage|Battery|For Wind Offshore (GW)"))
+  } else {
+    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "wind"], dim = 3),                         "Cap|Electricity|Wind|Onshore (GW)"))
+    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "windoff"], dim = 3),                      "Cap|Electricity|Wind|Offshore (GW)"))
+    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "storwind"], dim = 3) * 1.2,               "Cap|Electricity|Storage|Battery|For Wind (GW)"))
+    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "storwindoff"], dim = 3) * 1.2,            "Cap|Electricity|Storage|Battery|For Wind Offshore (GW)"))
   }
   tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "storspv"], dim = 3) * 4,         "Cap|Electricity|Storage|Battery|For PV (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "storwind"], dim = 3) * 1.2,      "Cap|Electricity|Storage|Battery|For Wind (GW)"))
 
   # heat
   tmp_chp <- NULL
   tmp_chp <- mbind(tmp_chp, setNames(dimSums(vm_cap[, , c("solhe")], dim = 3),                                                          "Cap|Heat|Solar (GW)"))
   tmp_chp <- mbind(tmp_chp, setNames(dimSums(vm_cap[, , c("geohe")], dim = 3),                                                          "Cap|Heat|Electricity|Heat Pump (GW)"))
   tmp_chp <- mbind(tmp_chp, setNames(dimSums(vm_cap[, , c("coalhp")], dim = 3)
-                                     + dimSums(vm_cap[, , c("coalchp")] * dataoc[,,"pecoal.seel.coalchp.sehe"], dim = 3, na.rm = TRUE), "Cap|Heat|Coal (GW)"))
+                                     + dimSums(vm_cap[, , c("coalchp")] * dataoc[, , "pecoal.seel.coalchp.sehe"], dim = 3, na.rm = TRUE), "Cap|Heat|Coal (GW)"))
   tmp_chp <- mbind(tmp_chp, setNames(dimSums(vm_cap[, , c("biohp")], dim = 3)
-                                     + dimSums(vm_cap[, , c("biochp")] * dataoc[,,"pebiolc.seel.biochp.sehe"], dim = 3, na.rm = TRUE),  "Cap|Heat|Biomass (GW)"))
+                                     + dimSums(vm_cap[, , c("biochp")] * dataoc[, , "pebiolc.seel.biochp.sehe"], dim = 3, na.rm = TRUE),  "Cap|Heat|Biomass (GW)"))
   tmp_chp <- mbind(tmp_chp, setNames(dimSums(vm_cap[, , c("gashp")], dim = 3)
-                                     + dimSums(vm_cap[, , c("gaschp")] * dataoc[,,"pegas.seel.gaschp.sehe"], dim = 3, na.rm = TRUE),    "Cap|Heat|Gas (GW)"))
+                                     + dimSums(vm_cap[, , c("gaschp")] * dataoc[, , "pegas.seel.gaschp.sehe"], dim = 3, na.rm = TRUE),    "Cap|Heat|Gas (GW)"))
   tmp_chp <- mbind(tmp_chp, setNames(dimSums(tmp_chp, dim = 3),                                                                         "Cap|Heat (GW)"))
   tmp <- mbind(tmp, tmp_chp)
 
@@ -146,26 +150,30 @@ reportCapacity <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5
   tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("h22ch4")], dim = 3), "Cap|Gases|Hydrogen (GW)"))
 
   # liquids
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("refliq", "bioftrec", "bioftcrec", "coalftrec", "coalftcrec", "MeOH","biodiesel", "bioeths", "bioethl")], dim = 3), "Cap|Liquids (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("refliq", "bioftrec", "bioftcrec", "coalftrec", "coalftcrec", "MeOH", "biodiesel", "bioeths", "bioethl")], dim = 3), "Cap|Liquids (GW)"))
   tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("refliq")], dim = 3), "Cap|Liquids|Oil (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("bioftrec", "bioftcrec","biodiesel", "bioeths", "bioethl")], dim = 3), "Cap|Liquids|Biomass (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("bioftrec", "bioftcrec", "biodiesel", "bioeths", "bioethl")], dim = 3), "Cap|Liquids|Biomass (GW)"))
   tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("coalftrec", "coalftcrec")], dim = 3), "Cap|Liquids|Coal (GW)"))
   tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("MeOH")], dim = 3), "Cap|Liquids|Hydrogen (GW)"))
 
   # carbon management
   if ("dac" %in% magclass::getNames(vm_cap, dim = 1)) {
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("dac")], dim = 3)*sm_c_2_co2, "Cap|Carbon Management|DAC (Mt CO2/yr)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("dac")], dim = 3) * sm_c_2_co2, "Cap|Carbon Management|DAC (Mt CO2/yr)"))
   }
 
   # Newly built capacities electricity (Should all go into tmp2, so that this can be used for calculating cumulated values in tmp5 below)
   tmp2 <- NULL
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("ngcc", "ngt", "gaschp", "ngccc")], dim = 3),            "New Cap|Electricity|Gas (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("igccc", "igcc", "pc", "coalchp")], dim = 3),            "New Cap|Electricity|Coal (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("bioigccc", "biochp", "bioigcc")], dim = 3),             "New Cap|Electricity|Biomass (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("geohdr", "hydro", "spv", "csp", "wind")], dim = 3),       "New Cap|Electricity|Non-Biomass Renewables (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("tnrs", "fnrs")], dim = 3),  "New Cap|Electricity|Nuclear (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "dot"], dim = 3),                      "New Cap|Electricity|Oil (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(tmp2, dim = 3),              "New Cap|Electricity (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("ngcc", "ngt", "gaschp", "ngccc")], dim = 3),        "New Cap|Electricity|Gas (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("igccc", "igcc", "pc", "coalchp")], dim = 3),        "New Cap|Electricity|Coal (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("bioigccc", "biochp", "bioigcc")], dim = 3),         "New Cap|Electricity|Biomass (GW/yr)"))
+  if ("windon" %in% magclass::getNames(vm_deltaCap, dim = 1)) {
+    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("geohdr", "hydro", "spv", "csp", "windon", "windoff")], dim = 3), "New Cap|Electricity|Non-Biomass Renewables (GW/yr)"))
+  } else {
+    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("geohdr", "hydro", "spv", "csp", "wind")], dim = 3), "New Cap|Electricity|Non-Biomass Renewables (GW/yr)"))
+  }
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("tnrs", "fnrs")], dim = 3),                          "New Cap|Electricity|Nuclear (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "dot"], dim = 3),                                      "New Cap|Electricity|Oil (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(tmp2, dim = 3),                                                        "New Cap|Electricity (GW/yr)"))
 
   tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "geohdr"], dim = 3),         "New Cap|Electricity|Geothermal (GW/yr)"))
   tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "igccc"], dim = 3),          "New Cap|Electricity|Coal|IGCC|w/ CC (GW/yr)"))
@@ -175,12 +183,14 @@ reportCapacity <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5
   tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "spv"], dim = 3),            "New Cap|Electricity|Solar|PV (GW/yr)"))
   tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "csp"], dim = 3),            "New Cap|Electricity|Solar|CSP (GW/yr)"))
 
-  if ("windoff" %in% magclass::getNames(vm_deltaCap, dim = 1)) {
-    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "wind"], dim = 3),           "New Cap|Electricity|Wind|Onshore (GW/yr)"))
-    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "windoff"], dim = 3),        "New Cap|Electricity|Wind|Offshore (GW/yr)"))
-    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("wind", "windoff")], dim = 3),    "New Cap|Electricity|Wind (GW/yr)"))
+  if ("windon" %in% magclass::getNames(vm_deltaCap, dim = 1)) {
+    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "windon"], dim = 3),               "New Cap|Electricity|Wind|Onshore (GW/yr)"))
+    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "windoff"], dim = 3),              "New Cap|Electricity|Wind|Offshore (GW/yr)"))
+    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("windon", "windoff")], dim = 3), "New Cap|Electricity|Wind (GW/yr)"))
   } else {
-    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "wind"], dim = 3),           "New Cap|Electricity|Wind (GW/yr)"))
+    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "wind"], dim = 3),                 "New Cap|Electricity|Wind|Onshore (GW/yr)"))
+    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "windoff"], dim = 3),              "New Cap|Electricity|Wind|Offshore (GW/yr)"))
+    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("wind", "windoff")], dim = 3),   "New Cap|Electricity|Wind (GW/yr)"))
   }
   tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "hydro"], dim = 3),         "New Cap|Electricity|Hydro (GW/yr)"))
   tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "ngccc"], dim = 3),          "New Cap|Electricity|Gas|w/ CC (GW/yr)"))
@@ -195,7 +205,12 @@ reportCapacity <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5
   tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("biochp", "bioigcc")], dim = 3),     "New Cap|Electricity|Biomass|w/o CC (GW/yr)"))
   tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("spv", "csp")], dim = 3),           "New Cap|Electricity|Solar (GW/yr)"))
   tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "storspv"], dim = 3) * 4,            "New Cap|Electricity|Storage|Battery|For PV (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "storwind"], dim = 3) * 1.2,         "New Cap|Electricity|Storage|Battery|For Wind (GW/yr)"))
+  if ("storwindon" %in% magclass::getNames(vm_deltaCap, dim = 1)) {
+    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("storwindon", "storwindoff")], dim = 3) * 1.2,   "New Cap|Electricity|Storage|Battery|For Wind (GW/yr)"))
+  } else {
+    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "storwind"], dim = 3) * 1.2,       "New Cap|Electricity|Storage|Battery|For Wind (GW/yr)"))
+  }
+
   # Newly built capacities hydrogen
   tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("bioh2c", "bioh2")], dim = 3),   "New Cap|Hydrogen|Biomass (GW/yr)"))
   tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("elh2", "elh2VRE")], dim = 3),                "New Cap|Hydrogen|Electricity (GW/yr)"))
@@ -218,11 +233,11 @@ reportCapacity <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5
   tmp_chpAdd <- mbind(tmp_chpAdd, setNames(dimSums(vm_deltaCap[, , c("solhe")], dim = 3),                                                       "New Cap|Heat|Solar (GW/yr)"))
   tmp_chpAdd <- mbind(tmp_chpAdd, setNames(dimSums(vm_deltaCap[, , c("geohe")], dim = 3),                                                       "New Cap|Heat|Electricity|Heat Pump (GW/yr)"))
   tmp_chpAdd <- mbind(tmp_chpAdd, setNames(dimSums(vm_deltaCap[, , c("coalhp")], dim = 3)
-                                           + dimSums(vm_deltaCap[, , c("coalchp")] * dataoc[,,"pecoal.seel.coalchp.sehe"], dim = 3, na.rm = T), "New Cap|Heat|Coal (GW/yr)"))
+                                           + dimSums(vm_deltaCap[, , c("coalchp")] * dataoc[, , "pecoal.seel.coalchp.sehe"], dim = 3, na.rm = TRUE), "New Cap|Heat|Coal (GW/yr)"))
   tmp_chpAdd <- mbind(tmp_chpAdd, setNames(dimSums(vm_deltaCap[, , c("biohp")], dim = 3)
-                                           + dimSums(vm_deltaCap[, , c("biochp")] * dataoc[,,"pebiolc.seel.biochp.sehe"], dim = 3, na.rm = T),  "New Cap|Heat|Biomass (GW/yr)"))
+                                           + dimSums(vm_deltaCap[, , c("biochp")] * dataoc[, , "pebiolc.seel.biochp.sehe"], dim = 3, na.rm = TRUE),  "New Cap|Heat|Biomass (GW/yr)"))
   tmp_chpAdd <- mbind(tmp_chpAdd, setNames(dimSums(vm_deltaCap[, , c("gashp")], dim = 3)
-                                           + dimSums(vm_deltaCap[, , c("gaschp")] * dataoc[,,"pegas.seel.gaschp.sehe"], dim = 3, na.rm = T),    "New Cap|Heat|Gas (GW/yr)"))
+                                           + dimSums(vm_deltaCap[, , c("gaschp")] * dataoc[, , "pegas.seel.gaschp.sehe"], dim = 3, na.rm = TRUE),    "New Cap|Heat|Gas (GW/yr)"))
   tmp_chpAdd <- mbind(tmp_chpAdd, setNames(dimSums(tmp_chpAdd, dim = 3),                                                                        "New Cap|Heat (GW/yr)"))
   tmp2 <- mbind(tmp2, tmp_chpAdd)
 
@@ -257,7 +272,7 @@ reportCapacity <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5
 
     # carbon management
     if ("dac" %in% magclass::getNames(vm_cap, dim = 1)) {
-    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("dac")], dim = 3)*sm_c_2_co2, "New Cap|Carbon Management|DAC (Mt CO2/yr/yr)"))
+    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("dac")], dim = 3) * sm_c_2_co2, "New Cap|Carbon Management|DAC (Mt CO2/yr/yr)"))
     }
 
 
@@ -323,7 +338,7 @@ reportCapacity <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5
 
 
 
-  magclass::getNames(tmp6)[grep("Cumulative Cap\\|Carbon Management", getNames(tmp6))] <- gsub("GW","Mt CO2/yr",
+  magclass::getNames(tmp6)[grep("Cumulative Cap\\|Carbon Management", getNames(tmp6))] <- gsub("GW", "Mt CO2/yr",
                                                                                                magclass::getNames(tmp6)[grep("Cumulative Cap\\|Carbon Management", getNames(tmp6))])
 
 

--- a/R/reportCapacity.R
+++ b/R/reportCapacity.R
@@ -61,40 +61,44 @@ reportCapacity <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5
 
   dataoc[dataoc < 0] <- 0
 
+  # determine whether onshore wind is called wind or windon
+  if ("windon" %in% magclass::getNames(vm_cap, dim = 1)) {
+    windonStr <- "windon"
+    storwindonStr <- "storwindon"
+  } else {
+    windonStr <- "wind"
+    storwindonStr <- "storwind"
+  }
 
   # build reporting
   tmp1 <- NULL
-  tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("tnrs", "fnrs")], dim = 3),                                 "Cap|Electricity|Nuclear (GW)"))
-  tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("spv", "csp")], dim = 3),                                   "Cap|Electricity|Solar (GW)"))
-  if ("windon" %in% magclass::getNames(vm_cap, dim = 1)) {
-    tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("windon", "windoff")], dim = 3),                          "Cap|Electricity|Wind (GW)"))
-  } else {
-    tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("wind", "windoff")], dim = 3),                            "Cap|Electricity|Wind (GW)"))
-  }
-  tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , "hydro"], dim = 3),                                           "Cap|Electricity|Hydro (GW)"))
-  tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , "dot"], dim = 3),                                             "Cap|Electricity|Oil (GW)"))
-  tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("igcc", "pc", "coalchp", "igccc")], dim = 3),               "Cap|Electricity|Coal (GW)"))
-  tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("ngcc", "ngt", "gaschp", "ngccc")], dim = 3),               "Cap|Electricity|Gas (GW)"))
-  tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("bioigccc", "biochp", "bioigcc")], dim = 3),                "Cap|Electricity|Biomass (GW)"))
-  tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , "geohdr"], dim = 3),                                          "Cap|Electricity|Geothermal (GW)"))
+  tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("tnrs", "fnrs")], dim = 3),                   "Cap|Electricity|Nuclear (GW)"))
+  tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("spv", "csp")], dim = 3),                     "Cap|Electricity|Solar (GW)"))
+  tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c(windonStr, "windoff")], dim = 3),             "Cap|Electricity|Wind (GW)"))
+  tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , "hydro"], dim = 3),                             "Cap|Electricity|Hydro (GW)"))
+  tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , "dot"], dim = 3),                               "Cap|Electricity|Oil (GW)"))
+  tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("igcc", "pc", "coalchp", "igccc")], dim = 3), "Cap|Electricity|Coal (GW)"))
+  tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("ngcc", "ngt", "gaschp", "ngccc")], dim = 3), "Cap|Electricity|Gas (GW)"))
+  tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("bioigccc", "biochp", "bioigcc")], dim = 3),  "Cap|Electricity|Biomass (GW)"))
+  tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , "geohdr"], dim = 3),                            "Cap|Electricity|Geothermal (GW)"))
   if (all(c("h2turbVRE", "h2turb") %in% magclass::getNames(vm_cap, dim = 1))) {
-    tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("h2turb", "h2turbVRE")], dim = 3),                        "Cap|Electricity|Hydrogen (GW)"))
+    tmp1 <- mbind(tmp1, setNames(dimSums(vm_cap[, , c("h2turb", "h2turbVRE")], dim = 3),          "Cap|Electricity|Hydrogen (GW)"))
   }
-  tmp1 <- mbind(tmp1, setNames(dimSums(tmp1, dim = 3),                                                          "Cap|Electricity (GW)"))
+  tmp1 <- mbind(tmp1, setNames(dimSums(tmp1, dim = 3),                                            "Cap|Electricity (GW)"))
 
   tmp7 <- NULL
-  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("gash2c")], dim = 3),         "Cap|Hydrogen|Gas|w/ CC (GW)"))
-  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("gash2")], dim = 3),         "Cap|Hydrogen|Gas|w/o CC (GW)"))
-  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("gash2", "gash2c")], dim = 3),         "Cap|Hydrogen|Gas (GW)"))
-  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("coalh2c")], dim = 3),         "Cap|Hydrogen|Coal|w/ CC (GW)"))
-  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("coalh2")], dim = 3),         "Cap|Hydrogen|Coal|w/o CC (GW)"))
-  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("coalh2", "coalh2c")], dim = 3),         "Cap|Hydrogen|Coal (GW)"))
-  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("bioh2c")], dim = 3),         "Cap|Hydrogen|Biomass|w/ CC (GW)"))
-  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("bioh2")], dim = 3),         "Cap|Hydrogen|Biomass|w/o CC (GW)"))
-  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("bioh2", "bioh2c")], dim = 3),         "Cap|Hydrogen|Biomass (GW)"))
-  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("elh2", "elh2VRE")], dim = 3),         "Cap|Hydrogen|Electricity (GW)"))
-  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("elh2", "elh2VRE")], dim = 3) / pm_eta_conv[, , "elh2"],         "Cap (GWel)|Hydrogen|Electricity (GW)"))
-  tmp7 <- mbind(tmp7, setNames(dimSums(tmp7, dim = 3),                      "Cap|Hydrogen (GW)"))
+  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("gash2c")], dim = 3),                                    "Cap|Hydrogen|Gas|w/ CC (GW)"))
+  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("gash2")], dim = 3),                                     "Cap|Hydrogen|Gas|w/o CC (GW)"))
+  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("gash2", "gash2c")], dim = 3),                           "Cap|Hydrogen|Gas (GW)"))
+  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("coalh2c")], dim = 3),                                   "Cap|Hydrogen|Coal|w/ CC (GW)"))
+  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("coalh2")], dim = 3),                                    "Cap|Hydrogen|Coal|w/o CC (GW)"))
+  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("coalh2", "coalh2c")], dim = 3),                         "Cap|Hydrogen|Coal (GW)"))
+  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("bioh2c")], dim = 3),                                    "Cap|Hydrogen|Biomass|w/ CC (GW)"))
+  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("bioh2")], dim = 3),                                     "Cap|Hydrogen|Biomass|w/o CC (GW)"))
+  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("bioh2", "bioh2c")], dim = 3),                           "Cap|Hydrogen|Biomass (GW)"))
+  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("elh2", "elh2VRE")], dim = 3),                           "Cap|Hydrogen|Electricity (GW)"))
+  tmp7 <- mbind(tmp7, setNames(dimSums(vm_cap[, , c("elh2", "elh2VRE")], dim = 3) / pm_eta_conv[, , "elh2"], "Cap (GWel)|Hydrogen|Electricity (GW)"))
+  tmp7 <- mbind(tmp7, setNames(dimSums(tmp7, dim = 3),                                                       "Cap|Hydrogen (GW)"))
 
   tmp <- NULL
   tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "igccc"], dim = 3),                          "Cap|Electricity|Coal|IGCC|w/ CC (GW)"))
@@ -112,22 +116,14 @@ reportCapacity <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5
   tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("biochp", "bioigcc")], dim = 3),           "Cap|Electricity|Biomass|w/o CC (GW)"))
   tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "biochp"], dim = 3),                         "Cap|Electricity|Biomass|CHP (GW)"))
   tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "dot"], dim = 3),                            "Cap|Electricity|Oil|w/o CC (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("biochp", "gaschp", "coalchp")], dim = 3), "Cap|Electricity|CHP (GW)"))
   tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "spv"], dim = 3),                            "Cap|Electricity|Solar|PV (GW)"))
   tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "csp"], dim = 3),                            "Cap|Electricity|Solar|CSP (GW)"))
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , c("biochp", "gaschp", "coalchp")], dim = 3), "Cap|Electricity|CHP (GW)"))
-
-  if ("windon" %in% magclass::getNames(vm_cap, dim = 1)) {
-    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "windon"], dim = 3),                       "Cap|Electricity|Wind|Onshore (GW)"))
-    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "windoff"], dim = 3),                      "Cap|Electricity|Wind|Offshore (GW)"))
-    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "storwindon"], dim = 3) * 1.2,             "Cap|Electricity|Storage|Battery|For Wind (GW)"))
-    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "storwindoff"], dim = 3) * 1.2,            "Cap|Electricity|Storage|Battery|For Wind Offshore (GW)"))
-  } else {
-    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "wind"], dim = 3),                         "Cap|Electricity|Wind|Onshore (GW)"))
-    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "windoff"], dim = 3),                      "Cap|Electricity|Wind|Offshore (GW)"))
-    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "storwind"], dim = 3) * 1.2,               "Cap|Electricity|Storage|Battery|For Wind (GW)"))
-    tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "storwindoff"], dim = 3) * 1.2,            "Cap|Electricity|Storage|Battery|For Wind Offshore (GW)"))
-  }
-  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "storspv"], dim = 3) * 4,         "Cap|Electricity|Storage|Battery|For PV (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , windonStr], dim = 3),                        "Cap|Electricity|Wind|Onshore (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "windoff"], dim = 3),                        "Cap|Electricity|Wind|Offshore (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "storspv"], dim = 3) * 4,                    "Cap|Electricity|Storage|Battery|For PV (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , storwindonStr], dim = 3) * 1.2,              "Cap|Electricity|Storage|Battery|For Wind (GW)"))
+  tmp <- mbind(tmp, setNames(dimSums(vm_cap[, , "storwindoff"], dim = 3) * 1.2,              "Cap|Electricity|Storage|Battery|For Wind Offshore (GW)"))
 
   # heat
   tmp_chp <- NULL
@@ -166,50 +162,38 @@ reportCapacity <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5
   tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("ngcc", "ngt", "gaschp", "ngccc")], dim = 3),        "New Cap|Electricity|Gas (GW/yr)"))
   tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("igccc", "igcc", "pc", "coalchp")], dim = 3),        "New Cap|Electricity|Coal (GW/yr)"))
   tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("bioigccc", "biochp", "bioigcc")], dim = 3),         "New Cap|Electricity|Biomass (GW/yr)"))
-  if ("windon" %in% magclass::getNames(vm_deltaCap, dim = 1)) {
-    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("geohdr", "hydro", "spv", "csp", "windon", "windoff")], dim = 3), "New Cap|Electricity|Non-Biomass Renewables (GW/yr)"))
-  } else {
-    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("geohdr", "hydro", "spv", "csp", "wind")], dim = 3), "New Cap|Electricity|Non-Biomass Renewables (GW/yr)"))
-  }
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("geohdr", "hydro", "spv", "csp", windonStr, "windoff")], dim = 3), "New Cap|Electricity|Non-Biomass Renewables (GW/yr)"))
+
   tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("tnrs", "fnrs")], dim = 3),                          "New Cap|Electricity|Nuclear (GW/yr)"))
   tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "dot"], dim = 3),                                      "New Cap|Electricity|Oil (GW/yr)"))
   tmp2 <- mbind(tmp2, setNames(dimSums(tmp2, dim = 3),                                                        "New Cap|Electricity (GW/yr)"))
 
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "geohdr"], dim = 3),         "New Cap|Electricity|Geothermal (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "igccc"], dim = 3),          "New Cap|Electricity|Coal|IGCC|w/ CC (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "igcc"], dim = 3),           "New Cap|Electricity|Coal|IGCC|w/o CC (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "ngccc"], dim = 3),          "New Cap|Electricity|Gas|CC|w/ CC (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "ngcc"], dim = 3),           "New Cap|Electricity|Gas|CC|w/o CC (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "spv"], dim = 3),            "New Cap|Electricity|Solar|PV (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "csp"], dim = 3),            "New Cap|Electricity|Solar|CSP (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "geohdr"], dim = 3),                "New Cap|Electricity|Geothermal (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "igccc"], dim = 3),                 "New Cap|Electricity|Coal|IGCC|w/ CC (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "igcc"], dim = 3),                  "New Cap|Electricity|Coal|IGCC|w/o CC (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "ngccc"], dim = 3),                 "New Cap|Electricity|Gas|CC|w/ CC (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "ngcc"], dim = 3),                  "New Cap|Electricity|Gas|CC|w/o CC (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "spv"], dim = 3),                   "New Cap|Electricity|Solar|PV (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "csp"], dim = 3),                   "New Cap|Electricity|Solar|CSP (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , windonStr], dim = 3),               "New Cap|Electricity|Wind|Onshore (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "windoff"], dim = 3),               "New Cap|Electricity|Wind|Offshore (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c(windonStr, "windoff")], dim = 3), "New Cap|Electricity|Wind (GW/yr)"))
 
-  if ("windon" %in% magclass::getNames(vm_deltaCap, dim = 1)) {
-    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "windon"], dim = 3),               "New Cap|Electricity|Wind|Onshore (GW/yr)"))
-    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "windoff"], dim = 3),              "New Cap|Electricity|Wind|Offshore (GW/yr)"))
-    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("windon", "windoff")], dim = 3), "New Cap|Electricity|Wind (GW/yr)"))
-  } else {
-    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "wind"], dim = 3),                 "New Cap|Electricity|Wind|Onshore (GW/yr)"))
-    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "windoff"], dim = 3),              "New Cap|Electricity|Wind|Offshore (GW/yr)"))
-    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("wind", "windoff")], dim = 3),   "New Cap|Electricity|Wind (GW/yr)"))
-  }
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "hydro"], dim = 3),         "New Cap|Electricity|Hydro (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "ngccc"], dim = 3),          "New Cap|Electricity|Gas|w/ CC (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("ngcc", "ngt", "gaschp")], dim = 3), "New Cap|Electricity|Gas|w/o CC (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "ngt"], dim = 3),            "New Cap|Electricity|Gas|GT (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "hydro"], dim = 3),                     "New Cap|Electricity|Hydro (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "ngccc"], dim = 3),                     "New Cap|Electricity|Gas|w/ CC (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("ngcc", "ngt", "gaschp")], dim = 3),  "New Cap|Electricity|Gas|w/o CC (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "ngt"], dim = 3),                       "New Cap|Electricity|Gas|GT (GW/yr)"))
   if (all(c("h2turbVRE", "h2turb") %in% magclass::getNames(vm_cap, dim = 1))) {
-    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("h2turb", "h2turbVRE")], dim = 3),            "New Cap|Electricity|Hydrogen (GW/yr)"))
+    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("h2turb", "h2turbVRE")], dim = 3),  "New Cap|Electricity|Hydrogen (GW/yr)"))
   }
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "igccc"], dim = 3),                    "New Cap|Electricity|Coal|w/ CC (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("igcc", "pc", "coalchp")], dim = 3), "New Cap|Electricity|Coal|w/o CC (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "bioigccc"], dim = 3),                 "New Cap|Electricity|Biomass|w/ CC (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("biochp", "bioigcc")], dim = 3),     "New Cap|Electricity|Biomass|w/o CC (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("spv", "csp")], dim = 3),           "New Cap|Electricity|Solar (GW/yr)"))
-  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "storspv"], dim = 3) * 4,            "New Cap|Electricity|Storage|Battery|For PV (GW/yr)"))
-  if ("storwindon" %in% magclass::getNames(vm_deltaCap, dim = 1)) {
-    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("storwindon", "storwindoff")], dim = 3) * 1.2,   "New Cap|Electricity|Storage|Battery|For Wind (GW/yr)"))
-  } else {
-    tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "storwind"], dim = 3) * 1.2,       "New Cap|Electricity|Storage|Battery|For Wind (GW/yr)"))
-  }
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "igccc"], dim = 3),                     "New Cap|Electricity|Coal|w/ CC (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("igcc", "pc", "coalchp")], dim = 3),  "New Cap|Electricity|Coal|w/o CC (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "bioigccc"], dim = 3),                  "New Cap|Electricity|Biomass|w/ CC (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("biochp", "bioigcc")], dim = 3),      "New Cap|Electricity|Biomass|w/o CC (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("spv", "csp")], dim = 3),             "New Cap|Electricity|Solar (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , "storspv"], dim = 3) * 4,               "New Cap|Electricity|Storage|Battery|For PV (GW/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c(storwindonStr, "storwindoff")], dim = 3) * 1.2, "New Cap|Electricity|Storage|Battery|For Wind (GW/yr)"))
+
 
   # Newly built capacities hydrogen
   tmp2 <- mbind(tmp2, setNames(dimSums(vm_deltaCap[, , c("bioh2c", "bioh2")], dim = 3),   "New Cap|Hydrogen|Biomass (GW/yr)"))

--- a/R/reportCosts.R
+++ b/R/reportCosts.R
@@ -234,7 +234,7 @@ reportCosts <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,
     out <- dimSums(                                       # sum OMF over technologies (fixed operation & maintenance costs)
       collapseNames(pm_data[,,"omf"])[,,e2e_allte] *
         (dimSums((v_investcost[,,e2e_allte] * vm_cap[,,e2e_allte])[teall2rlf],dim=3.2,na.rm=T)   # sum over rlf
-        )[,, e2e_allte],dim=3, na.rm=T) # windoffshore-todo: was e2e_allte, but need something like teall2rlf$e2e_allte to prevent problems when wind is absent
+        )[,, e2e_allte],dim=3, na.rm=T)
 
     if(!is.null(vm_prodE) & !length(e2e_allte)==0) {     # if either SE or FE is produced, then variable O&M is added
        out <- out + dimSums(collapseNames(pm_data[,,"omv"])[,,sub_e2e$all_te] * dimSums(vm_prodE[sub_e2e],dim=c(3.1,3.2),na.rm=T)

--- a/R/reportCosts.R
+++ b/R/reportCosts.R
@@ -234,7 +234,7 @@ reportCosts <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,
     out <- dimSums(                                       # sum OMF over technologies
       collapseNames(pm_data[,,"omf"])[,,e2e_allte] *
         (dimSums((v_investcost[,,e2e_allte] * vm_cap[,,e2e_allte])[teall2rlf],dim=3.2,na.rm=T)   # sum over rlf
-        )[,, e2e_allte],dim=3, na.rm=T)
+        )[,, e2e_allte],dim=3, na.rm=T) # windoffshore-todo: was e2e_allte, but need something like teall2rlf$e2e_allte to prevent problems when wind is absent
 
     if(!is.null(vm_prodE) & !length(e2e_allte)==0) {     # if either SE or FE is produced, then variable O&M is added
        out <- out + dimSums(collapseNames(pm_data[,,"omv"])[,,sub_e2e$all_te] * dimSums(vm_prodE[sub_e2e],dim=c(3.1,3.2),na.rm=T)

--- a/R/reportCosts.R
+++ b/R/reportCosts.R
@@ -222,16 +222,16 @@ reportCosts <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,
   op_costs <- function(ei,eo,te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=NULL,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost) {
     # Check whether a mapping with energy transfering technologies is given or just technologies
     if (!is.null(e2e)) {
-      sub_e2e         <- e2e[(e2e$all_enty %in% ei) & (e2e$all_enty1 %in% eo) & (e2e$all_te %in% te),]
+      sub_e2e         <- e2e[(e2e$all_enty %in% ei) & (e2e$all_enty1 %in% eo) & (e2e$all_te %in% te) & (e2e$all_te %in% teall2rlf$all_te),]
       # Save technologies to extra variables because in the "else" case there is no sub_e2e list that could be used
       e2e_allte       <- sub_e2e$all_te
     } else {
-      e2e_allte       <- te
+      e2e_allte       <- intersect(te, teall2rlf$all_te)
     }
 
     vm_cap <- dimSums(vm_cap,dim=3.2,na.rm = T) # get rid of grades which are not used in calculations below because all other variables dont have them neither
 
-    out <- dimSums(                                       # sum OMF over technologies
+    out <- dimSums(                                       # sum OMF over technologies (fixed operation & maintenance costs)
       collapseNames(pm_data[,,"omf"])[,,e2e_allte] *
         (dimSums((v_investcost[,,e2e_allte] * vm_cap[,,e2e_allte])[teall2rlf],dim=3.2,na.rm=T)   # sum over rlf
         )[,, e2e_allte],dim=3, na.rm=T) # windoffshore-todo: was e2e_allte, but need something like teall2rlf$e2e_allte to prevent problems when wind is absent

--- a/R/reportEnergyInvestment.R
+++ b/R/reportEnergyInvestment.R
@@ -115,13 +115,11 @@ reportEnergyInvestment <- function(gdx, regionSubsetList = NULL, t = c(seq(2005,
   tmp <- mbind(tmp, setNames(inv_se(ie = "pebiolc", te = tenoccs, oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv), "Energy Investments|Electricity|Biomass|+|w/o CC (billion US$2005/yr)"))
   tmp <- mbind(tmp, setNames(inv_se(ie = "peur", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv),                  "Energy Investments|Electricity|+|Nuclear (billion US$2005/yr)"))
   tmp <- mbind(tmp, setNames(inv_se(ie = "pesol", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv),                 "Energy Investments|Electricity|+|Solar (billion US$2005/yr)"))
-  if ("windon" %in% all_te) {
-    tmp <- mbind(tmp, setNames(inv_se(ie = "pewin", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv, te = "windon"),  "Energy Investments|Electricity|Wind|+|Onshore (billion US$2005/yr)"))
-    tmp <- mbind(tmp, setNames(inv_se(ie = "pewin", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv, te = "windoff"),   "Energy Investments|Electricity|Wind|+|Offshore (billion US$2005/yr)"))
-  } else {
-    tmp <- mbind(tmp, setNames(inv_se(ie = "pewin", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv, te = "wind"),    "Energy Investments|Electricity|Wind|+|Onshore (billion US$2005/yr)"))
-    tmp <- mbind(tmp, setNames(inv_se(ie = "pewin", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv, te = "windoff"),   "Energy Investments|Electricity|Wind|+|Offshore (billion US$2005/yr)"))
-  }
+  
+  windonStr <- ifelse ("windon" %in% all_te, "windon", "wind")
+  tmp <- mbind(tmp, setNames(inv_se(ie = "pewin", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv, te = windonStr),  "Energy Investments|Electricity|Wind|+|Onshore (billion US$2005/yr)"))
+  tmp <- mbind(tmp, setNames(inv_se(ie = "pewin", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv, te = "windoff"),   "Energy Investments|Electricity|Wind|+|Offshore (billion US$2005/yr)"))
+
   tmp <- mbind(tmp, setNames(inv_se(ie = "pewin", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv),                 "Energy Investments|Electricity|+|Wind (billion US$2005/yr)"))
   tmp <- mbind(tmp, setNames(inv_se(ie = "pehyd", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv),                 "Energy Investments|Electricity|+|Hydro (billion US$2005/yr)"))
   tmp <- mbind(tmp, setNames(inv_se(ie = "pegeo", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv),                 "Energy Investments|Electricity|+|Geothermal (billion US$2005/yr)"))

--- a/R/reportEnergyInvestment.R
+++ b/R/reportEnergyInvestment.R
@@ -115,7 +115,7 @@ reportEnergyInvestment <- function(gdx, regionSubsetList = NULL, t = c(seq(2005,
   tmp <- mbind(tmp, setNames(inv_se(ie = "pebiolc", te = tenoccs, oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv), "Energy Investments|Electricity|Biomass|+|w/o CC (billion US$2005/yr)"))
   tmp <- mbind(tmp, setNames(inv_se(ie = "peur", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv),                  "Energy Investments|Electricity|+|Nuclear (billion US$2005/yr)"))
   tmp <- mbind(tmp, setNames(inv_se(ie = "pesol", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv),                 "Energy Investments|Electricity|+|Solar (billion US$2005/yr)"))
-  if ("windon" %in% te) {
+  if ("windon" %in% all_te) {
     tmp <- mbind(tmp, setNames(inv_se(ie = "pewin", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv, te = "windon"),  "Energy Investments|Electricity|Wind|+|Onshore (billion US$2005/yr)"))
     tmp <- mbind(tmp, setNames(inv_se(ie = "pewin", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv, te = "windoff"),   "Energy Investments|Electricity|Wind|+|Offshore (billion US$2005/yr)"))
   } else {

--- a/R/reportEnergyInvestment.R
+++ b/R/reportEnergyInvestment.R
@@ -24,7 +24,6 @@
 #' @importFrom gdx readGDX
 
 reportEnergyInvestment <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150)) {
-
   # read sets
   te      <- readGDX(gdx, "te", format = "first_found")
   adjte   <- readGDX(gdx, name = c("teAdj", "adjte"), format = "first_found")
@@ -63,7 +62,7 @@ reportEnergyInvestment <- function(gdx, regionSubsetList = NULL, t = c(seq(2005,
   ttot <- as.numeric(as.vector(readGDX(gdx, "ttot", format = "first_found")))
   v_directteinv <- v_directteinv[, ttot, ]
   v_adjustteinv <- v_adjustteinv[, ttot, ]
-  costRatioTdelt2Tdels <- pm_data[,,"inco0.tdelt"]/pm_data[,,"inco0.tdels"]
+  costRatioTdelt2Tdels <- pm_data[, , "inco0.tdelt"] / pm_data[, , "inco0.tdels"]
 
 
   ####### internal function for reporting ###########
@@ -84,11 +83,11 @@ reportEnergyInvestment <- function(gdx, regionSubsetList = NULL, t = c(seq(2005,
       x1 <- dimSums(v_directteinv[, , sub1_pe2se], dim = 3) * 1000
       x2 <- dimSums(v_directteinv[, , sub2_pe2se] + v_adjustteinv[, , sub2_pe2se], dim = 3) * 1000
     }
-    if(is.magpie(x1) & is.magpie(x2)){
+    if (is.magpie(x1) & is.magpie(x2)) {
       out <- (x1 + x2)
-    } else if(is.magpie(x1)){
+    } else if (is.magpie(x1)) {
       out <- x1
-    } else if(is.magpie(x2)){
+    } else if (is.magpie(x2)) {
       out <- x2
     } else {
       out <- NULL
@@ -116,9 +115,12 @@ reportEnergyInvestment <- function(gdx, regionSubsetList = NULL, t = c(seq(2005,
   tmp <- mbind(tmp, setNames(inv_se(ie = "pebiolc", te = tenoccs, oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv), "Energy Investments|Electricity|Biomass|+|w/o CC (billion US$2005/yr)"))
   tmp <- mbind(tmp, setNames(inv_se(ie = "peur", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv),                  "Energy Investments|Electricity|+|Nuclear (billion US$2005/yr)"))
   tmp <- mbind(tmp, setNames(inv_se(ie = "pesol", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv),                 "Energy Investments|Electricity|+|Solar (billion US$2005/yr)"))
-  if ("windoff" %in% te) {
-    tmp <- mbind(tmp, setNames(inv_se(ie = "pewin", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv, te="wind"),    "Energy Investments|Electricity|Wind|+|Onshore (billion US$2005/yr)"))
-    tmp <- mbind(tmp, setNames(inv_se(ie = "pewin", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv, te="windoff"), "Energy Investments|Electricity|Wind|+|Offshore (billion US$2005/yr)"))
+  if ("windon" %in% te) {
+    tmp <- mbind(tmp, setNames(inv_se(ie = "pewin", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv, te = "windon"),  "Energy Investments|Electricity|Wind|+|Onshore (billion US$2005/yr)"))
+    tmp <- mbind(tmp, setNames(inv_se(ie = "pewin", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv, te = "windoff"),   "Energy Investments|Electricity|Wind|+|Offshore (billion US$2005/yr)"))
+  } else {
+    tmp <- mbind(tmp, setNames(inv_se(ie = "pewin", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv, te = "wind"),    "Energy Investments|Electricity|Wind|+|Onshore (billion US$2005/yr)"))
+    tmp <- mbind(tmp, setNames(inv_se(ie = "pewin", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv, te = "windoff"),   "Energy Investments|Electricity|Wind|+|Offshore (billion US$2005/yr)"))
   }
   tmp <- mbind(tmp, setNames(inv_se(ie = "pewin", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv),                 "Energy Investments|Electricity|+|Wind (billion US$2005/yr)"))
   tmp <- mbind(tmp, setNames(inv_se(ie = "pehyd", oe = "seel", pe2se, adjte, v_directteinv, v_adjustteinv),                 "Energy Investments|Electricity|+|Hydro (billion US$2005/yr)"))
@@ -126,9 +128,9 @@ reportEnergyInvestment <- function(gdx, regionSubsetList = NULL, t = c(seq(2005,
   tmp <- mbind(tmp, setNames(inv_se(ie = NULL, oe = NULL, stor, adjte, v_directteinv, v_adjustteinv, te = all_te),          "Energy Investments|Electricity|+|Storage (billion US$2005/yr)"))
   tmp <- mbind(tmp, setNames(inv_se(ie = NULL, oe = NULL, c("tdels", "tdelt", grid), adjte, v_directteinv, v_adjustteinv, te = all_te), "Energy Investments|Electricity|+|Grid (billion US$2005/yr)"))
 # split out the amount of "normal" grid, the additional grid/charger investments due to electric vehicles, and the additional grid investments needed for better pooling of VRE. For BEVs, the assumption is to only take the share of tdelt costs that are higher than the tdels costs
-  tmp <- mbind(tmp, setNames(inv_se(ie = NULL, oe = NULL, c("tdelt"), adjte, v_directteinv, v_adjustteinv, te = all_te) * (costRatioTdelt2Tdels - 1)/costRatioTdelt2Tdels, "Energy Investments|Electricity|Grid|+|BEV Chargers (billion US$2005/yr)"))
+  tmp <- mbind(tmp, setNames(inv_se(ie = NULL, oe = NULL, c("tdelt"), adjte, v_directteinv, v_adjustteinv, te = all_te) * (costRatioTdelt2Tdels - 1) / costRatioTdelt2Tdels, "Energy Investments|Electricity|Grid|+|BEV Chargers (billion US$2005/yr)"))
   tmp <- mbind(tmp, setNames(inv_se(ie = NULL, oe = NULL, c("tdels"), adjte, v_directteinv, v_adjustteinv, te = all_te)
-                             + inv_se(ie = NULL, oe = NULL, c("tdelt"), adjte, v_directteinv, v_adjustteinv, te = all_te) * 1/costRatioTdelt2Tdels, "Energy Investments|Electricity|Grid|+|Normal (billion US$2005/yr)"))
+                             + inv_se(ie = NULL, oe = NULL, c("tdelt"), adjte, v_directteinv, v_adjustteinv, te = all_te) * 1 / costRatioTdelt2Tdels, "Energy Investments|Electricity|Grid|+|Normal (billion US$2005/yr)"))
   tmp <- mbind(tmp, setNames(inv_se(ie = NULL, oe = NULL, c(grid), adjte, v_directteinv, v_adjustteinv, te = all_te), "Energy Investments|Electricity|Grid|+|VRE support (billion US$2005/yr)"))
 
 
@@ -146,7 +148,7 @@ reportEnergyInvestment <- function(gdx, regionSubsetList = NULL, t = c(seq(2005,
 
   tmp <- mbind(tmp, setNames(inv_se(ie = pe2se$all_enty, oe = "seh2", pe2se, adjte, v_directteinv, v_adjustteinv), "Energy Investments|Hydrogen|PE (billion US$2005/yr)"))
   tmp <- mbind(tmp, setNames(inv_se(ie = "seel", oe = "seh2", se2se, adjte, v_directteinv, v_adjustteinv, te = se2se$all_te), "Energy Investments|Hydrogen|se2se (billion US$2005/yr)"))
-  tmp <- mbind(tmp, setNames( inv_se(ie = "seh2", oe = se2fe$all_enty1, se2fe, adjte, v_directteinv, v_adjustteinv, te = se2fe$all_te), "Energy Investments|Hydrogen|se2fe (billion US$2005/yr)"))
+  tmp <- mbind(tmp, setNames(inv_se(ie = "seh2", oe = se2fe$all_enty1, se2fe, adjte, v_directteinv, v_adjustteinv, te = se2fe$all_te), "Energy Investments|Hydrogen|se2fe (billion US$2005/yr)"))
 
 
   tmp <- mbind(tmp, setNames(inv_se(ie = petyf, oe = "seh2", pe2se, adjte, v_directteinv, v_adjustteinv),             "Energy Investments|Hydrogen|+|Fossil (billion US$2005/yr)"))
@@ -157,7 +159,7 @@ reportEnergyInvestment <- function(gdx, regionSubsetList = NULL, t = c(seq(2005,
 
   # Liquids
   tmp <- mbind(tmp, setNames((inv_se(ie = pe2se$all_enty, oe = se_Liq, pe2se, adjte, v_directteinv, v_adjustteinv)
-  + inv_se(ie = se2se$all_enty, oe = se_Liq, se2se, adjte, v_directteinv, v_adjustteinv, te = se2se$all_te)  ),                             "Energy Investments|Liquids (billion US$2005/yr)"))
+  + inv_se(ie = se2se$all_enty, oe = se_Liq, se2se, adjte, v_directteinv, v_adjustteinv, te = se2se$all_te)),                             "Energy Investments|Liquids (billion US$2005/yr)"))
   tmp <- mbind(tmp, setNames(inv_se(ie = "peoil", oe = se_Liq, pe2se, adjte, v_directteinv, v_adjustteinv),                                 "Energy Investments|Liquids|Oil Ref (billion US$2005/yr)"))
   tmp <- mbind(tmp, setNames(inv_se(ie = petyf, oe = se_Liq, pe2se, adjte, v_directteinv, v_adjustteinv),                                   "Energy Investments|Liquids|+|Fossil (billion US$2005/yr)"))
   tmp <- mbind(tmp, setNames(inv_se(ie = "pecoal", oe = se_Liq, pe2se, adjte, v_directteinv, v_adjustteinv)

--- a/R/reportLCOE.R
+++ b/R/reportLCOE.R
@@ -360,31 +360,20 @@ v33_emiEW <- add_columns(v33_emiEW, addnm = c("y2005", "y2010", "y2015", "y2020"
  te_annual_grid_cost_wadj <- new.magpie(getRegions(te_inv_annuity), ttot_from2005, magclass::getNames(te_inv_annuity), fill = 0)
 
 
-  if ("windon" %in% all_te) {
-    te_annual_grid_cost[, , te2grid$all_te] <-
-      collapseNames(te_annual_inv_cost[, ttot_from2005, "gridwindon"] + te_annual_OMF_cost[, , "gridwindon"]) *
-      1 / vm_VRE_prodSe_grid *
-      # this multiplcative factor is added to reflect higher grid demand of wind, see q32_limitCapTeGrid
-      grid_factor_tech * vm_prodSe[, , te2grid$all_te]
+gridwindonStr <- ifelse("windon" %in% all_te, "gridwindon", "gridwind")
 
-    te_annual_grid_cost_wadj[, , te2grid$all_te] <-
-      collapseNames(te_annual_inv_cost_wadj[, ttot_from2005, "gridwindon"] + te_annual_OMF_cost[, , "gridwindon"]) *
-      1 / vm_VRE_prodSe_grid *
-      # this multiplcative factor is added to reflect higher grid demand of wind, see q32_limitCapTeGrid
-      grid_factor_tech * vm_prodSe[, , te2grid$all_te]
-  } else {
-    te_annual_grid_cost[, , te2grid$all_te] <-
-      collapseNames(te_annual_inv_cost[, ttot_from2005, "gridwind"] + te_annual_OMF_cost[, , "gridwind"]) *
-      1 / vm_VRE_prodSe_grid *
-      # this multiplcative factor is added to reflect higher grid demand of wind, see q32_limitCapTeGrid
-      grid_factor_tech * vm_prodSe[, , te2grid$all_te]
+te_annual_grid_cost[, , te2grid$all_te] <-
+  collapseNames(te_annual_inv_cost[, ttot_from2005, gridwindonStr] + te_annual_OMF_cost[, , gridwindonStr]) *
+  1 / vm_VRE_prodSe_grid *
+  # this multiplcative factor is added to reflect higher grid demand of wind, see q32_limitCapTeGrid
+  grid_factor_tech * vm_prodSe[, , te2grid$all_te]
 
-    te_annual_grid_cost_wadj[, , te2grid$all_te] <-
-      collapseNames(te_annual_inv_cost_wadj[, ttot_from2005, "gridwind"] + te_annual_OMF_cost[, , "gridwind"]) *
-      1 / vm_VRE_prodSe_grid *
-      # this multiplcative factor is added to reflect higher grid demand of wind, see q32_limitCapTeGrid
-      grid_factor_tech * vm_prodSe[, , te2grid$all_te]
-  }
+te_annual_grid_cost_wadj[, , te2grid$all_te] <-
+  collapseNames(te_annual_inv_cost_wadj[, ttot_from2005, gridwindonStr] + te_annual_OMF_cost[, , gridwindonStr]) *
+  1 / vm_VRE_prodSe_grid *
+  # this multiplcative factor is added to reflect higher grid demand of wind, see q32_limitCapTeGrid
+  grid_factor_tech * vm_prodSe[, , te2grid$all_te]
+  
 
 
  # 7. sub-part: ccs injection cost (for technologies capturing CO2) ----

--- a/R/reportLCOE.R
+++ b/R/reportLCOE.R
@@ -19,8 +19,9 @@
 #' @author Felix Schreyer, Robert Pietzcker, Lavinia Baumstark
 #' @seealso \code{\link{convGDX2MIF_LCOE}}
 #' @examples
-#'
-#' \dontrun{reportLCOE(gdx)}
+#' \dontrun{
+#' reportLCOE(gdx)
+#' }
 #'
 #' @export
 #' @importFrom gdx readGDX
@@ -31,31 +32,30 @@
 
 
 
-reportLCOE <- function(gdx, output.type = "both"){
-
+reportLCOE <- function(gdx, output.type = "both") {
  # test whether output.type defined
  if (!output.type %in% c("marginal", "average", "both", "marginal detail")) {
    print("Unknown output type. Please choose either marginal, average, both or marginal detail.")
    return(new.magpie(cells_and_regions = "GLO",
-                     years = c(seq(2005,2060,5),seq(2070,2110,10),2130,2150)))
+                     years = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150)))
  }
 
  # check whether key variables are there
  # LCOE reporting does not make sense for old gdx
  # where variables are missing and model structure is different
 
- vm_capFac <- readGDX(gdx, "vm_capFac", field = "l", restore_zeros = F)
- qm_balcapture  <- readGDX(gdx,"q_balcapture",field="m", restore_zeros = F)
- vm_co2CCS <- readGDX(gdx, "vm_co2CCS", field = "l", restore_zeros = F)
- vm_co2capture <- readGDX(gdx, "vm_co2capture", field="l", restore_zeros = F)
- pm_emifac <- readGDX(gdx, "pm_emiFac", field = "l", restore_zeros = F)
+ vm_capFac <- readGDX(gdx, "vm_capFac", field = "l", restore_zeros = FALSE)
+ qm_balcapture  <- readGDX(gdx, "q_balcapture", field = "m", restore_zeros = FALSE)
+ vm_co2CCS <- readGDX(gdx, "vm_co2CCS", field = "l", restore_zeros = FALSE)
+ vm_co2capture <- readGDX(gdx, "vm_co2capture", field = "l", restore_zeros = FALSE)
+ pm_emifac <- readGDX(gdx, "pm_emiFac", field = "l", restore_zeros = FALSE)
  v32_storloss <- readGDX(gdx, "v32_storloss", field = "l")
 
  if (is.null(vm_capFac) | is.null(qm_balcapture) | is.null(vm_co2CCS) |
      is.null(pm_emifac) | is.null(v32_storloss)) {
    print("The gdx file is too old for generating a LCOE reporting...returning NULL")
    return(new.magpie(cells_and_regions = "GLO",
-                     years = c(seq(2005,2060,5),seq(2070,2110,10),2130,2150)))
+                     years = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150)))
  }
 
 
@@ -63,98 +63,101 @@ reportLCOE <- function(gdx, output.type = "both"){
  module2realisation <- readGDX(gdx, "module2realisation")
  rownames(module2realisation) <- module2realisation$modules
 
- #initialize output array
+ # initialize output array
  LCOE.out <- NULL
 
 
  # read in general data (needed for average and marginal LCOE calculation)
- s_twa2mwh <- readGDX(gdx,c("sm_TWa_2_MWh","s_TWa_2_MWh","s_twa2mwh"),format="first_found")
- s_GtC2tCO2 <-  10^9 * readGDX(gdx,c("sm_c_2_co2","s_c_2_co2"),format="first_found")
- ttot     <- as.numeric(readGDX(gdx,"ttot"))
- ttot_before2005 <- paste0("y",ttot[which(ttot <= 2000)])
- ttot_from2005 <- paste0("y",ttot[which(ttot >= 2005)])
- te        <- readGDX(gdx,"te")
- te <- te[!te %in% c("lng_liq","gas_pipe", "lng_gas", "lng_ves", "coal_ves", "pipe_gas", "termX_lng", "termM_lng", "vess_lng")]
- p_priceCO2 <- readGDX(gdx,name=c("p_priceCO2","pm_priceCO2"),format="first_found") # co2 price
+ s_twa2mwh <- readGDX(gdx, c("sm_TWa_2_MWh", "s_TWa_2_MWh", "s_twa2mwh"), format = "first_found")
+ s_GtC2tCO2 <-  10^9 * readGDX(gdx, c("sm_c_2_co2", "s_c_2_co2"), format = "first_found")
+ ttot     <- as.numeric(readGDX(gdx, "ttot"))
+ ttot_before2005 <- paste0("y", ttot[which(ttot <= 2000)])
+ ttot_from2005 <- paste0("y", ttot[which(ttot >= 2005)])
+ te        <- readGDX(gdx, "te")
+ te <- te[!te %in% c("lng_liq", "gas_pipe", "lng_gas", "lng_ves", "coal_ves", "pipe_gas", "termX_lng", "termM_lng", "vess_lng")]
+ p_priceCO2 <- readGDX(gdx, name = c("p_priceCO2", "pm_priceCO2"), format = "first_found") # co2 price
 
 
  ## equations
- qm_pebal  <- readGDX(gdx,name=c("q_balPe"),field="m",format="first_found")
- qm_budget <- readGDX(gdx,name=c("qm_budget"),field="m",format="first_found")
+ qm_pebal  <- readGDX(gdx, name = c("q_balPe"), field = "m", format = "first_found")
+ qm_budget <- readGDX(gdx, name = c("qm_budget"), field = "m", format = "first_found")
 
  ## variables
- vm_prodSe  <- readGDX(gdx,name=c("vm_prodSe"),field="l",restore_zeros=FALSE,format="first_found")
+ vm_prodSe  <- readGDX(gdx, name = c("vm_prodSe"), field = "l", restore_zeros = FALSE, format = "first_found")
 
 
 
 #### A) Calculation of average (standing system) LCOE ----
 
  if (output.type %in% c("both", "average")) {
-
  # read in needed data ----
 
  ## sets
- opTimeYr <- readGDX(gdx,"opTimeYr")
- opTimeYr2te   <- readGDX(gdx,"opTimeYr2te")
- temapse  <- readGDX(gdx,"en2se")
- temapall <- readGDX(gdx,c("en2en","temapall"),format="first_found")
- teall2rlf <- readGDX(gdx,c("te2rlf","teall2rlf"),format="first_found")
- te2stor   <- readGDX(gdx,"VRE2teStor")
- te2grid   <- readGDX(gdx,"VRE2teGrid")
- teVRE   <- readGDX(gdx,"teVRE")
+ opTimeYr <- readGDX(gdx, "opTimeYr")
+ opTimeYr2te   <- readGDX(gdx, "opTimeYr2te")
+ temapse  <- readGDX(gdx, "en2se")
+ temapall <- readGDX(gdx, c("en2en", "temapall"), format = "first_found")
+ teall2rlf <- readGDX(gdx, c("te2rlf", "teall2rlf"), format = "first_found")
+ te2stor   <- readGDX(gdx, "VRE2teStor")
+ te2grid   <- readGDX(gdx, "VRE2teGrid")
+ teVRE   <- readGDX(gdx, "teVRE")
  # exclude "windoff" from teVRE as "windoff" does not have separate grid, storage technologies
  if ("windoff" %in% as.vector(teVRE)) {
    teVRE <- as.vector(teVRE)
    teVRE <- teVRE[teVRE != "windoff"]
  }
 
- se2fe     <- readGDX(gdx,"se2fe")
- pe2se     <- readGDX(gdx,"pe2se")
- teCCS     <- readGDX(gdx,"teCCS")
- teNoCCS   <- readGDX(gdx,"teNoCCS")
- techp     <- readGDX(gdx,c("teChp","techp"),format="first_found")
- teReNoBio <- readGDX(gdx,"teReNoBio")
- teCDR     <- readGDX(gdx,"te_used33")
+ se2fe     <- readGDX(gdx, "se2fe")
+ pe2se     <- readGDX(gdx, "pe2se")
+ teCCS     <- readGDX(gdx, "teCCS")
+ teNoCCS   <- readGDX(gdx, "teNoCCS")
+ techp     <- readGDX(gdx, c("teChp", "techp"), format = "first_found")
+ teReNoBio <- readGDX(gdx, "teReNoBio")
+ teCDR     <- readGDX(gdx, "te_used33")
  EW_name   <- "weathering" # necessary for backward compatibility
 
- pc2te <- readGDX(gdx,"pc2te") # mapping of couple production & consumption
+ pc2te <- readGDX(gdx, "pc2te") # mapping of couple production & consumption
 
  ## parameter
- p_omeg  <- readGDX(gdx,c("pm_omeg","p_omeg"),format="first_found")
+ p_omeg  <- readGDX(gdx, c("pm_omeg", "p_omeg"), format = "first_found")
  p_omeg  <- p_omeg[opTimeYr2te]
- pm_ts   <- readGDX(gdx,"pm_ts")
- pm_data <- readGDX(gdx,"pm_data")
- pm_emifac <- readGDX(gdx,"pm_emifac", restore_zeros=F) # emission factor per technology
- pm_taxemiMkt <- readGDX(gdx,"pm_taxemiMkt") # regional co2 price
- pm_eta_conv <- readGDX(gdx,"pm_eta_conv", restore_zeros=F) # efficiency oftechnologies with time-dependent eta
- pm_dataeta <- readGDX(gdx,"pm_dataeta", restore_zeros=F)# efficiency of technologies with time-independent eta
- p47_taxCO2eq_AggFE <- readGDX(gdx,"p47_taxCO2eq_AggFE", restore_zeros=F, react = "silent")
+ pm_ts   <- readGDX(gdx, "pm_ts")
+ pm_data <- readGDX(gdx, "pm_data")
+ pm_emifac <- readGDX(gdx, "pm_emifac", restore_zeros = FALSE) # emission factor per technology
+ pm_taxemiMkt <- readGDX(gdx, "pm_taxemiMkt") # regional co2 price
+ pm_eta_conv <- readGDX(gdx, "pm_eta_conv", restore_zeros = FALSE) # efficiency oftechnologies with time-dependent eta
+ pm_dataeta <- readGDX(gdx, "pm_dataeta", restore_zeros = FALSE) # efficiency of technologies with time-independent eta
+ p47_taxCO2eq_AggFE <- readGDX(gdx, "p47_taxCO2eq_AggFE", restore_zeros = FALSE, react = "silent")
 
- pm_prodCouple <- readGDX(gdx, "pm_prodCouple", restore_zeros = F) # Second fuel production or demand per unit output of technology. Negative values mean own consumption, positive values mean coupled product.
- pm_PEPrice <- readGDX(gdx, "pm_PEPrice", restore_zeros = F)
- pm_SEPrice <- readGDX(gdx, "pm_SEPrice", restore_zeros = F)
+ pm_prodCouple <- readGDX(gdx, "pm_prodCouple", restore_zeros = FALSE) # Second fuel production or demand per unit output of technology. Negative values mean own consumption, positive values mean coupled product.
+ pm_PEPrice <- readGDX(gdx, "pm_PEPrice", restore_zeros = FALSE)
+ pm_SEPrice <- readGDX(gdx, "pm_SEPrice", restore_zeros = FALSE)
 
  ## variables
- vm_costInvTeDir <- readGDX(gdx,name=c("vm_costInvTeDir","v_costInvTeDir","v_directteinv"),field="l",format="first_found")[,ttot,] ## Total direct Investment Cost in Timestep
- vm_costInvTeAdj <- readGDX(gdx,name=c("vm_costInvTeAdj","v_costInvTeAdj"),field="l",format="first_found")[,ttot,] ## total adjustment cost in period
- vm_capEarlyReti <- readGDX(gdx,name=c("vm_capEarlyReti"),field="l",format="first_found")[,ttot,]
- vm_deltaCap   <- readGDX(gdx,name=c("vm_deltaCap"),field="l",format="first_found")[,ttot,]
- vm_demPe      <- readGDX(gdx,name=c("vm_demPe","v_pedem"),field="l",restore_zeros=FALSE,format="first_found")
- v_investcost  <- readGDX(gdx,name=c("vm_costTeCapital","v_costTeCapital","v_investcost"),field="l",format="first_found")[,ttot,]
- vm_cap        <- readGDX(gdx,name=c("vm_cap"),field="l",format="first_found")
- vm_prodFe     <- readGDX(gdx,name=c("vm_prodFe"),field="l",restore_zeros=FALSE,format="first_found")
- v_emiTeDetail <- readGDX(gdx,name=c("vm_emiTeDetail","v_emiTeDetail"),field="l",restore_zeros=FALSE,format="first_found")
- vm_emiIndCCS <- readGDX(gdx,name=c("vm_emiIndCCS","v_emiIndCCS"),field="l",restore_zeros=FALSE,format="first_found")
- vm_emiCdrTeDetail <- readGDX(gdx, c("vm_emiCdrTeDetail","v33_emi"), field = "l", restore_zeros = F, react = "silent")[,ttot_from2005,teCDR]
+ vm_costInvTeDir <- readGDX(gdx, name = c("vm_costInvTeDir", "v_costInvTeDir", "v_directteinv"), field = "l", format = "first_found")[, ttot, ] ## Total direct Investment Cost in Timestep
+ vm_costInvTeAdj <- readGDX(gdx, name = c("vm_costInvTeAdj", "v_costInvTeAdj"), field = "l", format = "first_found")[, ttot, ] ## total adjustment cost in period
+ vm_capEarlyReti <- readGDX(gdx, name = c("vm_capEarlyReti"), field = "l", format = "first_found")[, ttot, ]
+ vm_deltaCap   <- readGDX(gdx, name = c("vm_deltaCap"), field = "l", format = "first_found")[, ttot, ]
+ vm_demPe      <- readGDX(gdx, name = c("vm_demPe", "v_pedem"), field = "l", restore_zeros = FALSE, format = "first_found")
+ v_investcost  <- readGDX(gdx, name = c("vm_costTeCapital", "v_costTeCapital", "v_investcost"), field = "l", format = "first_found")[, ttot, ]
+ vm_cap        <- readGDX(gdx, name = c("vm_cap"), field = "l", format = "first_found")
+ vm_prodFe     <- readGDX(gdx, name = c("vm_prodFe"), field = "l", restore_zeros = FALSE, format = "first_found")
+ v_emiTeDetail <- readGDX(gdx, name = c("vm_emiTeDetail", "v_emiTeDetail"), field = "l", restore_zeros = FALSE, format = "first_found")
+ vm_emiIndCCS <- readGDX(gdx, name = c("vm_emiIndCCS", "v_emiIndCCS"), field = "l", restore_zeros = FALSE, format = "first_found")
+ vm_emiCdrTeDetail <- readGDX(gdx, c("vm_emiCdrTeDetail", "v33_emi"), field = "l", restore_zeros = FALSE, react = "silent")[, ttot_from2005, teCDR]
   if (is.null(vm_emiCdrTeDetail)) { # compatibility with the CDR module before the portfolio was added
     # captured CO2 by DAC
-    v33_emiDAC <- readGDX(gdx, "v33_emiDAC", field = "l", restore_zeros = F, react = "silent")[, ttot_from2005, ]
-    if (!is.null(v33_emiDAC)){teCDR <- c(teCDR,"dac")}
+    v33_emiDAC <- readGDX(gdx, "v33_emiDAC", field = "l", restore_zeros = FALSE, react = "silent")[, ttot_from2005, ]
+    if (!is.null(v33_emiDAC)) {
+teCDR <- c(teCDR, "dac")
+}
     # captured CO2 by Enhanced Weathering
-    v33_emiEW <- readGDX(gdx, "v33_emiEW", field = "l", restore_zeros = F, react = "silent")
-    if (!is.null(v33_emiEW)) {v33_emiEW <- add_columns(v33_emiEW, addnm=c("y2005","y2010","y2015","y2020"),dim=2,fill=0)[, ttot_from2005, ]
-                              EW_name <- intersect(c("rockgrind","weathering"),te)
-                              teCDR <- c(teCDR,EW_name)}
+    v33_emiEW <- readGDX(gdx, "v33_emiEW", field = "l", restore_zeros = FALSE, react = "silent")
+    if (!is.null(v33_emiEW)) {
+v33_emiEW <- add_columns(v33_emiEW, addnm = c("y2005", "y2010", "y2015", "y2020"), dim = 2, fill = 0)[, ttot_from2005, ]
+                              EW_name <- intersect(c("rockgrind", "weathering"), te)
+                              teCDR <- c(teCDR, EW_name)
+}
     # variable used in the rest of the reporting
     vm_emiCdrTeDetail <- mbind(v33_emiDAC, v33_emiEW)
     vm_emiCdrTeDetail <- setNames(vm_emiCdrTeDetail, c("dac", EW_name))
@@ -162,11 +165,11 @@ reportLCOE <- function(gdx, output.type = "both"){
 
  # module-specific
  # amount of curtailed electricity
- if (module2realisation["power",2] == "RLDC") {
-   v32_curt <- readGDX(gdx,name=c("v32_curt"),field="l",restore_zeros=FALSE,format="first_found")
-   } else if (module2realisation["power",2] %in% c("IntC","DTcoup")) {
-   v32_curt <- v32_storloss[,ttot_from2005,getNames(vm_prodSe, dim=3)]
-   } else{
+ if (module2realisation["power", 2] == "RLDC") {
+   v32_curt <- readGDX(gdx, name = c("v32_curt"), field = "l", restore_zeros = FALSE, format = "first_found")
+   } else if (module2realisation["power", 2] %in% c("IntC", "DTcoup")) {
+   v32_curt <- v32_storloss[, ttot_from2005, getNames(vm_prodSe, dim = 3)]
+   } else {
    v32_curt <- 0
    }
 
@@ -194,21 +197,21 @@ reportLCOE <- function(gdx, output.type = "both"){
  # get a representative region
  reg1 <- getRegions(vm_prodSe)[1]
 
- te_annuity <- new.magpie("GLO",names=magclass::getNames(p_omeg,dim=2))
- for(a in magclass::getNames(p_omeg[reg1,,],dim=2)){
-  te_annuity[,,a] <- 1/dimSums(p_omeg[reg1,,a]/(1+discount_rate)**as.numeric(magclass::getNames(p_omeg[reg1,,a],dim=1)),dim=3.1)
+ te_annuity <- new.magpie("GLO", names = magclass::getNames(p_omeg, dim = 2))
+ for (a in magclass::getNames(p_omeg[reg1, , ], dim = 2)) {
+  te_annuity[, , a] <- 1 / dimSums(p_omeg[reg1, , a] / (1 + discount_rate)**as.numeric(magclass::getNames(p_omeg[reg1, , a], dim = 1)), dim = 3.1)
  }
 
- te_inv_annuity <- 1e+12 * te_annuity[,,te] *
+ te_inv_annuity <- 1e+12 * te_annuity[, , te] *
    mbind(
-     v_investcost[,ttot_before2005,te] * dimSums(vm_deltaCap[teall2rlf][,ttot_before2005,te],dim=3.2),
-     vm_costInvTeDir[,ttot_from2005,te]
+     v_investcost[, ttot_before2005, te] * dimSums(vm_deltaCap[teall2rlf][, ttot_before2005, te], dim = 3.2),
+     vm_costInvTeDir[, ttot_from2005, te]
    )
 
- te_inv_annuity_wadj <- 1e+12 * te_annuity[,,te] *
+ te_inv_annuity_wadj <- 1e+12 * te_annuity[, , te] *
    mbind(
-     v_investcost[,ttot_before2005,te] * dimSums(vm_deltaCap[teall2rlf][,ttot_before2005,te],dim=3.2),
-     vm_costInvTeAdj[,ttot_from2005,te] + vm_costInvTeDir[,ttot_from2005,te]
+     v_investcost[, ttot_before2005, te] * dimSums(vm_deltaCap[teall2rlf][, ttot_before2005, te], dim = 3.2),
+     vm_costInvTeAdj[, ttot_from2005, te] + vm_costInvTeDir[, ttot_from2005, te]
    )
 
  # average LCOE components ----
@@ -232,35 +235,35 @@ reportLCOE <- function(gdx, output.type = "both"){
 
 
  # take 74 tech from p_omeg, although in v_direct_in 114 in total
-  te_annual_inv_cost <- new.magpie(getRegions(te_inv_annuity[,ttot,]),getYears(te_inv_annuity[,ttot,]),magclass::getNames(te_inv_annuity[,ttot,]))
+  te_annual_inv_cost <- new.magpie(getRegions(te_inv_annuity[, ttot, ]), getYears(te_inv_annuity[, ttot, ]), magclass::getNames(te_inv_annuity[, ttot, ]))
   # loop over ttot
- for(t0 in ttot){
-   for(a in magclass::getNames(te_inv_annuity) ) {
+ for (t0 in ttot) {
+   for (a in magclass::getNames(te_inv_annuity)) {
      # all ttot before t0
-     t_id <- ttot[ttot<=t0]
+     t_id <- ttot[ttot <= t0]
      # only the time (t_id) within the opTimeYr of a specific technology a
-     t_id <- t_id[t_id >= (t0 - max(as.numeric(opTimeYr2te$opTimeYr[opTimeYr2te$all_te==a]))+1)]
-     p_omeg_h <- new.magpie(getRegions(p_omeg),years=t_id,names=a)
-     for(t_id0 in t_id){
-       p_omeg_h[,t_id0,a] <- p_omeg[,,a][,,t0-t_id0 +1]
+     t_id <- t_id[t_id >= (t0 - max(as.numeric(opTimeYr2te$opTimeYr[opTimeYr2te$all_te == a])) + 1)]
+     p_omeg_h <- new.magpie(getRegions(p_omeg), years = t_id, names = a)
+     for (t_id0 in t_id) {
+       p_omeg_h[, t_id0, a] <- p_omeg[, , a][, , t0 - t_id0 + 1]
      }
-     te_annual_inv_cost[,t0,a] <- dimSums(pm_ts[,t_id,] * te_inv_annuity[,t_id,a] * p_omeg_h[,t_id,a] ,dim=2)
+     te_annual_inv_cost[, t0, a] <- dimSums(pm_ts[, t_id, ] * te_inv_annuity[, t_id, a] * p_omeg_h[, t_id, a], dim = 2)
    } # a
  }  # t0
 
- te_annual_inv_cost_wadj <- new.magpie(getRegions(te_inv_annuity_wadj[,ttot,]),getYears(te_inv_annuity_wadj[,ttot,]),magclass::getNames(te_inv_annuity_wadj[,ttot,]))
+ te_annual_inv_cost_wadj <- new.magpie(getRegions(te_inv_annuity_wadj[, ttot, ]), getYears(te_inv_annuity_wadj[, ttot, ]), magclass::getNames(te_inv_annuity_wadj[, ttot, ]))
  # loop over ttot
- for(t0 in ttot){
-   for(a in magclass::getNames(te_inv_annuity_wadj) ) {
+ for (t0 in ttot) {
+   for (a in magclass::getNames(te_inv_annuity_wadj)) {
      # all ttot before t0
-     t_id <- ttot[ttot<=t0]
+     t_id <- ttot[ttot <= t0]
      # only the time (t_id) within the opTimeYr of a specific technology a
-     t_id <- t_id[t_id >= (t0 - max(as.numeric(opTimeYr2te$opTimeYr[opTimeYr2te$all_te==a]))+1)]
-     p_omeg_h <- new.magpie(getRegions(p_omeg),years=t_id,names=a)
-     for(t_id0 in t_id){
-       p_omeg_h[,t_id0,a] <- p_omeg[,,a][,,t0-t_id0 +1]
+     t_id <- t_id[t_id >= (t0 - max(as.numeric(opTimeYr2te$opTimeYr[opTimeYr2te$all_te == a])) + 1)]
+     p_omeg_h <- new.magpie(getRegions(p_omeg), years = t_id, names = a)
+     for (t_id0 in t_id) {
+       p_omeg_h[, t_id0, a] <- p_omeg[, , a][, , t0 - t_id0 + 1]
      }
-     te_annual_inv_cost_wadj[,t0,a] <- dimSums(pm_ts[,t_id,] * te_inv_annuity_wadj[,t_id,a] * p_omeg_h[,t_id,a] ,dim=2)
+     te_annual_inv_cost_wadj[, t0, a] <- dimSums(pm_ts[, t_id, ] * te_inv_annuity_wadj[, t_id, a] * p_omeg_h[, t_id, a], dim = 2)
    } # a
  }  # t0
 
@@ -268,25 +271,25 @@ reportLCOE <- function(gdx, output.type = "both"){
 
  # 2.1 primary fuel cost = PE price * PE demand of technology
 
- te_annual_fuel_cost <- new.magpie(getRegions(te_inv_annuity),ttot_from2005,magclass::getNames(te_inv_annuity), fill=0)
- te_annual_fuel_cost[,,pe2se$all_te] <- setNames(1e+12 * qm_pebal[,ttot_from2005,pe2se$all_enty] / qm_budget[,ttot_from2005,] *
-           setNames(vm_demPe[,,pe2se$all_te], pe2se$all_enty), pe2se$all_te)
+ te_annual_fuel_cost <- new.magpie(getRegions(te_inv_annuity), ttot_from2005, magclass::getNames(te_inv_annuity), fill = 0)
+ te_annual_fuel_cost[, , pe2se$all_te] <- setNames(1e+12 * qm_pebal[, ttot_from2005, pe2se$all_enty] / qm_budget[, ttot_from2005, ] *
+           setNames(vm_demPe[, , pe2se$all_te], pe2se$all_enty), pe2se$all_te)
 
  # 2.2 secondary fuel cost
- Fuel.Price <- mbind(pm_PEPrice,pm_SEPrice )[,,]*1e12 # convert from trUSD2005/TWa to USD2005/TWa [note: this already includes the CO2 price]
+ Fuel.Price <- mbind(pm_PEPrice, pm_SEPrice)[, , ] * 1e12 # convert from trUSD2005/TWa to USD2005/TWa [note: this already includes the CO2 price]
  Fuel.Price <- magclass::matchDim(Fuel.Price, vm_prodSe, dim = c(1), fill = 0)
 
- pm_SecFuel <- pm_prodCouple[,,getNames(pm_prodCouple)[pm_prodCouple[reg1,,]<0]] # keep only second fuel consumption, not co-production
+ pm_SecFuel <- pm_prodCouple[, , getNames(pm_prodCouple)[pm_prodCouple[reg1, , ] < 0]] # keep only second fuel consumption, not co-production
  SecFuelTechs <- intersect(getNames(pm_SecFuel, dim = 3), pc2te$all_te) # determine all te that have couple production
  SecFuelTechs_pe2se <- intersect(SecFuelTechs, pe2se$all_te)
  otherSecFuelTechs <- setdiff(SecFuelTechs, pe2se$all_te) # note: tdbiogas and tdfosgas are currently not being reported in the average LCOE, and are thus ignored below
 
- te_annual_secFuel_cost <- new.magpie(getRegions(te_inv_annuity),ttot_from2005, getNames(te_inv_annuity) , fill=0)
+ te_annual_secFuel_cost <- new.magpie(getRegions(te_inv_annuity), ttot_from2005, getNames(te_inv_annuity), fill = 0)
   # calculate secondary fuel cost for pe2se
-    te_annual_secFuel_cost[,,SecFuelTechs_pe2se] <- setNames(dimSums(-pm_SecFuel[,,SecFuelTechs_pe2se] * Fuel.Price[,ttot_from2005, getNames(pm_SecFuel, dim = 4)] *
-                                                            vm_prodSe[,ttot_from2005,SecFuelTechs_pe2se], dim=3.4) , SecFuelTechs_pe2se)
+    te_annual_secFuel_cost[, , SecFuelTechs_pe2se] <- setNames(dimSums(-pm_SecFuel[, , SecFuelTechs_pe2se] * Fuel.Price[, ttot_from2005, getNames(pm_SecFuel, dim = 4)] *
+                                                            vm_prodSe[, ttot_from2005, SecFuelTechs_pe2se], dim = 3.4), SecFuelTechs_pe2se)
   # calculate secondary fuel cost for ccsinje
-     te_annual_secFuel_cost[,,"ccsinje"] <- setNames(-pm_SecFuel[,,"ccsinje"] * Fuel.Price[,,"seel"] * vm_co2CCS[,,"ccsinje.1"], "ccsinje")
+     te_annual_secFuel_cost[, , "ccsinje"] <- setNames(-pm_SecFuel[, , "ccsinje"] * Fuel.Price[, , "seel"] * vm_co2CCS[, , "ccsinje.1"], "ccsinje")
   # calculation explanation:
           # units: -1 (so pm_SecFuel turns positive because consuming energy)
           # * electricity or heat demand (pm_SecFuel, TWa_input/TWa_mainOutput OR TWa/GtC)
@@ -295,13 +298,14 @@ reportLCOE <- function(gdx, output.type = "both"){
           # = te_annual_secFuel_cost = [USD2005]
 
 # 2.3 additional fuel demand of CDR module technologies
-  te_annual_otherFuel_cost <- new.magpie(getRegions(te_inv_annuity),ttot_from2005,getNames(te_inv_annuity), fill=0)
-  if (length(teCDR)>0 & !is.null(v33_FEdemand) ){  # i.e. this is only computed for remind post refactoring of cdr module (Nov 2024)
-  for (te in teCDR){
-    te_annual_otherFuel_cost[,ttot_from2005,te] <- setNames(dimSums(
-      1e+12 * setNames(pm_FEPrice[,,unique(fe2cdr$all_enty)], unique(fe2cdr$all_enty)) *
-        setNames(dimSums(v33_FEdemand[,,te],dim=3.2), unique(getNames(v33_FEdemand[,,te],dim=1)))),
-    te)}
+  te_annual_otherFuel_cost <- new.magpie(getRegions(te_inv_annuity), ttot_from2005, getNames(te_inv_annuity), fill = 0)
+  if (length(teCDR) > 0 & !is.null(v33_FEdemand)) {  # i.e. this is only computed for remind post refactoring of cdr module (Nov 2024)
+  for (te in teCDR) {
+    te_annual_otherFuel_cost[, ttot_from2005, te] <- setNames(dimSums(
+      1e+12 * setNames(pm_FEPrice[, , unique(fe2cdr$all_enty)], unique(fe2cdr$all_enty)) *
+        setNames(dimSums(v33_FEdemand[, , te], dim = 3.2), unique(getNames(v33_FEdemand[, , te], dim = 1)))),
+    te)
+}
   }
   # calculation explanation: 10^12 USD/TrnUSD * pm_FEPrice(TrnUSD/TWa) * FEdemand(TWa) = USD
 
@@ -310,9 +314,9 @@ reportLCOE <- function(gdx, output.type = "both"){
  # omv cost (from pm_data) * SE production
 
 
- temapse.names <- apply(temapse, 1, function(x) paste0(x, collapse = '.'))
- te_annual_OMV_cost <- new.magpie(getRegions(te_inv_annuity),ttot_from2005,magclass::getNames(te_inv_annuity), fill=0)
- te_annual_OMV_cost[,,temapse$all_te] <- 1e+12 * collapseNames(pm_data[,,"omv"])[,,temapse$all_te] * setNames(vm_prodSe[,,temapse.names],temapse$all_te)
+ temapse.names <- apply(temapse, 1, function(x) paste0(x, collapse = "."))
+ te_annual_OMV_cost <- new.magpie(getRegions(te_inv_annuity), ttot_from2005, magclass::getNames(te_inv_annuity), fill = 0)
+ te_annual_OMV_cost[, , temapse$all_te] <- 1e+12 * collapseNames(pm_data[, , "omv"])[, , temapse$all_te] * setNames(vm_prodSe[, , temapse.names], temapse$all_te)
 
  # 4. sub-part: OMF cost ----
 
@@ -320,10 +324,10 @@ reportLCOE <- function(gdx, output.type = "both"){
  # omf in pm_data given as share of investment cost
 
 
- te_annual_OMF_cost <- new.magpie(getRegions(te_inv_annuity),ttot_from2005,magclass::getNames(te_inv_annuity), fill=0)
+ te_annual_OMF_cost <- new.magpie(getRegions(te_inv_annuity), ttot_from2005, magclass::getNames(te_inv_annuity), fill = 0)
 
- te_annual_OMF_cost[,,getNames(te_inv_annuity)] <- 1e+12 * collapseNames(pm_data[,,"omf"])[,,getNames(te_inv_annuity)] * v_investcost[,ttot_from2005,getNames(te_inv_annuity)] *
-           dimSums(vm_cap[,ttot_from2005,], dim = 3.2)[,,getNames(te_inv_annuity)]
+ te_annual_OMF_cost[, , getNames(te_inv_annuity)] <- 1e+12 * collapseNames(pm_data[, , "omf"])[, , getNames(te_inv_annuity)] * v_investcost[, ttot_from2005, getNames(te_inv_annuity)] *
+           dimSums(vm_cap[, ttot_from2005, ], dim = 3.2)[, , getNames(te_inv_annuity)]
 
  # 5. sub-part: storage cost (for wind, spv, csp) ----
 
@@ -331,13 +335,13 @@ reportLCOE <- function(gdx, output.type = "both"){
  # of corresponding storage technology ("storwind", "storspv", "storcsp")
  # clarify: before, they used omv cost here, but storage, grid etc. does not have omv...instead, we use omf now!
 
- te_annual_stor_cost <- new.magpie(getRegions(te_inv_annuity),ttot_from2005,magclass::getNames(te_inv_annuity), fill=0)
- te_annual_stor_cost[,,te2stor$all_te] <- setNames(te_annual_inv_cost[,ttot_from2005,te2stor$teStor] +
-                                                   te_annual_OMF_cost[,,te2stor$teStor],te2stor$all_te)
+ te_annual_stor_cost <- new.magpie(getRegions(te_inv_annuity), ttot_from2005, magclass::getNames(te_inv_annuity), fill = 0)
+ te_annual_stor_cost[, , te2stor$all_te] <- setNames(te_annual_inv_cost[, ttot_from2005, te2stor$teStor] +
+                                                   te_annual_OMF_cost[, , te2stor$teStor], te2stor$all_te)
 
- te_annual_stor_cost_wadj <- new.magpie(getRegions(te_inv_annuity),ttot_from2005,magclass::getNames(te_inv_annuity), fill=0)
- te_annual_stor_cost_wadj[,,te2stor$all_te] <- setNames(te_annual_inv_cost_wadj[,ttot_from2005,te2stor$teStor] +
-                                                     te_annual_OMF_cost[,,te2stor$teStor],te2stor$all_te)
+ te_annual_stor_cost_wadj <- new.magpie(getRegions(te_inv_annuity), ttot_from2005, magclass::getNames(te_inv_annuity), fill = 0)
+ te_annual_stor_cost_wadj[, , te2stor$all_te] <- setNames(te_annual_inv_cost_wadj[, ttot_from2005, te2stor$teStor] +
+                                                     te_annual_OMF_cost[, , te2stor$teStor], te2stor$all_te)
 
 
  # 6. sub-part: grid cost ----
@@ -345,29 +349,42 @@ reportLCOE <- function(gdx, output.type = "both"){
  # same as for storage cost only with grid technologies: "gridwind", "gridspv", "gridcsp"
  # only "gridwind" technology active, wind requires 1.5 * the gridwind capacities as spv and csp
 
- grid_factor_tech <- new.magpie(names=te2grid$all_te, fill=1)
+ grid_factor_tech <- new.magpie(names = te2grid$all_te, fill = 1)
  getSets(grid_factor_tech)[3] <- "all_te"
- grid_factor_tech[,,"wind"] <- 1.5
- grid_factor_tech[,,"windoff"] <- 3.0
+ grid_factor_tech[, , "wind"] <- 1.5
+ grid_factor_tech[, , "windon"] <- 1.5
+ grid_factor_tech[, , "windoff"] <- 3.0
 
- te_annual_grid_cost <- new.magpie(getRegions(te_inv_annuity),ttot_from2005,magclass::getNames(te_inv_annuity), fill=0)
- vm_VRE_prodSe_grid <- dimSums(grid_factor_tech*vm_prodSe[,,te2grid$all_te])
+ vm_VRE_prodSe_grid <- dimSums(grid_factor_tech * vm_prodSe[, , te2grid$all_te])
+ te_annual_grid_cost <- new.magpie(getRegions(te_inv_annuity), ttot_from2005, magclass::getNames(te_inv_annuity), fill = 0)
+ te_annual_grid_cost_wadj <- new.magpie(getRegions(te_inv_annuity), ttot_from2005, magclass::getNames(te_inv_annuity), fill = 0)
 
 
- te_annual_grid_cost[,,te2grid$all_te] <- collapseNames(te_annual_inv_cost[,ttot_from2005,"gridwind"] +
-                                           te_annual_OMF_cost[,,"gridwind"]) *
-                                            # this multiplcative factor is added to reflect higher grid demand of wind
-                                            # see q32_limitCapTeGrid
-                                           grid_factor_tech * vm_prodSe[,,te2grid$all_te] /
-                                           vm_VRE_prodSe_grid
+  if ("windon" %in% all_te) {
+    te_annual_grid_cost[, , te2grid$all_te] <-
+      collapseNames(te_annual_inv_cost[, ttot_from2005, "gridwindon"] + te_annual_OMF_cost[, , "gridwindon"]) *
+      1 / vm_VRE_prodSe_grid *
+      # this multiplcative factor is added to reflect higher grid demand of wind, see q32_limitCapTeGrid
+      grid_factor_tech * vm_prodSe[, , te2grid$all_te]
 
- te_annual_grid_cost_wadj <- new.magpie(getRegions(te_inv_annuity),ttot_from2005,magclass::getNames(te_inv_annuity), fill=0)
- te_annual_grid_cost_wadj[,,te2grid$all_te] <- collapseNames(te_annual_inv_cost_wadj[,ttot_from2005,"gridwind"] +
-                                                          te_annual_OMF_cost[,,"gridwind"]) *
-   # this multiplcative factor is added to reflect higher grid demand of wind
-   # see q32_limitCapTeGrid
-   grid_factor_tech * vm_prodSe[,,te2grid$all_te] /
-   vm_VRE_prodSe_grid
+    te_annual_grid_cost_wadj[, , te2grid$all_te] <-
+      collapseNames(te_annual_inv_cost_wadj[, ttot_from2005, "gridwindon"] + te_annual_OMF_cost[, , "gridwindon"]) *
+      1 / vm_VRE_prodSe_grid *
+      # this multiplcative factor is added to reflect higher grid demand of wind, see q32_limitCapTeGrid
+      grid_factor_tech * vm_prodSe[, , te2grid$all_te]
+  } else {
+    te_annual_grid_cost[, , te2grid$all_te] <-
+      collapseNames(te_annual_inv_cost[, ttot_from2005, "gridwind"] + te_annual_OMF_cost[, , "gridwind"]) *
+      1 / vm_VRE_prodSe_grid *
+      # this multiplcative factor is added to reflect higher grid demand of wind, see q32_limitCapTeGrid
+      grid_factor_tech * vm_prodSe[, , te2grid$all_te]
+
+    te_annual_grid_cost_wadj[, , te2grid$all_te] <-
+      collapseNames(te_annual_inv_cost_wadj[, ttot_from2005, "gridwind"] + te_annual_OMF_cost[, , "gridwind"]) *
+      1 / vm_VRE_prodSe_grid *
+      # this multiplcative factor is added to reflect higher grid demand of wind, see q32_limitCapTeGrid
+      grid_factor_tech * vm_prodSe[, , te2grid$all_te]
+  }
 
 
  # 7. sub-part: ccs injection cost (for technologies capturing CO2) ----
@@ -377,27 +394,27 @@ reportLCOE <- function(gdx, output.type = "both"){
 
  # (annual ccsinje investment + annual ccsinje omf) * captured co2 (tech) / total captured co2 of all tech
 
- te_annual_ccsInj_cost <- new.magpie(getRegions(te_inv_annuity),ttot_from2005,getNames(te_inv_annuity), fill=0)
- te_annual_ccsInj_inclAdjCost <- new.magpie(getRegions(te_inv_annuity),ttot_from2005,getNames(te_inv_annuity), fill=0)
+ te_annual_ccsInj_cost <- new.magpie(getRegions(te_inv_annuity), ttot_from2005, getNames(te_inv_annuity), fill = 0)
+ te_annual_ccsInj_inclAdjCost <- new.magpie(getRegions(te_inv_annuity), ttot_from2005, getNames(te_inv_annuity), fill = 0)
 
 
  # calculate total ccsinjection cost for all techs
- total_ccsInj_cost <- dimReduce(te_annual_inv_cost[getRegions(te_annual_OMF_cost),getYears(te_annual_OMF_cost),"ccsinje"] +
-                                                     te_annual_OMF_cost[,,"ccsinje"] + te_annual_secFuel_cost[,,"ccsinje"])
+ total_ccsInj_cost <- dimReduce(te_annual_inv_cost[getRegions(te_annual_OMF_cost), getYears(te_annual_OMF_cost), "ccsinje"] +
+                                                     te_annual_OMF_cost[, , "ccsinje"] + te_annual_secFuel_cost[, , "ccsinje"])
 
- total_ccsInj_inclAdjCost <- dimReduce(te_annual_inv_cost_wadj[getRegions(te_annual_OMF_cost),getYears(te_annual_OMF_cost),"ccsinje"] +
-                                        te_annual_OMF_cost[,,"ccsinje"] +
-                                         te_annual_secFuel_cost[,,"ccsinje"])
+ total_ccsInj_inclAdjCost <- dimReduce(te_annual_inv_cost_wadj[getRegions(te_annual_OMF_cost), getYears(te_annual_OMF_cost), "ccsinje"] +
+                                        te_annual_OMF_cost[, , "ccsinje"] +
+                                         te_annual_secFuel_cost[, , "ccsinje"])
   # all captured co2 by tech: pe2se and cdr and industry
-  cco2_byTech <-  mbind(dimSums(v_emiTeDetail[,,"cco2"][,ttot_from2005,teCCS], dim = c(3.1,3.2,3.4), na.rm = T),
-                        setNames(DAC_ccsdemand,"dac"), vm_emiIndCCS[,ttot_from2005,])
-  cco2Techs <- intersect(getNames(cco2_byTech),getNames(te_inv_annuity))
+  cco2_byTech <-  mbind(dimSums(v_emiTeDetail[, , "cco2"][, ttot_from2005, teCCS], dim = c(3.1, 3.2, 3.4), na.rm = TRUE),
+                        setNames(DAC_ccsdemand, "dac"), vm_emiIndCCS[, ttot_from2005, ])
+  cco2Techs <- intersect(getNames(cco2_byTech), getNames(te_inv_annuity))
 
 
  # distribute ccs injection cost over techs
- te_annual_ccsInj_cost[,,cco2Techs] <- setNames(total_ccsInj_cost * cco2_byTech[,,cco2Techs] / vm_co2capture,
+ te_annual_ccsInj_cost[, , cco2Techs] <- setNames(total_ccsInj_cost * cco2_byTech[, , cco2Techs] / vm_co2capture,
                                                 cco2Techs)
- te_annual_ccsInj_inclAdjCost[,,cco2Techs] <- setNames(total_ccsInj_inclAdjCost * cco2_byTech[,,cco2Techs]/vm_co2capture,
+ te_annual_ccsInj_inclAdjCost[, , cco2Techs] <- setNames(total_ccsInj_inclAdjCost * cco2_byTech[, , cco2Techs] / vm_co2capture,
                                                        cco2Techs)
 
 
@@ -411,23 +428,23 @@ reportLCOE <- function(gdx, output.type = "both"){
  # limit technology names to those existing in both te_inv_annuity and
  # v_emiTeDetail
  tmp <- intersect(getNames(te_inv_annuity),
-                  getNames(v_emiTeDetail[,,"co2"], dim = 3))
- te_annual_co2_cost[,,tmp] <- setNames(
-   ( p_priceCO2[,getYears(v_emiTeDetail),]
-     * dimSums(v_emiTeDetail[,,tmp], dim = c(3.1, 3.2, 3.4), na.rm = TRUE)
+                  getNames(v_emiTeDetail[, , "co2"], dim = 3))
+ te_annual_co2_cost[, , tmp] <- setNames(
+   (p_priceCO2[, getYears(v_emiTeDetail), ]
+     * dimSums(v_emiTeDetail[, , tmp], dim = c(3.1, 3.2, 3.4), na.rm = TRUE)
      * 1e9   # $/tC * GtC/yr * 1e9 t/Gt = $/yr
    ),
    tmp)
  rm(tmp)
 
  # regional part of the CO2 price (p47_taxCO2eq_AggFE only exits when regipol is run)
- if(!is.null(p47_taxCO2eq_AggFE)){
+ if (!is.null(p47_taxCO2eq_AggFE)) {
    tmp <- intersect(getNames(te_inv_annuity),
-                    getNames(v_emiTeDetail[,,"co2"], dim = 3))
+                    getNames(v_emiTeDetail[, , "co2"], dim = 3))
 
-   te_annual_co2_cost[,getYears(p47_taxCO2eq_AggFE),tmp] <- setNames(
-     ( dimSums(p47_taxCO2eq_AggFE,dim=3, na.rm = TRUE)
-       * dimSums(v_emiTeDetail[,getYears(p47_taxCO2eq_AggFE),tmp], dim = c(3.1, 3.2, 3.4), na.rm = TRUE)
+   te_annual_co2_cost[, getYears(p47_taxCO2eq_AggFE), tmp] <- setNames(
+     (dimSums(p47_taxCO2eq_AggFE, dim = 3, na.rm = TRUE)
+       * dimSums(v_emiTeDetail[, getYears(p47_taxCO2eq_AggFE), tmp], dim = c(3.1, 3.2, 3.4), na.rm = TRUE)
        * 1e9 * 1e3  # T$/tC * GtC/yr * 1e9 t/Gt 1e3$/T$ = $/yr
      ),
      tmp)
@@ -444,17 +461,17 @@ reportLCOE <- function(gdx, output.type = "both"){
  # total annual cost = sum of all previous annual cost
  # curt_share = share of curtailed electricity relative to total generated electricity
 
- te_curt_cost <- new.magpie(getRegions(te_annual_fuel_cost), getYears(te_annual_fuel_cost), getNames(te_annual_fuel_cost), fill=0)
+ te_curt_cost <- new.magpie(getRegions(te_annual_fuel_cost), getYears(te_annual_fuel_cost), getNames(te_annual_fuel_cost), fill = 0)
 
  # calculate curtailment share of total generation
  pe2se.seel <- pe2se[pe2se$all_enty1 == "seel", ]
 
- curt_share <- v32_curt[,,teVRE] / vm_prodSe[,,teVRE]
+ curt_share <- v32_curt[, , teVRE] / vm_prodSe[, , teVRE]
 
  # calculate total annual cost (without curtailment cost) as sum of previous parts (excl. grid and storage cost)
  te_annual_total_cost_noCurt <- new.magpie(getRegions(te_annual_fuel_cost), getYears(te_annual_fuel_cost), getNames(te_annual_fuel_cost))
 
- te_annual_total_cost_noCurt <- te_annual_inv_cost[,getYears(te_annual_fuel_cost),] +
+ te_annual_total_cost_noCurt <- te_annual_inv_cost[, getYears(te_annual_fuel_cost), ] +
    te_annual_fuel_cost +
    te_annual_OMV_cost  +
    te_annual_OMF_cost  +
@@ -462,67 +479,67 @@ reportLCOE <- function(gdx, output.type = "both"){
    te_annual_co2_cost
 
 ###### 10. sub-part: Additional Enhanced Weathering data & calculations
- if(EW_name %in% teCDR){
+ if (EW_name %in% teCDR) {
   # read amount of rock spread
-   v33_EW_onfield <- readGDX(gdx,c("v33_EW_onfield","v33_grindrock_onfield"), restore_zeros = F,field="l",format="first_found")[,ttot_from2005,]
-   v33_EW_onfield_sum <- dimSums(v33_EW_onfield,dim=3)
+   v33_EW_onfield <- readGDX(gdx, c("v33_EW_onfield", "v33_grindrock_onfield"), restore_zeros = FALSE, field = "l", format = "first_found")[, ttot_from2005, ]
+   v33_EW_onfield_sum <- dimSums(v33_EW_onfield, dim = 3)
 
   # EW-specific fixed OM cost are given by vm_omcosts_cdr. This cumulates a) completely fixed cost for mining, grinding and spreading; and b) fixed transportation cost that depend on the distance grade.
   # To allow interpretation of the LC, separate these cost components.
-   te_annual_addOM_cost  <- 10^12 * setNames(readGDX(gdx,"vm_omcosts_cdr",restore_zeros = F,field="l",format="first_found"),EW_name)
-   s33_costs_fix <- readGDX(gdx,"s33_costs_fix")
-   p33_EW_transport_costs <- readGDX(gdx,c("p33_EW_transport_costs","p33_transport_costs"),format="first_found")
+   te_annual_addOM_cost  <- 10^12 * setNames(readGDX(gdx, "vm_omcosts_cdr", restore_zeros = FALSE, field = "l", format = "first_found"), EW_name)
+   s33_costs_fix <- readGDX(gdx, "s33_costs_fix")
+   p33_EW_transport_costs <- readGDX(gdx, c("p33_EW_transport_costs", "p33_transport_costs"), format = "first_found")
 
    EW_fixed_other_cost <- 10^12 * s33_costs_fix * v33_EW_onfield_sum
-   EW_fixed_transport_cost <-  10^12 *  dimSums(p33_EW_transport_costs[,,getNames(v33_EW_onfield)] * v33_EW_onfield)
+   EW_fixed_transport_cost <-  10^12 *  dimSums(p33_EW_transport_costs[, , getNames(v33_EW_onfield)] * v33_EW_onfield)
   }
 
 ####### 11. sub-part: calculate total energy production and carbon storage  #################################
  # a) production volumes to divide by:
   # for LCO-ccsinje: change unit of stored CO2 from GtC to tCO2
- vm_co2CCS_tCO2 <- vm_co2CCS*s_GtC2tCO2
+ vm_co2CCS_tCO2 <- vm_co2CCS * s_GtC2tCO2
 
   # for LCO-cc: calculate captured CO2 to calculate cost per tCO2
- cco2_byTech_tCO2 <-  cco2_byTech*s_GtC2tCO2
+ cco2_byTech_tCO2 <-  cco2_byTech * s_GtC2tCO2
  cco2_byTech_tCO2[cco2_byTech_tCO2 < 1000] <- NA   # set to NA if very small (<1000tCO2/yr) to avoid very large cost parts & weird plots
 
- te_cco2 <- intersect(getNames(cco2_byTech_tCO2),getNames(te_inv_annuity)) # Technologies that capture co2 to enter ccus system, no matter which source
+ te_cco2 <- intersect(getNames(cco2_byTech_tCO2), getNames(te_inv_annuity)) # Technologies that capture co2 to enter ccus system, no matter which source
 
   # for LCO-sc: calculate stored CO2 to calculate cost per tCO2
-  cdrco2_byTech_tCO2 <- vm_emiCdrTeDetail[,,setdiff(teCDR,te_cco2)]*s_GtC2tCO2*-1 # will become relevant when biochar included
+  cdrco2_byTech_tCO2 <- vm_emiCdrTeDetail[, , setdiff(teCDR, te_cco2)] * s_GtC2tCO2 * -1 # will become relevant when biochar included
 
   # enhanced weathering:
-  if (EW_name %in% teCDR){
+  if (EW_name %in% teCDR) {
       # The calculation of cost is associated with the spreading of rocks in a time step. However, the removal induced thereby is spread across time steps.
       # Thus, we need to calculate the total removal induced through spreading a given amount of rock as reference value for the cost incurred in that time step.
       s33_co2_rem_pot <- readGDX(gdx, "s33_co2_rem_pot")
-      EW_induced_in_tCO2 <- dimSums(v33_EW_onfield*s33_co2_rem_pot * s_GtC2tCO2, dim=3) # here grades do not matter because the overall removal depends on the type of stone and not grade
+      EW_induced_in_tCO2 <- dimSums(v33_EW_onfield * s33_co2_rem_pot * s_GtC2tCO2, dim = 3) # here grades do not matter because the overall removal depends on the type of stone and not grade
                                       # [Gt stone] * [GtC/GtStone] * [tCO2/GtC]
-      EW_induced_in_tCO2[EW_induced_in_tCO2==0] <- NA # set NA to avoid infinite investment cost for the standing system when regions do not spread EW in time steps after initial investment was taken
-      cdrco2_byTech_tCO2[,,EW_name] <- EW_induced_in_tCO2[,ttot_from2005,]
+      EW_induced_in_tCO2[EW_induced_in_tCO2 == 0] <- NA # set NA to avoid infinite investment cost for the standing system when regions do not spread EW in time steps after initial investment was taken
+      cdrco2_byTech_tCO2[, , EW_name] <- EW_induced_in_tCO2[, ttot_from2005, ]
       # Note that there is an alternative way to allocate the cost which may be added in the future.
   }
 
   te_sco2 <- getNames(cdrco2_byTech_tCO2)
 
  # for pe2se: SE and FE production in MWh
- total_te_energy <- new.magpie(getRegions(vm_prodSe),getYears(vm_prodSe),
-                               c(magclass::getNames(collapseNames(vm_prodSe[temapse],collapsedim = c(1,2))),
-                                 magclass::getNames(collapseNames(vm_prodFe[se2fe],collapsedim = c(1,2)))))
- total_te_energy[,,temapse$all_te] <- s_twa2mwh * setNames(vm_prodSe[,,temapse.names], temapse$all_te)
- total_te_energy[,,se2fe$all_te]   <- s_twa2mwh * vm_prodFe[,,se2fe$all_te]
+ total_te_energy <- new.magpie(getRegions(vm_prodSe), getYears(vm_prodSe),
+                               c(magclass::getNames(collapseNames(vm_prodSe[temapse], collapsedim = c(1, 2))),
+                                 magclass::getNames(collapseNames(vm_prodFe[se2fe], collapsedim = c(1, 2)))))
+ total_te_energy[, , temapse$all_te] <- s_twa2mwh * setNames(vm_prodSe[, , temapse.names], temapse$all_te)
+ total_te_energy[, , se2fe$all_te]   <- s_twa2mwh * vm_prodFe[, , se2fe$all_te]
 
  # set total energy to NA if it is very small (< 100 MWh/yr),
  # this avoids very large or infinite cost parts and weird plots
  total_te_energy[total_te_energy < 100] <- NA
 
  # b) calculate curtailment cost & total energy production after curtailment
- te_curt_cost[,,teVRE] <- te_annual_total_cost_noCurt[,,teVRE] / (total_te_energy[,,teVRE] * (1-curt_share[,,teVRE])) -
-                                          te_annual_total_cost_noCurt[,,teVRE] / total_te_energy[,,teVRE]
+ te_curt_cost[, , teVRE] <- te_annual_total_cost_noCurt[, , teVRE] / (total_te_energy[, , teVRE] * (1 - curt_share[, , teVRE])) -
+                                          te_annual_total_cost_noCurt[, , teVRE] / total_te_energy[, , teVRE]
 
  # calculate total energy production after curtailment
  total_te_energy_usable <- total_te_energy
- total_te_energy_usable[,,teVRE] <- total_te_energy[,,teVRE] - v32_storloss[,ttot_from2005,teVRE]*s_twa2mwh
+ total_te_energy_usable[, , teVRE] <- total_te_energy[, , teVRE] - v32_storloss[, ttot_from2005, teVRE] * s_twa2mwh
 
 
 
@@ -541,137 +558,140 @@ reportLCOE <- function(gdx, output.type = "both"){
  LCOE.avg <- mbind(
       #### Energy technologies (pe2se$all_te)
           ### production cost components
-              setNames(te_annual_inv_cost[,ttot_from2005,pe2se$all_te]/
-                         total_te_energy[,,pe2se$all_te],
-                       paste0("LCOE|average|",pe2se$all_enty1,"|",pe2se$all_te,"|supply-side", "|Investment Cost")),
-              setNames(te_annual_inv_cost_wadj[,ttot_from2005,pe2se$all_te]/
-                         total_te_energy[,,pe2se$all_te],
-                       paste0("LCOE|average|",pe2se$all_enty1,"|",pe2se$all_te,"|supply-side", "|Investment Cost w/ Adj Cost")),
-              setNames(te_annual_fuel_cost[,,pe2se$all_te]/total_te_energy[,,pe2se$all_te],
-                       paste0("LCOE|average|",pe2se$all_enty1,"|",pe2se$all_te,"|supply-side", "|Fuel Cost")),
-              setNames(te_annual_secFuel_cost[,,pe2se$all_te]/total_te_energy[,,pe2se$all_te],
-                       paste0("LCOE|average|",pe2se$all_enty1,"|",pe2se$all_te,"|supply-side", "|Second Fuel Cost")),
-              setNames(te_annual_OMF_cost[,,pe2se$all_te]/total_te_energy[,,pe2se$all_te],
-                       paste0("LCOE|average|",pe2se$all_enty1,"|",pe2se$all_te, "|supply-side","|OMF Cost")),
-              setNames(te_annual_OMV_cost[,,pe2se$all_te]/total_te_energy[,,pe2se$all_te],
-                       paste0("LCOE|average|",pe2se$all_enty1,"|",pe2se$all_te, "|supply-side","|OMV Cost")),
+              setNames(te_annual_inv_cost[, ttot_from2005, pe2se$all_te] /
+                         total_te_energy[, , pe2se$all_te],
+                       paste0("LCOE|average|", pe2se$all_enty1, "|", pe2se$all_te, "|supply-side", "|Investment Cost")),
+              setNames(te_annual_inv_cost_wadj[, ttot_from2005, pe2se$all_te] /
+                         total_te_energy[, , pe2se$all_te],
+                       paste0("LCOE|average|", pe2se$all_enty1, "|", pe2se$all_te, "|supply-side", "|Investment Cost w/ Adj Cost")),
+              setNames(te_annual_fuel_cost[, , pe2se$all_te] / total_te_energy[, , pe2se$all_te],
+                       paste0("LCOE|average|", pe2se$all_enty1, "|", pe2se$all_te, "|supply-side", "|Fuel Cost")),
+              setNames(te_annual_secFuel_cost[, , pe2se$all_te] / total_te_energy[, , pe2se$all_te],
+                       paste0("LCOE|average|", pe2se$all_enty1, "|", pe2se$all_te, "|supply-side", "|Second Fuel Cost")),
+              setNames(te_annual_OMF_cost[, , pe2se$all_te] / total_te_energy[, , pe2se$all_te],
+                       paste0("LCOE|average|", pe2se$all_enty1, "|", pe2se$all_te, "|supply-side", "|OMF Cost")),
+              setNames(te_annual_OMV_cost[, , pe2se$all_te] / total_te_energy[, , pe2se$all_te],
+                       paste0("LCOE|average|", pe2se$all_enty1, "|", pe2se$all_te, "|supply-side", "|OMV Cost")),
           ### calculate VRE grid and storage cost by dividing by usable generation (after generation)
-              setNames(te_annual_stor_cost[,,pe2se$all_te]/total_te_energy_usable[,,pe2se$all_te],
-                       paste0("LCOE|average|",pe2se$all_enty1,"|",pe2se$all_te, "|supply-side","|Storage Cost")),
-              setNames(te_annual_grid_cost[,,pe2se$all_te]/total_te_energy_usable[,,pe2se$all_te],
-                       paste0("LCOE|average|",pe2se$all_enty1,"|",pe2se$all_te, "|supply-side","|Grid Cost")),
+              setNames(te_annual_stor_cost[, , pe2se$all_te] / total_te_energy_usable[, , pe2se$all_te],
+                       paste0("LCOE|average|", pe2se$all_enty1, "|", pe2se$all_te, "|supply-side", "|Storage Cost")),
+              setNames(te_annual_grid_cost[, , pe2se$all_te] / total_te_energy_usable[, , pe2se$all_te],
+                       paste0("LCOE|average|", pe2se$all_enty1, "|", pe2se$all_te, "|supply-side", "|Grid Cost")),
           ### calculate VRE grid and storage cost (with adjustment costs) by dividing by usable generation (after generation)
-              setNames(te_annual_stor_cost_wadj[,,pe2se$all_te]/total_te_energy_usable[,,pe2se$all_te],
-                       paste0("LCOE|average|",pe2se$all_enty1,"|",pe2se$all_te, "|supply-side","|Storage Cost w/ Adj Cost")),
-              setNames(te_annual_grid_cost_wadj[,,pe2se$all_te]/total_te_energy_usable[,,pe2se$all_te],
-                       paste0("LCOE|average|",pe2se$all_enty1,"|",pe2se$all_te, "|supply-side","|Grid Cost w/ Adj Cost")),
+              setNames(te_annual_stor_cost_wadj[, , pe2se$all_te] / total_te_energy_usable[, , pe2se$all_te],
+                       paste0("LCOE|average|", pe2se$all_enty1, "|", pe2se$all_te, "|supply-side", "|Storage Cost w/ Adj Cost")),
+              setNames(te_annual_grid_cost_wadj[, , pe2se$all_te] / total_te_energy_usable[, , pe2se$all_te],
+                       paste0("LCOE|average|", pe2se$all_enty1, "|", pe2se$all_te, "|supply-side", "|Grid Cost w/ Adj Cost")),
           ### add cost for carbon storage and for carbon emissions
-              setNames(te_annual_ccsInj_cost[,,pe2se$all_te]/total_te_energy[,,pe2se$all_te],
-                       paste0("LCOE|average|",pe2se$all_enty1,"|",pe2se$all_te, "|supply-side","|CCS Cost")),
-              setNames(te_annual_ccsInj_inclAdjCost[,,pe2se$all_te]/total_te_energy[,,pe2se$all_te],
-                       paste0("LCOE|average|",pe2se$all_enty1,"|",pe2se$all_te, "|supply-side","|CCS Cost w/ Adj Cost")),
-              setNames(te_annual_co2_cost[,,pe2se$all_te]/total_te_energy[,,pe2se$all_te],
-                       paste0("LCOE|average|",pe2se$all_enty1,"|",pe2se$all_te, "|supply-side","|CO2 Cost")),
+              setNames(te_annual_ccsInj_cost[, , pe2se$all_te] / total_te_energy[, , pe2se$all_te],
+                       paste0("LCOE|average|", pe2se$all_enty1, "|", pe2se$all_te, "|supply-side", "|CCS Cost")),
+              setNames(te_annual_ccsInj_inclAdjCost[, , pe2se$all_te] / total_te_energy[, , pe2se$all_te],
+                       paste0("LCOE|average|", pe2se$all_enty1, "|", pe2se$all_te, "|supply-side", "|CCS Cost w/ Adj Cost")),
+              setNames(te_annual_co2_cost[, , pe2se$all_te] / total_te_energy[, , pe2se$all_te],
+                       paste0("LCOE|average|", pe2se$all_enty1, "|", pe2se$all_te, "|supply-side", "|CO2 Cost")),
           ### add curtailment cost
-              setNames(te_curt_cost[,,pe2se$all_te],
-                       paste0("LCOE|average|",pe2se$all_enty1,"|",pe2se$all_te, "|supply-side","|Curtailment Cost")),
+              setNames(te_curt_cost[, , pe2se$all_te],
+                       paste0("LCOE|average|", pe2se$all_enty1, "|", pe2se$all_te, "|supply-side", "|Curtailment Cost")),
           ### Total Cost
-              setNames((te_annual_inv_cost[,ttot_from2005,pe2se$all_te]+ te_annual_fuel_cost[,,pe2se$all_te] + te_annual_secFuel_cost[,,pe2se$all_te] + te_annual_OMF_cost[,,pe2se$all_te] +
-                             te_annual_OMV_cost[,,pe2se$all_te] + te_annual_ccsInj_cost[,,pe2se$all_te] + te_annual_co2_cost[,,pe2se$all_te])/total_te_energy[,,pe2se$all_te] +
-                       (te_annual_stor_cost[,,pe2se$all_te] + te_annual_grid_cost[,,pe2se$all_te]) / total_te_energy_usable[,,pe2se$all_te] + te_curt_cost[,,pe2se$all_te],
-                       paste0("LCOE|average|",pe2se$all_enty1,"|",pe2se$all_te, "|supply-side","|Total Cost")),
-              setNames((te_annual_inv_cost_wadj[,ttot_from2005,pe2se$all_te]+ te_annual_fuel_cost[,,pe2se$all_te] + te_annual_secFuel_cost[,,pe2se$all_te] + te_annual_OMF_cost[,,pe2se$all_te] +
-                             te_annual_OMV_cost[,,pe2se$all_te] + te_annual_ccsInj_inclAdjCost[,,pe2se$all_te] + te_annual_co2_cost[,,pe2se$all_te])/total_te_energy[,,pe2se$all_te] +
-                       (te_annual_stor_cost_wadj[,,pe2se$all_te] + te_annual_grid_cost_wadj[,,pe2se$all_te]) / total_te_energy_usable[,,pe2se$all_te] + te_curt_cost[,,pe2se$all_te],
-                       paste0("LCOE|average|",pe2se$all_enty1,"|",pe2se$all_te, "|supply-side","|Total Cost w/ Adj Cost")),
+              setNames((te_annual_inv_cost[, ttot_from2005, pe2se$all_te] + te_annual_fuel_cost[, , pe2se$all_te] + te_annual_secFuel_cost[, , pe2se$all_te] + te_annual_OMF_cost[, , pe2se$all_te] +
+                             te_annual_OMV_cost[, , pe2se$all_te] + te_annual_ccsInj_cost[, , pe2se$all_te] + te_annual_co2_cost[, , pe2se$all_te]) / total_te_energy[, , pe2se$all_te] +
+                       (te_annual_stor_cost[, , pe2se$all_te] + te_annual_grid_cost[, , pe2se$all_te]) / total_te_energy_usable[, , pe2se$all_te] + te_curt_cost[, , pe2se$all_te],
+                       paste0("LCOE|average|", pe2se$all_enty1, "|", pe2se$all_te, "|supply-side", "|Total Cost")),
+              setNames((te_annual_inv_cost_wadj[, ttot_from2005, pe2se$all_te] + te_annual_fuel_cost[, , pe2se$all_te] + te_annual_secFuel_cost[, , pe2se$all_te] + te_annual_OMF_cost[, , pe2se$all_te] +
+                             te_annual_OMV_cost[, , pe2se$all_te] + te_annual_ccsInj_inclAdjCost[, , pe2se$all_te] + te_annual_co2_cost[, , pe2se$all_te]) / total_te_energy[, , pe2se$all_te] +
+                       (te_annual_stor_cost_wadj[, , pe2se$all_te] + te_annual_grid_cost_wadj[, , pe2se$all_te]) / total_te_energy_usable[, , pe2se$all_te] + te_curt_cost[, , pe2se$all_te],
+                       paste0("LCOE|average|", pe2se$all_enty1, "|", pe2se$all_te, "|supply-side", "|Total Cost w/ Adj Cost")),
       #### Carbon Transport and storage ("ccsinje")
-              setNames(te_annual_inv_cost[,ttot_from2005,"ccsinje"]/
-                         vm_co2CCS_tCO2[,,"ccsinje.1"],
-                       paste0("LCOCS|average|","ico2|","ccsinje","|carbon management", "|Investment Cost")),
-              setNames(te_annual_inv_cost_wadj[,ttot_from2005,"ccsinje"]/
-                         vm_co2CCS_tCO2[,,"ccsinje.1"],
-                       paste0("LCOCS|average|","ico2|","ccsinje","|carbon management", "|Investment Cost w/ Adj Cost")),
-              setNames(te_annual_OMF_cost[,,"ccsinje"]/vm_co2CCS_tCO2[,,"ccsinje.1"],
-                       paste0("LCOCS|average|","ico2|","ccsinje", "|carbon management","|OMF Cost")),
-              setNames(te_annual_secFuel_cost[,,"ccsinje"]/vm_co2CCS_tCO2[,,"ccsinje.1"],
-                       paste0("LCOCS|average|","ico2|","ccsinje", "|carbon management","|Second Fuel Cost")),
-              setNames((te_annual_inv_cost[,ttot_from2005,"ccsinje"]+te_annual_OMF_cost[,,"ccsinje"]+te_annual_secFuel_cost[,,"ccsinje"])/vm_co2CCS_tCO2[,,"ccsinje.1"],
-                       paste0("LCOCS|average|","ico2|","ccsinje", "|carbon management","|Total Cost")),
-              setNames((te_annual_inv_cost_wadj[,ttot_from2005,"ccsinje"]+te_annual_OMF_cost[,,"ccsinje"]+te_annual_secFuel_cost[,,"ccsinje"])/vm_co2CCS_tCO2[,,"ccsinje.1"],
-                       paste0("LCOCS|average|","ico2|","ccsinje", "|carbon management","|Total Cost w/ Adj Cost")),
+              setNames(te_annual_inv_cost[, ttot_from2005, "ccsinje"] /
+                         vm_co2CCS_tCO2[, , "ccsinje.1"],
+                       paste0("LCOCS|average|", "ico2|", "ccsinje", "|carbon management", "|Investment Cost")),
+              setNames(te_annual_inv_cost_wadj[, ttot_from2005, "ccsinje"] /
+                         vm_co2CCS_tCO2[, , "ccsinje.1"],
+                       paste0("LCOCS|average|", "ico2|", "ccsinje", "|carbon management", "|Investment Cost w/ Adj Cost")),
+              setNames(te_annual_OMF_cost[, , "ccsinje"] / vm_co2CCS_tCO2[, , "ccsinje.1"],
+                       paste0("LCOCS|average|", "ico2|", "ccsinje", "|carbon management", "|OMF Cost")),
+              setNames(te_annual_secFuel_cost[, , "ccsinje"] / vm_co2CCS_tCO2[, , "ccsinje.1"],
+                       paste0("LCOCS|average|", "ico2|", "ccsinje", "|carbon management", "|Second Fuel Cost")),
+              setNames((te_annual_inv_cost[, ttot_from2005, "ccsinje"] + te_annual_OMF_cost[, , "ccsinje"] + te_annual_secFuel_cost[, , "ccsinje"]) / vm_co2CCS_tCO2[, , "ccsinje.1"],
+                       paste0("LCOCS|average|", "ico2|", "ccsinje", "|carbon management", "|Total Cost")),
+              setNames((te_annual_inv_cost_wadj[, ttot_from2005, "ccsinje"] + te_annual_OMF_cost[, , "ccsinje"] + te_annual_secFuel_cost[, , "ccsinje"]) / vm_co2CCS_tCO2[, , "ccsinje.1"],
+                       paste0("LCOCS|average|", "ico2|", "ccsinje", "|carbon management", "|Total Cost w/ Adj Cost")),
       #### Carbon Management Technologies
           ### main cost
-               setNames(te_annual_inv_cost[,ttot_from2005,te_cco2]/
-                         cco2_byTech_tCO2[,ttot_from2005,te_cco2] ,
-                       paste0("LCOCC|average|","cco2|",te_cco2,"|carbon management", "|Investment Cost")),
-              setNames(te_annual_inv_cost_wadj[,ttot_from2005,te_cco2]/
-                         cco2_byTech_tCO2[,ttot_from2005,te_cco2] ,
-                       paste0("LCOCC|average|","cco2|",te_cco2,"|carbon management", "|Investment Cost w/ Adj Cost")),
-              setNames(te_annual_fuel_cost[,,te_cco2]/cco2_byTech_tCO2[,ttot_from2005,te_cco2],
-                       paste0("LCOCC|average|","cco2|",te_cco2, "|carbon management","|Fuel Cost")),
-              setNames(te_annual_secFuel_cost[,,te_cco2]/cco2_byTech_tCO2[,ttot_from2005,te_cco2],
-                       paste0("LCOCC|average|","cco2|",te_cco2, "|carbon management","|Second Fuel Cost")),
-              setNames(te_annual_otherFuel_cost[,,te_cco2]/cco2_byTech_tCO2[,ttot_from2005,te_cco2],
-                       paste0("LCOCC|average|","cco2|",te_cco2, "|carbon management","|Other Fuel Cost")),
-              setNames(te_annual_OMF_cost[,,te_cco2]/cco2_byTech_tCO2[,ttot_from2005,te_cco2],
-                       paste0("LCOCC|average|","cco2|",te_cco2, "|carbon management","|OMF Cost")),
-              setNames(te_annual_OMV_cost[,,te_cco2]/cco2_byTech_tCO2[,ttot_from2005,te_cco2],
-                       paste0("LCOCC|average|","cco2|",te_cco2, "|carbon management","|OMV Cost")),
+               setNames(te_annual_inv_cost[, ttot_from2005, te_cco2] /
+                         cco2_byTech_tCO2[, ttot_from2005, te_cco2],
+                       paste0("LCOCC|average|", "cco2|", te_cco2, "|carbon management", "|Investment Cost")),
+              setNames(te_annual_inv_cost_wadj[, ttot_from2005, te_cco2] /
+                         cco2_byTech_tCO2[, ttot_from2005, te_cco2],
+                       paste0("LCOCC|average|", "cco2|", te_cco2, "|carbon management", "|Investment Cost w/ Adj Cost")),
+              setNames(te_annual_fuel_cost[, , te_cco2] / cco2_byTech_tCO2[, ttot_from2005, te_cco2],
+                       paste0("LCOCC|average|", "cco2|", te_cco2, "|carbon management", "|Fuel Cost")),
+              setNames(te_annual_secFuel_cost[, , te_cco2] / cco2_byTech_tCO2[, ttot_from2005, te_cco2],
+                       paste0("LCOCC|average|", "cco2|", te_cco2, "|carbon management", "|Second Fuel Cost")),
+              setNames(te_annual_otherFuel_cost[, , te_cco2] / cco2_byTech_tCO2[, ttot_from2005, te_cco2],
+                       paste0("LCOCC|average|", "cco2|", te_cco2, "|carbon management", "|Other Fuel Cost")),
+              setNames(te_annual_OMF_cost[, , te_cco2] / cco2_byTech_tCO2[, ttot_from2005, te_cco2],
+                       paste0("LCOCC|average|", "cco2|", te_cco2, "|carbon management", "|OMF Cost")),
+              setNames(te_annual_OMV_cost[, , te_cco2] / cco2_byTech_tCO2[, ttot_from2005, te_cco2],
+                       paste0("LCOCC|average|", "cco2|", te_cco2, "|carbon management", "|OMV Cost")),
           ### cost of storage / amount of the total captured that is stored
-              setNames(te_annual_ccsInj_cost[,ttot_from2005,cco2Techs]/
-                         (cco2_byTech_tCO2[,ttot_from2005,cco2Techs] * dimSums(vm_co2CCS/vm_co2capture)),
-                       paste0("LCOCC|average|","ico2|", cco2Techs, "|carbon management","|CCS Cost")),
-              setNames(te_annual_ccsInj_inclAdjCost[,ttot_from2005,cco2Techs]/
-                         (cco2_byTech_tCO2[,ttot_from2005,cco2Techs] * dimSums(vm_co2CCS/vm_co2capture)),
-                       paste0("LCOCC|average|","ico2|", cco2Techs, "|carbon management","|CCS Cost w/ Adj Cost")),
+              setNames(te_annual_ccsInj_cost[, ttot_from2005, cco2Techs] /
+                         (cco2_byTech_tCO2[, ttot_from2005, cco2Techs] * dimSums(vm_co2CCS / vm_co2capture)),
+                       paste0("LCOCC|average|", "ico2|", cco2Techs, "|carbon management", "|CCS Cost")),
+              setNames(te_annual_ccsInj_inclAdjCost[, ttot_from2005, cco2Techs] /
+                         (cco2_byTech_tCO2[, ttot_from2005, cco2Techs] * dimSums(vm_co2CCS / vm_co2capture)),
+                       paste0("LCOCC|average|", "ico2|", cco2Techs, "|carbon management", "|CCS Cost w/ Adj Cost")),
           ### total cost for capturing co2
-          setNames((te_annual_inv_cost[,ttot_from2005,te_cco2] + te_annual_OMF_cost[,,te_cco2] + te_annual_OMV_cost[,,te_cco2] +
-                      te_annual_fuel_cost[,,te_cco2] + te_annual_secFuel_cost[,,te_cco2] + te_annual_otherFuel_cost[,,te_cco2])/ cco2_byTech_tCO2[,ttot_from2005,te_cco2] ,
-                       paste0("LCOCC|average|","cco2|",te_cco2,"|carbon management", "|Total Cost")),
-          setNames((te_annual_inv_cost_wadj[,ttot_from2005,te_cco2] + te_annual_OMF_cost[,,te_cco2] + te_annual_OMV_cost[,,te_cco2] +
-                      te_annual_fuel_cost[,,te_cco2]+ te_annual_secFuel_cost[,,te_cco2] + te_annual_otherFuel_cost[,,te_cco2]) / cco2_byTech_tCO2[,ttot_from2005,te_cco2] ,
-                       paste0("LCOCC|average|","cco2|",te_cco2,"|carbon management", "|Total Cost w/ Adj Cost")),
+          setNames((te_annual_inv_cost[, ttot_from2005, te_cco2] + te_annual_OMF_cost[, , te_cco2] + te_annual_OMV_cost[, , te_cco2] +
+                      te_annual_fuel_cost[, , te_cco2] + te_annual_secFuel_cost[, , te_cco2] + te_annual_otherFuel_cost[, , te_cco2]) / cco2_byTech_tCO2[, ttot_from2005, te_cco2],
+                       paste0("LCOCC|average|", "cco2|", te_cco2, "|carbon management", "|Total Cost")),
+          setNames((te_annual_inv_cost_wadj[, ttot_from2005, te_cco2] + te_annual_OMF_cost[, , te_cco2] + te_annual_OMV_cost[, , te_cco2] +
+                      te_annual_fuel_cost[, , te_cco2] + te_annual_secFuel_cost[, , te_cco2] + te_annual_otherFuel_cost[, , te_cco2]) / cco2_byTech_tCO2[, ttot_from2005, te_cco2],
+                       paste0("LCOCC|average|", "cco2|", te_cco2, "|carbon management", "|Total Cost w/ Adj Cost")),
           ### total cost for injecting co2.
-          setNames((te_annual_inv_cost[,ttot_from2005,te_cco2] + te_annual_OMF_cost[,,te_cco2] + te_annual_OMV_cost[,,te_cco2] +
-                      te_annual_fuel_cost[,,te_cco2]+ te_annual_secFuel_cost[,,te_cco2] + te_annual_otherFuel_cost[,,te_cco2]) / cco2_byTech_tCO2[,ttot_from2005,te_cco2] +
-                      te_annual_ccsInj_cost[,ttot_from2005,cco2Techs]/ (cco2_byTech_tCO2[,ttot_from2005,cco2Techs] * dimSums(vm_co2CCS/vm_co2capture)) ,
-                       paste0("LCOCCS|average|","ico2|",te_cco2,"|carbon management", "|Total Cost")),
-          setNames((te_annual_inv_cost_wadj[,ttot_from2005,te_cco2] + te_annual_OMF_cost[,,te_cco2] + te_annual_OMV_cost[,,te_cco2] +
-                      te_annual_fuel_cost[,,te_cco2] + te_annual_secFuel_cost[,,te_cco2] + te_annual_otherFuel_cost[,,te_cco2]) / cco2_byTech_tCO2[,ttot_from2005,te_cco2] +
-                      te_annual_ccsInj_inclAdjCost[,ttot_from2005,cco2Techs]/ (cco2_byTech_tCO2[,ttot_from2005,cco2Techs] * dimSums(vm_co2CCS/vm_co2capture)) ,
-                       paste0("LCOCCS|average|","ico2|",te_cco2,"|carbon management", "|Total Cost w/ Adj Cost")),
+          setNames((te_annual_inv_cost[, ttot_from2005, te_cco2] + te_annual_OMF_cost[, , te_cco2] + te_annual_OMV_cost[, , te_cco2] +
+                      te_annual_fuel_cost[, , te_cco2] + te_annual_secFuel_cost[, , te_cco2] + te_annual_otherFuel_cost[, , te_cco2]) / cco2_byTech_tCO2[, ttot_from2005, te_cco2] +
+                      te_annual_ccsInj_cost[, ttot_from2005, cco2Techs] / (cco2_byTech_tCO2[, ttot_from2005, cco2Techs] * dimSums(vm_co2CCS / vm_co2capture)),
+                       paste0("LCOCCS|average|", "ico2|", te_cco2, "|carbon management", "|Total Cost")),
+          setNames((te_annual_inv_cost_wadj[, ttot_from2005, te_cco2] + te_annual_OMF_cost[, , te_cco2] + te_annual_OMV_cost[, , te_cco2] +
+                      te_annual_fuel_cost[, , te_cco2] + te_annual_secFuel_cost[, , te_cco2] + te_annual_otherFuel_cost[, , te_cco2]) / cco2_byTech_tCO2[, ttot_from2005, te_cco2] +
+                      te_annual_ccsInj_inclAdjCost[, ttot_from2005, cco2Techs] / (cco2_byTech_tCO2[, ttot_from2005, cco2Techs] * dimSums(vm_co2CCS / vm_co2capture)),
+                       paste0("LCOCCS|average|", "ico2|", te_cco2, "|carbon management", "|Total Cost w/ Adj Cost")),
       #### Carbon storing Technologies (other than CCUS chain; for now only if EW included, will include biochar in future)
-          if (EW_name %in% teCDR){mbind(
+          if (EW_name %in% teCDR) {
+mbind(
           ## calculation based on removal initiated in t
-              setNames(te_annual_inv_cost[,ttot_from2005,te_sco2]/cdrco2_byTech_tCO2[,ttot_from2005,te_sco2],
-                       paste0("LCOCS|average|","sco2|",te_sco2,"|carbon management", "|Investment Cost")),
-              setNames(te_annual_inv_cost_wadj[,ttot_from2005,te_sco2]/cdrco2_byTech_tCO2[,ttot_from2005,te_sco2],
-                       paste0("LCOCS|average|","sco2|",te_sco2,"|carbon management", "|Investment Cost w/ Adj Cost")),
-              setNames(te_annual_fuel_cost[,,te_sco2]/cdrco2_byTech_tCO2[,ttot_from2005,te_sco2],
-                       paste0("LCOCS|average|","sco2|",te_sco2, "|carbon management","|Fuel Cost")),
-              setNames(te_annual_secFuel_cost[,,te_sco2]/cdrco2_byTech_tCO2[,ttot_from2005,te_sco2],
-                       paste0("LCOCS|average|","sco2|",te_sco2, "|carbon management","|Second Fuel Cost")),
-              setNames(te_annual_otherFuel_cost[,,te_sco2]/cdrco2_byTech_tCO2[,ttot_from2005,te_sco2],
-                       paste0("LCOCC|average|","sco2|",te_sco2, "|carbon management","|Other Fuel Cost")),
-              setNames(te_annual_OMF_cost[,,te_sco2]/cdrco2_byTech_tCO2[,ttot_from2005,te_sco2],
-                       paste0("LCOCS|average|","sco2|",te_sco2, "|carbon management","|OMF Cost")),
-              setNames(te_annual_OMV_cost[,,te_sco2]/cdrco2_byTech_tCO2[,ttot_from2005,te_sco2],
-                       paste0("LCOCS|average|","sco2|",te_sco2, "|carbon management","|OMV Cost")),
+              setNames(te_annual_inv_cost[, ttot_from2005, te_sco2] / cdrco2_byTech_tCO2[, ttot_from2005, te_sco2],
+                       paste0("LCOCS|average|", "sco2|", te_sco2, "|carbon management", "|Investment Cost")),
+              setNames(te_annual_inv_cost_wadj[, ttot_from2005, te_sco2] / cdrco2_byTech_tCO2[, ttot_from2005, te_sco2],
+                       paste0("LCOCS|average|", "sco2|", te_sco2, "|carbon management", "|Investment Cost w/ Adj Cost")),
+              setNames(te_annual_fuel_cost[, , te_sco2] / cdrco2_byTech_tCO2[, ttot_from2005, te_sco2],
+                       paste0("LCOCS|average|", "sco2|", te_sco2, "|carbon management", "|Fuel Cost")),
+              setNames(te_annual_secFuel_cost[, , te_sco2] / cdrco2_byTech_tCO2[, ttot_from2005, te_sco2],
+                       paste0("LCOCS|average|", "sco2|", te_sco2, "|carbon management", "|Second Fuel Cost")),
+              setNames(te_annual_otherFuel_cost[, , te_sco2] / cdrco2_byTech_tCO2[, ttot_from2005, te_sco2],
+                       paste0("LCOCC|average|", "sco2|", te_sco2, "|carbon management", "|Other Fuel Cost")),
+              setNames(te_annual_OMF_cost[, , te_sco2] / cdrco2_byTech_tCO2[, ttot_from2005, te_sco2],
+                       paste0("LCOCS|average|", "sco2|", te_sco2, "|carbon management", "|OMF Cost")),
+              setNames(te_annual_OMV_cost[, , te_sco2] / cdrco2_byTech_tCO2[, ttot_from2005, te_sco2],
+                       paste0("LCOCS|average|", "sco2|", te_sco2, "|carbon management", "|OMV Cost")),
               # specific to enhanced weathering
-              setNames(EW_fixed_other_cost[,,]/cdrco2_byTech_tCO2[,ttot_from2005,EW_name],
-                       paste0("LCOCS|average|","sco2|",EW_name, "|carbon management","|OMF other Cost")),
-              setNames(EW_fixed_transport_cost/cdrco2_byTech_tCO2[,ttot_from2005,EW_name],
-                       paste0("LCOCS|average|","sco2|",EW_name, "|carbon management","|OMF transport Cost")),
+              setNames(EW_fixed_other_cost[, , ] / cdrco2_byTech_tCO2[, ttot_from2005, EW_name],
+                       paste0("LCOCS|average|", "sco2|", EW_name, "|carbon management", "|OMF other Cost")),
+              setNames(EW_fixed_transport_cost / cdrco2_byTech_tCO2[, ttot_from2005, EW_name],
+                       paste0("LCOCS|average|", "sco2|", EW_name, "|carbon management", "|OMF transport Cost")),
               # sum for enhanced weathering (incl. special om cost)
-              setNames((te_annual_inv_cost[,ttot_from2005,EW_name] +  te_annual_OMF_cost[,,EW_name] + te_annual_otherFuel_cost[,,EW_name] + EW_fixed_other_cost +
-                        EW_fixed_transport_cost) / cdrco2_byTech_tCO2[,ttot_from2005,EW_name] ,
-                       paste0("LCOCS|average|","sco2|",EW_name,"|carbon management", "|Total Cost")),
-              setNames((te_annual_inv_cost_wadj[,ttot_from2005,EW_name] + te_annual_otherFuel_cost[,,EW_name] + EW_fixed_other_cost +
-                        EW_fixed_transport_cost ) / cdrco2_byTech_tCO2[,ttot_from2005,EW_name],
-                       paste0("LCOCS|average|","sco2|",EW_name,"|carbon management", "|Total Cost w/ Adj Cost"))
-                       )}
-          else {NULL}
- )*1.2
+              setNames((te_annual_inv_cost[, ttot_from2005, EW_name] +  te_annual_OMF_cost[, , EW_name] + te_annual_otherFuel_cost[, , EW_name] + EW_fixed_other_cost +
+                        EW_fixed_transport_cost) / cdrco2_byTech_tCO2[, ttot_from2005, EW_name],
+                       paste0("LCOCS|average|", "sco2|", EW_name, "|carbon management", "|Total Cost")),
+              setNames((te_annual_inv_cost_wadj[, ttot_from2005, EW_name] + te_annual_otherFuel_cost[, , EW_name] + EW_fixed_other_cost +
+                        EW_fixed_transport_cost) / cdrco2_byTech_tCO2[, ttot_from2005, EW_name],
+                       paste0("LCOCS|average|", "sco2|", EW_name, "|carbon management", "|Total Cost w/ Adj Cost"))
+                       )
+} else {
+NULL
+}
+ ) * 1.2
 
  # convert to better dimensional format
  df.lcoe.avg <- as.quitte(LCOE.avg) %>%
@@ -697,12 +717,12 @@ reportLCOE <- function(gdx, output.type = "both"){
  df.lcoe.avg$cost <- sapply(df.lcoe.avg$cost, "[[", 6)
 
  df.lcoe.avg <- df.lcoe.avg %>%
-                  mutate( unit = "US$2015/MWh") %>%
-                  mutate(unit = case_when(output=="ico2"|output=="cco2"|output=="sco2" ~ "US$2015/tCO2", TRUE ~ unit)) %>%
+                  mutate(unit = "US$2015/MWh") %>%
+                  mutate(unit = case_when(output == "ico2" | output == "cco2" | output == "sco2" ~ "US$2015/tCO2", TRUE ~ unit)) %>%
                   select(region, period, type, output, tech, sector, unit, cost, value)
 
  # reconvert to magpie object
- LCOE.avg.out <- suppressWarnings(as.magpie(df.lcoe.avg, spatial=1, temporal=2, datacol=9))
+ LCOE.avg.out <- suppressWarnings(as.magpie(df.lcoe.avg, spatial = 1, temporal = 2, datacol = 9))
  # bind to output file
  LCOE.out <- mbind(LCOE.out, LCOE.avg.out)
  }
@@ -713,7 +733,6 @@ reportLCOE <- function(gdx, output.type = "both"){
 
 
  if (output.type %in% c("marginal", "both", "marginal detail")) {
-
 # variable definitions for dplyr operations in the following section
 # avoids error of "no visible binding for global variable for X" in buildLibrary()
   region <- NULL
@@ -826,9 +845,9 @@ reportLCOE <- function(gdx, output.type = "both"){
 
 
   ### technologies
-  pe2se <- readGDX(gdx,"pe2se") # pe2se technology mappings
-  se2se <- readGDX(gdx,"se2se") # hydrogen <--> electricity technologies
-  se2fe <- readGDX(gdx,"se2fe") # se2fe technology mappings
+  pe2se <- readGDX(gdx, "pe2se") # pe2se technology mappings
+  se2se <- readGDX(gdx, "se2se") # hydrogen <--> electricity technologies
+  se2fe <- readGDX(gdx, "se2fe") # se2fe technology mappings
   te <- readGDX(gdx, "te") # all technologies
   teStor <- readGDX(gdx, "teStor") # storage technologies for VREs
   teGrid <- readGDX(gdx, "teGrid") # grid technologies for VREs
@@ -836,7 +855,7 @@ reportLCOE <- function(gdx, output.type = "both"){
   teReNoBio <- readGDX(gdx, "teReNoBio") # renewable technologies without biomass
   teCCS <- readGDX(gdx, "teCCS") # ccs technologies
   teReNoBio <- c(teReNoBio) # renewables without biomass
-  teVRE   <- readGDX(gdx,"teVRE") # VRE technologies
+  teVRE   <- readGDX(gdx, "teVRE") # VRE technologies
   # exclude "windoff" from teVRE as "windoff" does not have separate grid, storage technologies
   if ("windoff" %in% as.vector(teVRE)) {
     teVRE <- as.vector(teVRE)
@@ -849,14 +868,14 @@ reportLCOE <- function(gdx, output.type = "both"){
   entyFe <- readGDX(gdx, "entyFe")
 
   # final energy demand
-  vm_demFeSector <- readGDX(gdx, "vm_demFeSector", field = "l", restore_zeros = F)
+  vm_demFeSector <- readGDX(gdx, "vm_demFeSector", field = "l", restore_zeros = FALSE)
 
   # conversion factors
-  s_twa2mwh <- readGDX(gdx,c("sm_TWa_2_MWh","s_TWa_2_MWh","s_twa2mwh"),format="first_found")
+  s_twa2mwh <- readGDX(gdx, c("sm_TWa_2_MWh", "s_TWa_2_MWh", "s_twa2mwh"), format = "first_found")
 
 
   # all technologies to calculate LCOE for
-  te_LCOE <- c(pe2se$all_te, se2se$all_te,se2fe$all_te, "ccsinje")
+  te_LCOE <- c(pe2se$all_te, se2se$all_te, se2fe$all_te, "ccsinje")
 
   # all technologies to calculate investment, adjustment and O&M LCOE for (needed for storage, grid cost)
   te_LCOE_Inv <- c(te_LCOE, as.vector(teStor), as.vector(teGrid), te[te %in% c("dac")])
@@ -865,7 +884,7 @@ reportLCOE <- function(gdx, output.type = "both"){
   te_SE_gen <- c(pe2se$all_te, se2se$all_te)
 
   # auxiliary technologies to calculate other cost parts: grid cost, storage cost, carbon capture and storage
-  te_aux_tech <- c( teStor, teGrid, ccs2te$all_te)
+  te_aux_tech <- c(teStor, teGrid, ccs2te$all_te)
 
   # mappings
   se_gen_mapping <- rbind(pe2se, se2se)
@@ -881,18 +900,18 @@ reportLCOE <- function(gdx, output.type = "both"){
                   rename(tech = all_te)
 
   ### time steps
-  ttot     <- as.numeric(readGDX(gdx,"ttot"))
-  ttot_from2005 <- paste0("y",ttot[which(ttot >= 2005)])
+  ttot     <- as.numeric(readGDX(gdx, "ttot"))
+  ttot_from2005 <- paste0("y", ttot[which(ttot >= 2005)])
 
   ### conversion factors
-  s_twa2mwh <- as.vector(readGDX(gdx,c("sm_TWa_2_MWh","s_TWa_2_MWh","s_twa2mwh"),format="first_found"))
+  s_twa2mwh <- as.vector(readGDX(gdx, c("sm_TWa_2_MWh", "s_TWa_2_MWh", "s_twa2mwh"), format = "first_found"))
 
 
 
   ### Read investment and O&M cost ----
 
   # investment cost
-  vm_costTeCapital <- readGDX(gdx, "vm_costTeCapital", field = "l", restore_zeros = F)[,ttot_from2005,te_LCOE_Inv]
+  vm_costTeCapital <- readGDX(gdx, "vm_costTeCapital", field = "l", restore_zeros = FALSE)[, ttot_from2005, te_LCOE_Inv]
 
 
   df.CAPEX <- as.quitte(vm_costTeCapital) %>%
@@ -902,14 +921,14 @@ reportLCOE <- function(gdx, output.type = "both"){
     select(region, period, tech, fuel, output, CAPEX)
 
   # omf cost
-  pm_data_omf <- readGDX(gdx, "pm_data", restore_zeros = F)[,,"omf"]
+  pm_data_omf <- readGDX(gdx, "pm_data", restore_zeros = FALSE)[, , "omf"]
 
   df.OMF <- as.quitte(pm_data_omf) %>%
     select(region, all_te, value) %>%
     rename(tech = all_te, OMF = value)
 
   # omv cost
-  pm_data_omv <- readGDX(gdx, "pm_data", restore_zeros = F)[,,"omv"]
+  pm_data_omv <- readGDX(gdx, "pm_data", restore_zeros = FALSE)[, , "omv"]
 
   df.OMV <- as.quitte(pm_data_omv) %>%
     select(region, all_te, value) %>%
@@ -919,11 +938,11 @@ reportLCOE <- function(gdx, output.type = "both"){
   # Read/calculate capacity factors ----
 
   # capacity factor of non-renewables
-  vm_capFac <- readGDX(gdx, "vm_capFac", field="l", restore_zeros = F)[,ttot_from2005,]
+  vm_capFac <- readGDX(gdx, "vm_capFac", field = "l", restore_zeros = FALSE)[, ttot_from2005, ]
 
   # calculate renewable capacity factors of new plants
-  v_capDistr <- readGDX(gdx, c("vm_capDistr","v_capDistr"), field = "l", restore_zeros = F)
-  pm_dataren <- readGDX(gdx, "pm_dataren", restore_zeros = F)
+  v_capDistr <- readGDX(gdx, c("vm_capDistr", "v_capDistr"), field = "l", restore_zeros = FALSE)
+  pm_dataren <- readGDX(gdx, "pm_dataren", restore_zeros = FALSE)
 
 
   ### determine capacity factor of highest free grade for renewables
@@ -933,7 +952,7 @@ reportLCOE <- function(gdx, output.type = "both"){
     rename(tech = all_te, CapDistr = value)
 
   # max. potential of renewable production per grade
-  df.RE.maxprod <- as.quitte(pm_dataren[,,c("maxprod","nur")]) %>%
+  df.RE.maxprod <- as.quitte(pm_dataren[, , c("maxprod", "nur")]) %>%
                     rename(tech = all_te) %>%
                     select(region, tech, rlf, char, value) %>%
                     spread(char, value)
@@ -944,7 +963,7 @@ reportLCOE <- function(gdx, output.type = "both"){
                       left_join(df.RE.maxprod, by = c("region", "tech", "rlf")) %>%
                       # filter for the lowest grade that is filled (remark by Robert: this will then slightly overestimate CF for the cases that the model expands this technology, but in such a case it will anyway go into the next bad grade in the next time step, so it should in general look better)
                       # but not smaller than ninth grade (last grade of spv; still check all REN technologies for number of last grade)
-                      filter( CapDistr >= 1e-7 | as.numeric(rlf) >= 9)  %>%
+                      filter(CapDistr >= 1e-7 | as.numeric(rlf) >= 9)  %>%
                       # choose highest grade
                       group_by(region, period, tech) %>%
                       summarise(CapFac = min(nur)) %>%
@@ -954,13 +973,13 @@ reportLCOE <- function(gdx, output.type = "both"){
   df.CapFac <- as.quitte(vm_capFac) %>%
     select(region, period, all_te, value) %>%
     rename(tech = all_te, CapFac = value) %>%
-    filter( ! tech %in% teReNoBio ) %>%
+    filter(!tech %in% teReNoBio) %>%
     rbind(df.CapFac.ren) %>%
-    mutate( period = as.numeric(period))
+    mutate(period = as.numeric(period))
 
   ### Read plant lifetime and annuity factor ----
 
-  #discount rate
+  # discount rate
   r <- 0.051
   # r <- readGDX(gdx, name="p_r", restore_zeros = F)
   #
@@ -974,12 +993,12 @@ reportLCOE <- function(gdx, output.type = "both"){
 
   # read lifetime of technology
   # calculate annuity factor to annuitize CAPEX and OMF (annuity factor labeled "annuity.fac")
-  lt <- readGDX(gdx, name="fm_dataglob", restore_zeros = F)[,,"lifetime"][,,te_LCOE_Inv][,,"lifetime"]
+  lt <- readGDX(gdx, name = "fm_dataglob", restore_zeros = FALSE)[, , "lifetime"][, , te_LCOE_Inv][, , "lifetime"]
 
   df.lifetime <- as.quitte(lt) %>%
     select(all_te, value) %>%
     rename(tech = all_te, lifetime = value) %>%
-    mutate( annuity.fac = r * (1+r)^lifetime/(-1+(1+r)^lifetime))
+    mutate(annuity.fac = r * (1 + r)^lifetime / (-1 + (1 + r)^lifetime))
 
 
   ### note: just take LCOE investment cost formula with fix lifetime, ignoring that in REMIND capacity is drepeciating over time
@@ -989,35 +1008,35 @@ reportLCOE <- function(gdx, output.type = "both"){
   # # annuity factor from REMIND,
   # TODO: check whether this is the same as calculated above
   # so far only used in levelized cost of DAC calculation below
-  p_teAnnuity <- readGDX(gdx, c("p_teAnnuity","pm_teAnnuity"), restore_zeros = F)
+  p_teAnnuity <- readGDX(gdx, c("p_teAnnuity", "pm_teAnnuity"), restore_zeros = FALSE)
 
   ### Read marginal adjustment costs ----
 
   # Read marginal adjustment cost calculated in core/postsolve.gms
   # It is calculated as d(vm_costInvTeAdj) / d(vm_deltaCap).
   # Unit: trUSD2005/ (TW(out)/yr).
-  o_margAdjCostInv <- readGDX(gdx, "o_margAdjCostInv", restore_zeros = F)
+  o_margAdjCostInv <- readGDX(gdx, "o_margAdjCostInv", restore_zeros = FALSE)
 
   df.margAdjCostInv <- as.quitte(o_margAdjCostInv) %>%
                         rename(tech = all_te,
                                AdjCost = value) %>%
-                        select( region, period, tech, AdjCost)
+                        select(region, period, tech, AdjCost)
 
   ### Read fuel price ----
 
 
 
   # fuels to calculate price for
-  fuels <- c("peoil","pegas","pecoal","peur", "pebiolc" , "pebios","pebioil",
-             "seel","seliqbio", "seliqfos","seliqsyn", "sesobio","sesofos","seh2","segabio" ,
-              "segafos","segasyn","sehe")
+  fuels <- c("peoil", "pegas", "pecoal", "peur", "pebiolc", "pebios", "pebioil",
+             "seel", "seliqbio", "seliqfos", "seliqsyn", "sesobio", "sesofos", "seh2", "segabio",
+              "segafos", "segasyn", "sehe")
 
 
 
-  pm_PEPrice <- readGDX(gdx, "pm_PEPrice", restore_zeros = F)
-  pm_SEPrice <- readGDX(gdx, "pm_SEPrice", restore_zeros = F)
+  pm_PEPrice <- readGDX(gdx, "pm_PEPrice", restore_zeros = FALSE)
+  pm_SEPrice <- readGDX(gdx, "pm_SEPrice", restore_zeros = FALSE)
   # bind PE and SE prices and convert from tr USD 2005/TWa to USD2015/MWh
-  Fuel.Price <- mbind(pm_PEPrice,pm_SEPrice )[,,fuels]*1e12/s_twa2mwh*1.2
+  Fuel.Price <- mbind(pm_PEPrice, pm_SEPrice)[, , fuels] * 1e12 / s_twa2mwh * 1.2
 
 
   # Fuel price for the time period for which LCOE are calculated
@@ -1025,20 +1044,20 @@ reportLCOE <- function(gdx, output.type = "both"){
     select(region, period, all_enty, value) %>%
     rename(fuel = all_enty, fuel.price = value) %>%
     # replace zeros by last or (if not available) next value of time series (marginals are sometimes zero if there are other constriants)
-    mutate( fuel.price = ifelse(fuel.price == 0, NA, fuel.price)) %>%
+    mutate(fuel.price = ifelse(fuel.price == 0, NA, fuel.price)) %>%
     group_by(region, fuel) %>%
     tidyr::fill(fuel.price, .direction = "downup") %>%
     ungroup()
 
   ### Read carbon price ----
-  p_priceCO2 <- readGDX(gdx,name=c("p_priceCO2","pm_priceCO2"),format="first_found") # co2 price
+  p_priceCO2 <- readGDX(gdx, name = c("p_priceCO2", "pm_priceCO2"), format = "first_found") # co2 price
 
   # carbon price for the time period for which LCOE are calculated
   df.co2price <- as.quitte(p_priceCO2) %>%
     select(region, period, value) %>%
     # where carbon price is NA, it is zero
     # convert from USD2005/tC CO2 to USD2015/tCO2
-    mutate(value = ifelse(is.na(value), 0, value*1.2/3.66)) %>%
+    mutate(value = ifelse(is.na(value), 0, value * 1.2 / 3.66)) %>%
     rename(co2.price = value)
 
   # Calculate intertemporal fuel and carbon prices ----
@@ -1056,11 +1075,11 @@ reportLCOE <- function(gdx, output.type = "both"){
 
   # retrieve capacity distribution over lifetime
   # (fraction of capacity still standing in that year of plant lifetime)
-  p_omeg  <- readGDX(gdx,c("pm_omeg","p_omeg"),format="first_found")
+  p_omeg  <- readGDX(gdx, c("pm_omeg", "p_omeg"), format = "first_found")
 
   # operation time steps of plant, only take every 5 years and limit calculation to 50 years as
   # by then most of the capacity of all technologies is already retired
-  set_operation_period <- c(1,seq(5,50,5))
+  set_operation_period <- c(1, seq(5, 50, 5))
 
 
   # capacity distribution over lifetime
@@ -1079,11 +1098,11 @@ reportLCOE <- function(gdx, output.type = "both"){
                                            period = getPeriods(df.Fuel.Price)) %>%
                                   # operationPeriod is commissioning period + years of operation (opTimeYr)
                                   # for comissioning period take value of first year of operation
-                                  mutate( operationPeriod = ifelse(as.numeric(opTimeYr) > 1,
+                                  mutate(operationPeriod = ifelse(as.numeric(opTimeYr) > 1,
                                                                    as.numeric(opTimeYr) + period,
                                                                    period)) %>%
                                   # remove time steps from operationPeriod that are not remind_timesteps
-                                  filter( operationPeriod %in% unique(quitte::remind_timesteps$period))
+                                  filter(operationPeriod %in% unique(quitte::remind_timesteps$period))
 
   # Join capacity distribution with above dataframe to get
   # capacity distribution over all commissioning years (period) and
@@ -1102,14 +1121,14 @@ df.fuel.price.weighted <- df.pomeg.expand %>%
                                                "fuel" = "fuel"),
                                         relationship = "many-to-many") %>%
                               # calculate discount factor
-                              mutate( discount =1 / (1+r)^(operationPeriod - period)) %>%
+                              mutate(discount = 1 / (1 + r)^(operationPeriod - period)) %>%
                               # calculate weights over lifetime as operational capacity * discount factor,
                               # normalize by sum over all time steps for weights to add up to one
                               group_by(region, period, tech) %>%
-                              mutate( weight = pomeg * discount / sum(pomeg * discount)) %>%
+                              mutate(weight = pomeg * discount / sum(pomeg * discount)) %>%
                               # calculate average weighted fuel price over lifetime as
                               # the sum of the capacity-discount weights
-                              summarise( fuel.price.weighted = sum(fuel.price * weight)) %>%
+                              summarise(fuel.price.weighted = sum(fuel.price * weight)) %>%
                               ungroup()
 
 
@@ -1124,14 +1143,14 @@ df.co2price.weighted <- df.pomeg.expand %>%
                                     by = c("operationPeriod" = "period"),
                                     relationship = "many-to-many") %>%
                               # calculate discount factor
-                              mutate( discount =1 / (1+r)^(operationPeriod - period)) %>%
+                              mutate(discount = 1 / (1 + r)^(operationPeriod - period)) %>%
                               # calculate weights over lifetime as operational capacity * discount factor,
                               # normalize by sum over all time steps for weights to add up to one
                               group_by(region, period, tech) %>%
-                              mutate( weight = pomeg * discount / sum(pomeg * discount)) %>%
+                              mutate(weight = pomeg * discount / sum(pomeg * discount)) %>%
                               # calculate average weighted fuel price over lifetime as
                               # the sum of the capacity-discount weights
-                              summarise( co2.price.weighted = sum(co2.price * weight)) %>%
+                              summarise(co2.price.weighted = sum(co2.price * weight)) %>%
                               ungroup()
 
 
@@ -1139,36 +1158,36 @@ df.co2price.weighted <- df.pomeg.expand %>%
 
 
   ### Read conversion efficiencies ----
-  pm_eta_conv <- readGDX(gdx,"pm_eta_conv", restore_zeros=F)[,ttot_from2005,] # efficiency oftechnologies with time-independent eta
-  pm_dataeta <- readGDX(gdx,"pm_dataeta", restore_zeros=F)[,ttot_from2005,]# efficiency of technologies with time-dependent eta
+  pm_eta_conv <- readGDX(gdx, "pm_eta_conv", restore_zeros = FALSE)[, ttot_from2005, ] # efficiency oftechnologies with time-independent eta
+  pm_dataeta <- readGDX(gdx, "pm_dataeta", restore_zeros = FALSE)[, ttot_from2005, ] # efficiency of technologies with time-dependent eta
 
-  df.eff <- as.quitte(mbind(pm_eta_conv, pm_dataeta[,,setdiff(getNames(pm_dataeta),getNames(pm_eta_conv))])) %>%
+  df.eff <- as.quitte(mbind(pm_eta_conv, pm_dataeta[, , setdiff(getNames(pm_dataeta), getNames(pm_eta_conv))])) %>%
     rename(tech = all_te, eff = value) %>%
     select(region, period, tech, eff)
 
   ### 11. get emission factors of technologies
-  pm_emifac <- readGDX(gdx,"pm_emifac", restore_zeros=F)[,ttot_from2005,"co2"] # co2 emission factor per technology
-  pm_emifac_cco2 <- readGDX(gdx,"pm_emifac", restore_zeros=F)[,ttot_from2005,"cco2"] # captured co2 emission factor per technology
+  pm_emifac <- readGDX(gdx, "pm_emifac", restore_zeros = FALSE)[, ttot_from2005, "co2"] # co2 emission factor per technology
+  pm_emifac_cco2 <- readGDX(gdx, "pm_emifac", restore_zeros = FALSE)[, ttot_from2005, "cco2"] # captured co2 emission factor per technology
 
   df.emiFac <- as.quitte(pm_emifac) %>%
     # do not need period dimension
     filter(period == 2005) %>%
     select(region, all_te, value) %>%
     # convert from GtC CO2/TWa to tCo2/MWh
-    mutate(value = value / s_twa2mwh * 3.66 *1e9) %>%
+    mutate(value = value / s_twa2mwh * 3.66 * 1e9) %>%
     rename(tech = all_te, emiFac = value) %>%
     # join other technologies without emission factor -> set emission factor to zero
     # (so far, only emissions of energy input captured, not of co2 input for CCU)
     full_join(data.frame(tech = te_LCOE_Inv) %>%
                 expand(tech, region = getRegs(df.CAPEX)), by = c("region", "tech")) %>%
-    mutate( emiFac = ifelse(is.na(emiFac), 0, emiFac))
+    mutate(emiFac = ifelse(is.na(emiFac), 0, emiFac))
 
 
   # get se2fe emision factor to add to calculate CO2 cost for pe2se technologies whose outputs are seliqfos/segasfos etc.
   df.emifac.se2fe <- df.emiFac %>%
-                        left_join(se2fe, by=c("tech"="all_te")) %>%
+                        left_join(se2fe, by = c("tech" = "all_te")) %>%
     # filter for SE fossil, take diesel emifac for all liquids
-    filter(all_enty %in% c("seliqfos","segafos","sesofos")) %>%
+    filter(all_enty %in% c("seliqfos", "segafos", "sesofos")) %>%
     filter(all_enty != "seliqfos" | all_enty1 == "fedie") %>%
     rename(input = all_enty, emiFac.se2fe = emiFac) %>%
     select(region, input, emiFac.se2fe) %>%
@@ -1191,27 +1210,27 @@ df.co2price.weighted <- df.pomeg.expand %>%
   # DAC energy demand per unit captured CO2 (EJ/GtC)
 
   LCOD <- new.magpie(getRegions(vm_costTeCapital), getYears(vm_costTeCapital),
-                     c("Investment Cost","OMF Cost","Electricity Cost","Heat Cost","Total LCOE"), fill = 0)
+                     c("Investment Cost", "OMF Cost", "Electricity Cost", "Heat Cost", "Total LCOE"), fill = 0)
 
   if ("dac" %in% te) {
-    p33_fedem <- readGDX(gdx, "p33_fedem", restore_zeros = F, react = "silent")
+    p33_fedem <- readGDX(gdx, "p33_fedem", restore_zeros = FALSE, react = "silent")
     if (is.null(p33_fedem)) { # compatibility with the REMIND version prior to adding a CDR portfolio
-      p33_dac_fedem_el <- readGDX(gdx, "p33_dac_fedem_el", restore_zeros = F)
-      p33_dac_fedem_heat <- readGDX(gdx, "p33_dac_fedem_heat", restore_zeros = F)
+      p33_dac_fedem_el <- readGDX(gdx, "p33_dac_fedem_el", restore_zeros = FALSE)
+      p33_dac_fedem_heat <- readGDX(gdx, "p33_dac_fedem_heat", restore_zeros = FALSE)
       p33_fedem <- new.magpie(getRegions(p33_dac_fedem_el), getYears(p33_dac_fedem_el), c("dac.feels", "dac.fehes"))
-      p33_fedem[,,"dac.feels"] <- p33_dac_fedem_el
-      p33_fedem[,,"dac.fehes"] <- p33_dac_fedem_heat[,,"fehes"]
+      p33_fedem[, , "dac.feels"] <- p33_dac_fedem_el
+      p33_fedem[, , "dac.fehes"] <- p33_dac_fedem_heat[, , "fehes"]
     }
 
     Fuel.Price <- magclass::matchDim(Fuel.Price, p33_fedem, dim = c(1), fill = 0)
     # capital cost in trUSD2005/GtC -> convert to USD2015/tCO2
-    LCOD[,,"Investment Cost"] <- vm_costTeCapital[,,"dac"] * 1.2 / 3.66 /vm_capFac[,,"dac"] * p_teAnnuity[,,"dac"]*1e3
-    LCOD[,,"OMF Cost"] <-  pm_data_omf[,,"dac"]*vm_costTeCapital[,,"dac"] * 1.2 / 3.66 /vm_capFac[,,"dac"]*1e3
+    LCOD[, , "Investment Cost"] <- vm_costTeCapital[, , "dac"] * 1.2 / 3.66 / vm_capFac[, , "dac"] * p_teAnnuity[, , "dac"] * 1e3
+    LCOD[, , "OMF Cost"] <-  pm_data_omf[, , "dac"] * vm_costTeCapital[, , "dac"] * 1.2 / 3.66 / vm_capFac[, , "dac"] * 1e3
     # elecitricty cost (convert DAC FE demand to GJ/tCO2 and fuel price to USD/GJ)
-    LCOD[,,"Electricity Cost"] <-  p33_fedem[,,"dac.feels"] / 3.66 * Fuel.Price[,,"seel"] / 3.66
+    LCOD[, , "Electricity Cost"] <-  p33_fedem[, , "dac.feels"] / 3.66 * Fuel.Price[, , "seel"] / 3.66
     # TODO: adapt to FE prices and new CDR FE structure, temporary: conversion as above, assume for now that heat is always supplied by district heat
-    LCOD[,,"Heat Cost"] <- p33_fedem[,,"dac.fehes"] / 3.66 * Fuel.Price[,,"sehe"]  / 3.66
-    LCOD[,,"Total LCOE"] <- LCOD[,,"Investment Cost"]+LCOD[,,"OMF Cost"]+LCOD[,,"Electricity Cost"]+LCOD[,,"Heat Cost"]
+    LCOD[, , "Heat Cost"] <- p33_fedem[, , "dac.fehes"] / 3.66 * Fuel.Price[, , "sehe"]  / 3.66
+    LCOD[, , "Total LCOE"] <- LCOD[, , "Investment Cost"] + LCOD[, , "OMF Cost"] + LCOD[, , "Electricity Cost"] + LCOD[, , "Heat Cost"]
   }
 
   getSets(LCOD)[3] <- "cost"
@@ -1222,17 +1241,17 @@ df.co2price.weighted <- df.pomeg.expand %>%
     add_dimension(add = "tech", nm = "dac") %>%
     add_dimension(add = "output", nm = "cco2") %>%
     add_dimension(add = "type", nm = "marginal") %>%
-    add_dimension(add = "sector", dim=3.4, nm = "carbon management")
+    add_dimension(add = "sector", dim = 3.4, nm = "carbon management")
 
 
   # Co2 Capture price, marginal of q_balcapture,  convert from tr USD 2005/GtC to USD2015/tCO2
-  qm_balcapture  <- readGDX(gdx,"q_balcapture",field="m", restore_zeros = F)
+  qm_balcapture  <- readGDX(gdx, "q_balcapture", field = "m", restore_zeros = FALSE)
   Co2.Capt.Price <- qm_balcapture /
-                      (qm_budget[,getYears(qm_balcapture),]+1e-10)*1e3*1.2/3.66 ## looks weird
+                      (qm_budget[, getYears(qm_balcapture), ] + 1e-10) * 1e3 * 1.2 / 3.66 ## looks weird
 
 
   ### for now, just assume CO2 Capture Cost = DAC Cost
-  Co2.Capt.Price[,,] <- LCOD[,,"dac"][,,"Total LCOE"]
+  Co2.Capt.Price[, , ] <- LCOD[, , "dac"][, , "Total LCOE"]
 
   df.Co2.Capt.Price <- as.quitte(Co2.Capt.Price) %>%
     rename(Co2.Capt.Price = value) %>%
@@ -1242,8 +1261,8 @@ df.co2price.weighted <- df.pomeg.expand %>%
 
 
   # CO2 required per unit output (for CCU technologies)
-  if(module2realisation["CCU",2] == "on") {
-    p39_co2_dem <- readGDX(gdx, c("p39_co2_dem","p39_ratioCtoH"), restore_zeros = F)[,,]
+  if (module2realisation["CCU", 2] == "on") {
+    p39_co2_dem <- readGDX(gdx, c("p39_co2_dem", "p39_ratioCtoH"), restore_zeros = FALSE)[, , ]
   } else {
     # some dummy data, only needed to create the following data frame if CCU is off
     p39_co2_dem <- new.magpie(getRegions(vm_costTeCapital), getYears(vm_costTeCapital), fill = 0)
@@ -1253,26 +1272,26 @@ df.co2price.weighted <- df.pomeg.expand %>%
     rename(co2_dem = value, tech = all_te) %>%
     select(region, period, tech, co2_dem) %>%
     # from GtC CO2/TWa(H2) to tCO2/MWh(H2)
-    mutate( co2_dem = co2_dem * 3.66 / s_twa2mwh * 1e9)
+    mutate(co2_dem = co2_dem * 3.66 / s_twa2mwh * 1e9)
 
   ### 13. calculate share stored carbon from capture carbon
-  vm_co2CCS <- readGDX(gdx, "vm_co2CCS", field = "l", restore_zeros = F)
-  vm_co2capture <- readGDX(gdx, "vm_co2capture", field = "l", restore_zeros = F)
+  vm_co2CCS <- readGDX(gdx, "vm_co2CCS", field = "l", restore_zeros = FALSE)
+  vm_co2capture <- readGDX(gdx, "vm_co2capture", field = "l", restore_zeros = FALSE)
 
-  if(getSets(vm_co2capture)[[3]] == "emiAll"){
+  if (getSets(vm_co2capture)[[3]] == "emiAll") {
       sel_vm_co2capture_cco2 <- mselect(vm_co2capture, emiAll = "cco2")
   } else {
       sel_vm_co2capture_cco2 <- mselect(vm_co2capture, all_enty = "cco2")
   }
 
   p_share_carbonCapture_stor <- (
-    vm_co2CCS[,,"cco2.ico2.ccsinje.1"]
+    vm_co2CCS[, , "cco2.ico2.ccsinje.1"]
     / dimSums(sel_vm_co2capture_cco2, dim = 3)
   )
   p_share_carbonCapture_stor[is.na(p_share_carbonCapture_stor)] <- 1
 
   df.CO2StoreShare <- as.quitte(p_share_carbonCapture_stor) %>%
-    rename( CO2StoreShare = value) %>%
+    rename(CO2StoreShare = value) %>%
     select(region, period, CO2StoreShare)
 
   # Note: This is assuming that the CO2 capture to storage share stays constant over time.
@@ -1286,7 +1305,7 @@ df.co2price.weighted <- df.pomeg.expand %>%
   # mapping of SE technologies that require second fuel input (own consumption)
   pc2te <- readGDX(gdx, "pc2te")
   # second fuel production per unit output of technology
-  pm_prodCouple <- readGDX(gdx, "pm_prodCouple", restore_zeros = F)
+  pm_prodCouple <- readGDX(gdx, "pm_prodCouple", restore_zeros = FALSE)
 
   # secfuel.prod (share of coupled production per unit output),
   # secfuel.price (price of coupled product)
@@ -1305,16 +1324,16 @@ df.co2price.weighted <- df.pomeg.expand %>%
     # curtailment cost = LCOE(VRE) * curtshare/((1-curtShare)),
     # where LCOE(VRE) is the generation LCOE of VREs, so Investment Cost + O&M Cost
 
-    if (module2realisation["power",2] == "RLDC") {
-      v32_curt <- readGDX(gdx,name=c("v32_curt"),field="l",restore_zeros=FALSE,format="first_found")
-    } else if (module2realisation["power",2] %in% c("IntC","DTcoup")) {
-      v32_curt <- v32_storloss[,ttot_from2005,getNames(vm_prodSe, dim=3)]
-    } else{
+    if (module2realisation["power", 2] == "RLDC") {
+      v32_curt <- readGDX(gdx, name = c("v32_curt"), field = "l", restore_zeros = FALSE, format = "first_found")
+    } else if (module2realisation["power", 2] %in% c("IntC", "DTcoup")) {
+      v32_curt <- v32_storloss[, ttot_from2005, getNames(vm_prodSe, dim = 3)]
+    } else {
       v32_curt <- 0
     }
 
 
-    curt_share <- v32_curt[,,teVRE] / vm_prodSe[,,teVRE]
+    curt_share <- v32_curt[, , teVRE] / vm_prodSe[, , teVRE]
 
     df.curtShare <- as.quitte(curt_share) %>%
                       rename(tech = all_te, curtShare = value) %>%
@@ -1325,27 +1344,27 @@ df.co2price.weighted <- df.pomeg.expand %>%
 ### Calculate CCS tax ----
 
     # following q21_taxrevCCS
-    vm_co2CCS <- readGDX(gdx, "vm_co2CCS", field = "l", restore_zeros = F)
+    vm_co2CCS <- readGDX(gdx, "vm_co2CCS", field = "l", restore_zeros = FALSE)
     sm_ccsinjecrate <- readGDX(gdx, c("sm_ccsinjecrate", "s_ccsinjecrate"), format = "first_found")
     pm_ccsinjecrate <- readGDX(gdx, "pm_ccsinjecrate", react = "silent")
     if (is.null(pm_ccsinjecrate)) pm_ccsinjecrate <- sm_ccsinjecrate
-    pm_dataccs <- readGDX(gdx, "pm_dataccs", restore_zeros = F)
+    pm_dataccs <- readGDX(gdx, "pm_dataccs", restore_zeros = FALSE)
 
 
     # calculate storage share of captured CO2,
     # for now take the storage share of the construction year of plant, it will not change much over time
     # (if CCS, then no CCU and v_capturevalve is mostly small)
-    vm_co2CCS <- readGDX(gdx, "vm_co2CCS", field = "l", restore_zeros = F)
-    vm_co2capture <- readGDX(gdx, "vm_co2capture", field = "l", restore_zeros = F)
+    vm_co2CCS <- readGDX(gdx, "vm_co2CCS", field = "l", restore_zeros = FALSE)
+    vm_co2capture <- readGDX(gdx, "vm_co2capture", field = "l", restore_zeros = FALSE)
 
 
     # calculate stored CO2 per output of capture technology (GtC/TWa)
-    pm_eff <- mbind(pm_eta_conv, pm_dataeta[,, setdiff(getNames(pm_dataeta), getNames(pm_eta_conv)) ])
-    vm_co2CCS_m <- pm_emifac_cco2/pm_eff[,,getNames(pm_emifac_cco2, dim=3)]*collapseNames(p_share_carbonCapture_stor)
+    pm_eff <- mbind(pm_eta_conv, pm_dataeta[, , setdiff(getNames(pm_dataeta), getNames(pm_eta_conv))])
+    vm_co2CCS_m <- pm_emifac_cco2 / pm_eff[, , getNames(pm_emifac_cco2, dim = 3)] * collapseNames(p_share_carbonCapture_stor)
 
 
     # calculate CCS tax markup following q21_taxrevCCS, convert to USD2015/MWh
-    CCStax <- dimReduce(pm_data_omf[,,"ccsinje"]*vm_costTeCapital[,,"ccsinje"]*vm_co2CCS_m^2/pm_dataccs[,,"quan.1"]/pm_ccsinjecrate/s_twa2mwh*1e12*1.2)
+    CCStax <- dimReduce(pm_data_omf[, , "ccsinje"] * vm_costTeCapital[, , "ccsinje"] * vm_co2CCS_m^2 / pm_dataccs[, , "quan.1"] / pm_ccsinjecrate / s_twa2mwh * 1e12 * 1.2)
 
 
     df.CCStax <- as.quitte(CCStax) %>%
@@ -1354,21 +1373,21 @@ df.co2price.weighted <- df.pomeg.expand %>%
 
     # Note: CCS tax still to fix, set temporarily to 0
     df.CCStax <- df.CCStax %>%
-                  mutate( CCStax.cost = 0)
+                  mutate(CCStax.cost = 0)
 
 
 
 ### Read Flexibility Tax ----
 
     cm_FlexTax <- readGDX(gdx, "cm_flex_tax")
-    v32_flexPriceShare <- readGDX(gdx, "v32_flexPriceShare", field = "l", restore_zeros = F)
+    v32_flexPriceShare <- readGDX(gdx, "v32_flexPriceShare", field = "l", restore_zeros = FALSE)
     if (is.null(v32_flexPriceShare) | is.null(cm_FlexTax)) {
       v32_flexPriceShare <- vm_costTeCapital
-      v32_flexPriceShare[,,] <- 1
+      v32_flexPriceShare[, , ] <- 1
     } else {
       if (cm_FlexTax == 0) {
         v32_flexPriceShare <- vm_costTeCapital
-        v32_flexPriceShare[,,] <- 1
+        v32_flexPriceShare[, , ] <- 1
       }
     }
 
@@ -1380,18 +1399,18 @@ df.co2price.weighted <- df.pomeg.expand %>%
 ### Read SE Tax for Electrolysis ----
 
     # read SE tax for electrolysis from GDX
-    v21_tau_SE_tax <- readGDX(gdx, "v21_tau_SE_tax", field = "l", restore_zeros = F, react = "silent")
+    v21_tau_SE_tax <- readGDX(gdx, "v21_tau_SE_tax", field = "l", restore_zeros = FALSE, react = "silent")
     # if not SE tax in run, set to 0
-    if(is.null(v21_tau_SE_tax)) {
+    if (is.null(v21_tau_SE_tax)) {
       v21_tau_SE_tax <- vm_costTeCapital
-      v21_tau_SE_tax[,,] <- 0
+      v21_tau_SE_tax[, , ] <- 0
     }
 
     df.tau_SE_tax <- as.quitte(v21_tau_SE_tax) %>%
                       rename(tech = all_te, tau_SE_tax = value) %>%
                       select(region, period, tech, tau_SE_tax) %>%
                       # convert to USD2015/MWh
-                      mutate( tau_SE_tax = 1.2 / as.vector(s_twa2mwh) * 1e12 * tau_SE_tax)
+                      mutate(tau_SE_tax = 1.2 / as.vector(s_twa2mwh) * 1e12 * tau_SE_tax)
 
 
 
@@ -1404,8 +1423,8 @@ df.co2price.weighted <- df.pomeg.expand %>%
     sector.mapping <- c("build" = "buildings", "indst" = "industry", "trans" = "transport")
 
 
-    pm_tau_fe_tax <- readGDX(gdx, c("p21_tau_fe_tax","pm_tau_fe_tax"), restore_zeros = F)
-    pm_tau_fe_sub <- readGDX(gdx, c("p21_tau_fe_sub","pm_tau_fe_sub"), restore_zeros = F)
+    pm_tau_fe_tax <- readGDX(gdx, c("p21_tau_fe_tax", "pm_tau_fe_tax"), restore_zeros = FALSE)
+    pm_tau_fe_sub <- readGDX(gdx, c("p21_tau_fe_sub", "pm_tau_fe_sub"), restore_zeros = FALSE)
 
     df.taxrate <- as.quitte(pm_tau_fe_tax * 1.2 / s_twa2mwh * 1e12) %>%
                     rename(taxrate = value)
@@ -1416,14 +1435,14 @@ df.co2price.weighted <- df.pomeg.expand %>%
     df.FEtax <- df.taxrate %>%
                   full_join(df.subrate) %>%
                   # set NA to 0
-                  mutate(subrate = ifelse(is.na(subrate),0,subrate),
-                         taxrate = ifelse(is.na(taxrate),0,taxrate)) %>%
+                  mutate(subrate = ifelse(is.na(subrate), 0, subrate),
+                         taxrate = ifelse(is.na(taxrate), 0, taxrate)) %>%
                   # taxrate + subsidy rate = net FE tax
-                  mutate( FEtax = taxrate + subrate) %>%
+                  mutate(FEtax = taxrate + subrate) %>%
                   filter(emi_sectors %in% names(sector.mapping)) %>%
                   revalue.levels(emi_sectors = sector.mapping) %>%
-                  rename( sector = emi_sectors, output = all_enty) %>%
-                  select(region,period,sector,output,FEtax)
+                  rename(sector = emi_sectors, output = all_enty) %>%
+                  select(region, period, sector, output, FEtax)
 
 
 
@@ -1432,29 +1451,29 @@ df.co2price.weighted <- df.pomeg.expand %>%
     ### for buildings and industry (calculate average cost for simplicity, not marginal)
 
 
-    v37_costAddTeInvH2 <- readGDX(gdx, "v37_costAddTeInvH2", field = "l", restore_zeros = F, react = "silent")
-    v36_costAddTeInvH2 <- readGDX(gdx, "v36_costAddTeInvH2", field = "l", restore_zeros = F, react = "silent")
+    v37_costAddTeInvH2 <- readGDX(gdx, "v37_costAddTeInvH2", field = "l", restore_zeros = FALSE, react = "silent")
+    v36_costAddTeInvH2 <- readGDX(gdx, "v36_costAddTeInvH2", field = "l", restore_zeros = FALSE, react = "silent")
 
 
     df.AddTeInvH2 <- NULL
     if (!is.null(v36_costAddTeInvH2)) {
 
-      df.AddTeInvH2Build <- as.quitte(v36_costAddTeInvH2[,ttot_from2005,"tdh2s"] / collapseNames(dimSums(vm_demFeSector[,ttot_from2005,"seh2.feh2s.build"], dim=3.4, na.rm = T)) / s_twa2mwh * 1e12 * 1.2) %>%
-                            mutate( value = ifelse(is.infinite(value), 0, value)) %>%
-                            mutate( emi_sectors = "buildings") %>%
+      df.AddTeInvH2Build <- as.quitte(v36_costAddTeInvH2[, ttot_from2005, "tdh2s"] / collapseNames(dimSums(vm_demFeSector[, ttot_from2005, "seh2.feh2s.build"], dim = 3.4, na.rm = TRUE)) / s_twa2mwh * 1e12 * 1.2) %>%
+                            mutate(value = ifelse(is.infinite(value), 0, value)) %>%
+                            mutate(emi_sectors = "buildings") %>%
                             select(region, period, all_te, emi_sectors, value) %>%
-                            rename( AddH2TdCost = value, sector = emi_sectors, tech = all_te)
+                            rename(AddH2TdCost = value, sector = emi_sectors, tech = all_te)
 
       df.AddTeInvH2 <- rbind(df.AddTeInvH2, df.AddTeInvH2Build)
     }
 
     if (!is.null(v37_costAddTeInvH2)) {
 
-      df.AddTeInvH2Indst <- as.quitte(v37_costAddTeInvH2[,ttot_from2005,"tdh2s"] / collapseNames(dimSums(vm_demFeSector[,ttot_from2005,"seh2.feh2s.indst"], dim=3.4, na.rm = T)) / s_twa2mwh * 1e12 * 1.2) %>%
-        mutate( value = ifelse(is.infinite(value), 0, value)) %>%
-        mutate( emi_sectors = "industry") %>%
+      df.AddTeInvH2Indst <- as.quitte(v37_costAddTeInvH2[, ttot_from2005, "tdh2s"] / collapseNames(dimSums(vm_demFeSector[, ttot_from2005, "seh2.feh2s.indst"], dim = 3.4, na.rm = TRUE)) / s_twa2mwh * 1e12 * 1.2) %>%
+        mutate(value = ifelse(is.infinite(value), 0, value)) %>%
+        mutate(emi_sectors = "industry") %>%
         select(region, period, all_te, emi_sectors, value) %>%
-        rename( AddH2TdCost = value, sector = emi_sectors, tech = all_te)
+        rename(AddH2TdCost = value, sector = emi_sectors, tech = all_te)
 
       df.AddTeInvH2 <- rbind(df.AddTeInvH2, df.AddTeInvH2Indst)
     }
@@ -1478,7 +1497,7 @@ df.co2price.weighted <- df.pomeg.expand %>%
     left_join(df.emiFac, by = c("region", "tech")) %>%
     left_join(df.emifac.se2fe, by = c("region", "tech")) %>%
     left_join(df.Co2.Capt.Price, by = c("region", "period")) %>%
-    left_join(df.co2_dem, by = c("region", "period", if (module2realisation["CCU",2] == "on") "tech")) %>%
+    left_join(df.co2_dem, by = c("region", "period", if (module2realisation["CCU", 2] == "on") "tech")) %>%
     left_join(df.CO2StoreShare, by = c("region", "period")) %>%
     left_join(df.secfuel, by = c("region", "period", "tech", "fuel")) %>%
     left_join(df.curtShare, by = c("region", "period", "tech")) %>%
@@ -1488,36 +1507,36 @@ df.co2price.weighted <- df.pomeg.expand %>%
     left_join(df.FEtax, relationship = "many-to-many", by = c("region", "period", "output")) %>%
     left_join(df.AddTeInvH2, by = c("region", "period", "tech", "sector")) %>%
     # filter to only have LCOE technologies
-    filter( tech %in% c(te_LCOE))
+    filter(tech %in% c(te_LCOE))
 
 
   # only retain unique region, period, tech combinations
   df.LCOE <- df.LCOE %>%
-              unique(by=c("region", "period", "tech","sector"))
+              unique(by = c("region", "period", "tech", "sector"))
 
 
   # replace NA by 0 in certain columns
   # columns where NA should be replaced by 0
-  col.NA.zero <- c("OMF","OMV", "AdjCost","co2.price","co2.price.weighted", "fuel.price","fuel.price.weighted", "co2_dem","emiFac.se2fe","Co2.Capt.Price",
-                   "secfuel.prod", "secfuel.price", "curtShare","CCStax.cost","FEtax","AddH2TdCost","tau_SE_tax")
-  df.LCOE[,col.NA.zero][is.na(df.LCOE[,col.NA.zero])] <- 0
+  col.NA.zero <- c("OMF", "OMV", "AdjCost", "co2.price", "co2.price.weighted", "fuel.price", "fuel.price.weighted", "co2_dem", "emiFac.se2fe", "Co2.Capt.Price",
+                   "secfuel.prod", "secfuel.price", "curtShare", "CCStax.cost", "FEtax", "AddH2TdCost", "tau_SE_tax")
+  df.LCOE[, col.NA.zero][is.na(df.LCOE[, col.NA.zero])] <- 0
 
   # replace NA by 1 in certain columns
   # columns where NA should be replaced by 1
   col.NA.one <- c("FlexPriceShare")
-  df.LCOE[,col.NA.one][is.na(df.LCOE[,col.NA.one])] <- 1
+  df.LCOE[, col.NA.one][is.na(df.LCOE[, col.NA.one])] <- 1
 
   # replace NA for sectors by "supply-side" (for all SE generating technologies)
   # Carbon management for all technologies handling CO2
   df.LCOE <- df.LCOE %>%
-              mutate( sector = ifelse(tech %in% c(ccs2te$all_te),
+              mutate(sector = ifelse(tech %in% c(ccs2te$all_te),
                                             "carbon management",
                                             sector)) %>%
-              mutate( sector = ifelse(tech %in% c(pe2se$all_te,
+              mutate(sector = ifelse(tech %in% c(pe2se$all_te,
                                                   se2se$all_te),
                                              "supply-side",
                                               sector)) %>%
-              filter( !is.na(sector))
+              filter(!is.na(sector))
 
 
 
@@ -1531,14 +1550,14 @@ df.co2price.weighted <- df.pomeg.expand %>%
     # in case of CCS technologies convert from tr USD2005/GtC to USD2015/tCO2
     mutate(CAPEX = ifelse(tech %in% ccs2te$all_te,
                           # CCS technology unit conversion
-                          CAPEX *1.2*1e3/3.66,
+                          CAPEX * 1.2 * 1e3 / 3.66,
                           # energy technology unit conversion
-                          CAPEX *1.2 * 1e3),
+                          CAPEX * 1.2 * 1e3),
            AdjCost = ifelse(tech %in% ccs2te$all_te,
                             # CCS technology unit conversion
-                            AdjCost *1.2*1e3/3.66,
+                            AdjCost * 1.2 * 1e3 / 3.66,
                             # energy technology unit conversion
-                            AdjCost *1.2 * 1e3)) %>%
+                            AdjCost * 1.2 * 1e3)) %>%
     # conversion from tr USD 2005/TWa to USD2015/MWh
     # in case of CCS technologies convert from tr USD2005/GtC to USD2015/tCO2
     mutate(OMV = ifelse(tech %in% ccs2te$all_te,
@@ -1547,9 +1566,9 @@ df.co2price.weighted <- df.pomeg.expand %>%
                         # energy technology unit conversion
                         OMV * 1.2 / as.numeric(s_twa2mwh) * 1e12)) %>%
     # share of stored carbon from captured carbon is only relevant for CCS technologies, others -> 1
-    mutate( CO2StoreShare = ifelse(tech %in% teCCS, CO2StoreShare, 1)) %>%
+    mutate(CO2StoreShare = ifelse(tech %in% teCCS, CO2StoreShare, 1)) %>%
     # calculate annuity factor for annualizing investment cost over lifetime
-    mutate( annuity.fac = r * (1+r)^lifetime/(-1+(1+r)^lifetime))
+    mutate(annuity.fac = r * (1 + r)^lifetime / (-1 + (1 + r)^lifetime))
 
 
 # LCOE Calculation (marginal) ----
@@ -1557,54 +1576,54 @@ df.co2price.weighted <- df.pomeg.expand %>%
 
   df.LCOE <- df.LCOE %>%
     # investment cost LCOE in USD/MWh or USD/tCO2
-    mutate( `Investment Cost` = ifelse(tech %in% ccs2te$all_te,
+    mutate(`Investment Cost` = ifelse(tech %in% ccs2te$all_te,
                                        # CCS technology, CAPEX in USD/tCO2
                                        CAPEX * annuity.fac / CapFac,
                                        # energy technology, CAPEX in USD/kW(out)
-                                       CAPEX * annuity.fac / (CapFac*8760)*1e3)) %>%
+                                       CAPEX * annuity.fac / (CapFac * 8760) * 1e3)) %>%
     # OMF cost LCOE in USD/MWh, OMF are defined as share of CAPEX
-    mutate( `OMF Cost` = ifelse(tech %in% ccs2te$all_te,
+    mutate(`OMF Cost` = ifelse(tech %in% ccs2te$all_te,
                                 # CCS technology, CAPEX in USD/tCO2
                                 CAPEX * OMF / CapFac,
                                 # energy technology, CAPEX in USD/kW(out)
-                                CAPEX * OMF / (CapFac*8760)*1e3)) %>%
-    mutate( `OMV Cost` = OMV) %>%
+                                CAPEX * OMF / (CapFac * 8760) * 1e3)) %>%
+    mutate(`OMV Cost` = OMV) %>%
     # adjustment cost LCOE in USD/MWh or USD/tCO2
     # (parallel to investment cost calculation)
-    mutate( `Adjustment Cost` = ifelse(tech %in% ccs2te$all_te,
+    mutate(`Adjustment Cost` = ifelse(tech %in% ccs2te$all_te,
                                        # CCS technology, CAPEX in USD/tCO2
                                        AdjCost * annuity.fac / CapFac,
                                        # energy technology, CAPEX in USD/kW(out)
-                                       AdjCost * annuity.fac / (CapFac*8760)*1e3)) %>%
+                                       AdjCost * annuity.fac / (CapFac * 8760) * 1e3)) %>%
     # Fuel Cost
     # # Fuel cost with fuel price of time step for which LCOE are calculated
-    mutate( `Fuel Cost (time step prices)` = fuel.price / eff) %>%
+    mutate(`Fuel Cost (time step prices)` = fuel.price / eff) %>%
     # Fuel cost with weighted average fuel price over plant lifetime
-    mutate(  `Fuel Cost (intertemporal prices)` = fuel.price.weighted / eff) %>%
+    mutate(`Fuel Cost (intertemporal prices)` = fuel.price.weighted / eff) %>%
     # CO2 Tax cost
     # CO2 Tax cost on SE level refer to (supply-side) emissions of pe2se technologies
     # CO2 Tax cost on FE level refer to (demand-side) emissions of FE carriers
     # # CO2 Tax cost with co2 price of time step for which LCOE are calculated
-    mutate( `CO2 Tax Cost (time step prices)` = co2.price * (emiFac / eff) * CO2StoreShare) %>%
+    mutate(`CO2 Tax Cost (time step prices)` = co2.price * (emiFac / eff) * CO2StoreShare) %>%
     # CO2 Tax cost with weighted average co2 price over plant lifetime
     # These are the  CO2 tax cost that feature the total LCOE calculate below
-    mutate(  `CO2 Tax Cost (intertemporal prices)` = co2.price.weighted * (emiFac / eff) * CO2StoreShare) %>%
-    mutate( `CO2 Provision Cost` = Co2.Capt.Price * co2_dem) %>%
+    mutate(`CO2 Tax Cost (intertemporal prices)` = co2.price.weighted * (emiFac / eff) * CO2StoreShare) %>%
+    mutate(`CO2 Provision Cost` = Co2.Capt.Price * co2_dem) %>%
     # fuel cost of second fuel if technology has two inputs or outputs
     # is positive for cost of second input
     # is negative for benefit of a second output
-    mutate( `Second Fuel Cost` = -(secfuel.prod * secfuel.price)) %>%
+    mutate(`Second Fuel Cost` = -(secfuel.prod * secfuel.price)) %>%
     # curtailment cost are generation LCOE of VRE technologies of curtailed generation
-    mutate( `Curtailment Cost` = curtShare / (1-curtShare) * (`Investment Cost` + `OMF Cost` + `OMV Cost`)) %>%
+    mutate(`Curtailment Cost` = curtShare / (1 - curtShare) * (`Investment Cost` + `OMF Cost` + `OMV Cost`)) %>%
     # CCS Tax cost as defined in 21_tax module
-    mutate( `CCS Tax Cost` = CCStax.cost) %>%
+    mutate(`CCS Tax Cost` = CCStax.cost) %>%
     # Flex Tax benefit for electrolysis
     # FlexPriceShare denotes share of the electricity price that electrolysis sees
-    mutate( `Flex Tax` = -(1-FlexPriceShare) * `Fuel Cost (time step prices)`) %>%
+    mutate(`Flex Tax` = -(1 - FlexPriceShare) * `Fuel Cost (time step prices)`) %>%
     # SE tax for electrolysis, calculates fuel cost increase due to taxes and grid fees on electricity going into electrolysis
     mutate(`SE Tax` = tau_SE_tax / eff) %>%
     # se2fe technologies come with FE tax
-    mutate( `FE Tax` = FEtax,
+    mutate(`FE Tax` = FEtax,
     # FE H2 has some additional t&d cost at low H2 shares (phase-in cost) in REMIND
             `Additional H2 t&d Cost` = AddH2TdCost) %>%
     # calculate total LCOE by adding all components
@@ -1626,10 +1645,10 @@ df.co2price.weighted <- df.pomeg.expand %>%
     df.LCOE.out <- df.LCOE %>%
       select(region, period, tech, output, sector,
              `Investment Cost`, `Adjustment Cost`, `OMF Cost`, `OMV Cost`,
-             `Fuel Cost (time step prices)` , `CO2 Tax Cost (time step prices)`,
+             `Fuel Cost (time step prices)`, `CO2 Tax Cost (time step prices)`,
              `Fuel Cost (intertemporal prices)`, `CO2 Tax Cost (intertemporal prices)`,
-             `CO2 Provision Cost`,`Second Fuel Cost`, `Curtailment Cost`,
-             `CCS Tax Cost`, `Flex Tax`,`SE Tax`,`FE Tax`,`Additional H2 t&d Cost`,
+             `CO2 Provision Cost`, `Second Fuel Cost`, `Curtailment Cost`,
+             `CCS Tax Cost`, `Flex Tax`, `SE Tax`, `FE Tax`, `Additional H2 t&d Cost`,
              `Total LCOE (time step prices)`,
              `Total LCOE (intertemporal prices)`
               ) %>%
@@ -1637,26 +1656,26 @@ df.co2price.weighted <- df.pomeg.expand %>%
       mutate(unit = ifelse(tech %in% ccs2te$all_te,
                            "US$2015/tCO2",
                            "US$2015/MWh"),
-             type="marginal") %>%
-      filter( value != 0) %>%
+             type = "marginal") %>%
+      filter(value != 0) %>%
       select(region, period, type, output, tech, sector, unit, cost, value)
 
-    LCOE.mar.out <- as.magpie(df.LCOE.out, spatial = 1, temporal = 2, datacol=9)
+    LCOE.mar.out <- as.magpie(df.LCOE.out, spatial = 1, temporal = 2, datacol = 9)
 
 
 
     # add DAC levelized cost, buildings UE LCOE to marginal LCOE
     LCOE.mar.out <- mbind(LCOE.mar.out, LCOD)
     # bind to previous calculations (if there are)
-    LCOE.out <- mbind(LCOE.out,LCOE.mar.out)
+    LCOE.out <- mbind(LCOE.out, LCOE.mar.out)
 
  }
 
  ### calculate global average LCOE for region "World"
- LCOE.out.inclGlobal <- new.magpie(c(getRegions(LCOE.out),"GLO"), getYears(LCOE.out), getNames(LCOE.out))
+ LCOE.out.inclGlobal <- new.magpie(c(getRegions(LCOE.out), "GLO"), getYears(LCOE.out), getNames(LCOE.out))
  getSets(LCOE.out.inclGlobal) <- getSets(LCOE.out)
- LCOE.out.inclGlobal[getRegions(LCOE.out),,] <- LCOE.out
- LCOE.out.inclGlobal["GLO",,] <- dimSums(LCOE.out, dim=1) / length(getRegions(LCOE.out))
+ LCOE.out.inclGlobal[getRegions(LCOE.out), , ] <- LCOE.out
+ LCOE.out.inclGlobal["GLO", , ] <- dimSums(LCOE.out, dim = 1) / length(getRegions(LCOE.out))
 
 
 

--- a/R/reportPE.R
+++ b/R/reportPE.R
@@ -120,7 +120,7 @@ reportPE <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq
   tmp2 <- mbind(tmp2, setNames(dimSums(mselect(prodSE, all_enty = "pehyd"), dim = 3),    "PE|+|Hydro (EJ/yr)"))
   tmp2 <- mbind(tmp2, setNames(dimSums(mselect(prodSE, all_enty = "pewin"), dim = 3),    "PE|+|Wind (EJ/yr)"))
   if ("windon" %in% te) {
-    tmp2 <- mbind(tmp2, setNames(dimSums(mselect(prodSE, all_enty = "pewin", all_te = "windon"), dim = 3),    "PE|Wind|+|Onshore (EJ/yr)"))
+    tmp2 <- mbind(tmp2, setNames(dimSums(mselect(prodSE, all_enty = "pewin", all_te = "windon"), dim = 3),  "PE|Wind|+|Onshore (EJ/yr)"))
     tmp2 <- mbind(tmp2, setNames(dimSums(mselect(prodSE, all_enty = "pewin", all_te = "windoff"), dim = 3), "PE|Wind|+|Offshore (EJ/yr)"))
   } else {
     tmp2 <- mbind(tmp2, setNames(dimSums(mselect(prodSE, all_enty = "pewin", all_te = "wind"), dim = 3),    "PE|Wind|+|Onshore (EJ/yr)"))

--- a/R/reportPE.R
+++ b/R/reportPE.R
@@ -1,203 +1,207 @@
 #' Read in GDX and calculate primary energy, used in convGDX2MIF.R for the
 #' reporting
-#' 
+#'
 #' Read in primary energy information from GDX file, information used in
 #' convGDX2MIF.R for the reporting
-#' 
-#' 
+#'
+#'
 #' @param gdx a GDX as created by readGDX, or the file name of a gdx
 #' @param regionSubsetList a list containing regions to create report variables region
 #' aggregations. If NULL (default value) only the global region aggregation "GLO" will
 #' be created.
 #' @param t temporal resolution of the reporting, default:
 #' t=c(seq(2005,2060,5),seq(2070,2110,10),2130,2150)
-#' 
+#'
 #' @author Lavinia Baumstark
 #' @examples
-#' 
-#' \dontrun{reportPE(gdx)}
-#' 
+#' \dontrun{
+#' reportPE(gdx)
+#' }
+#'
 #' @export
 #' @importFrom gdx readGDX
 #' @importFrom magclass mselect getYears getNames<- mbind setNames
 
-reportPE <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2070,2110,10),2130,2150)){
+reportPE <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150)) {
   ####### conversion factors ##########
   TWa_2_EJ     <- 31.536
   ####### read in needed data #########
   ## sets
-  pe2se    <- readGDX(gdx,"pe2se")
+  pe2se    <- readGDX(gdx, "pe2se")
   te       <- readGDX(gdx, "te")
-  tefosccs <- readGDX(gdx,c("teFosCCS","tefosccs"),format="first_found")
-  teccs    <- readGDX(gdx,c("teCCS","teccs"),format="first_found")
-  tenoccs  <- readGDX(gdx,c("teNoCCS","tenoccs"),format="first_found")
-  pebio    <- readGDX(gdx,c("peBio","pebio"),format="first_found")
-  sety     <- readGDX(gdx,c("entySe","sety"),format="first_found")
-  oc2te    <- readGDX(gdx,c("pc2te","oc2te"),format="first_found")
-  
+  tefosccs <- readGDX(gdx, c("teFosCCS", "tefosccs"), format = "first_found")
+  teccs    <- readGDX(gdx, c("teCCS", "teccs"), format = "first_found")
+  tenoccs  <- readGDX(gdx, c("teNoCCS", "tenoccs"), format = "first_found")
+  pebio    <- readGDX(gdx, c("peBio", "pebio"), format = "first_found")
+  sety     <- readGDX(gdx, c("entySe", "sety"), format = "first_found")
+  oc2te    <- readGDX(gdx, c("pc2te", "oc2te"), format = "first_found")
+
   # the set liquids changed from sepet+sedie to seLiq in REMIND 1.7. Seliq, sega and seso changed to include biomass or Fossil origin after REMIND 2.0
-  se_Liq    <- intersect(c("seliqfos", "seliqbio", "seliq", "sepet","sedie"),sety)
-  se_Gas    <- intersect(c("segafos", "segabio", "sega"),sety)
-  se_Solids <- intersect(c("sesofos", "sesobio", "seso"),sety)
-  
-  enty2rlf <- readGDX(gdx,c("pe2rlf","enty2rlf"),format="first_found")
+  se_Liq    <- intersect(c("seliqfos", "seliqbio", "seliq", "sepet", "sedie"), sety)
+  se_Gas    <- intersect(c("segafos", "segabio", "sega"), sety)
+  se_Solids <- intersect(c("sesofos", "sesobio", "seso"), sety)
+
+  enty2rlf <- readGDX(gdx, c("pe2rlf", "enty2rlf"), format = "first_found")
   ## parameter
-  dataoc_tmp       <- readGDX(gdx,c("pm_prodCouple","p_prodCouple","p_dataoc"),restore_zeros=FALSE,format="first_found") 
+  dataoc_tmp       <- readGDX(gdx, c("pm_prodCouple", "p_prodCouple", "p_dataoc"), restore_zeros = FALSE, format = "first_found")
   dataoc_tmp[is.na(dataoc_tmp)] <- 0
-  p_costsPEtradeMp <- readGDX(gdx,c("pm_costsPEtradeMp","p_costsPEtradeMp"),restore_zeros=FALSE)
-  p_macBase        <- readGDX(gdx,c("pm_macBaseMagpie","p_macBaseMagpie","p_macBase"),format="first_found")*TWa_2_EJ
+  p_costsPEtradeMp <- readGDX(gdx, c("pm_costsPEtradeMp", "p_costsPEtradeMp"), restore_zeros = FALSE)
+  p_macBase        <- readGDX(gdx, c("pm_macBaseMagpie", "p_macBaseMagpie", "p_macBase"), format = "first_found") * TWa_2_EJ
 #  p_macEmi         <- readGDX(gdx,c("p_macEmi"),format="first_found")*TWa_2_EJ
   ## variables
-  demPE  <- readGDX(gdx,name=c("vm_demPe","v_pedem"),field="l",restore_zeros=FALSE,format="first_found")*TWa_2_EJ
+  demPE  <- readGDX(gdx, name = c("vm_demPe", "v_pedem"), field = "l", restore_zeros = FALSE, format = "first_found") * TWa_2_EJ
   demPE  <- demPE[pe2se]
-  prodSE <- readGDX(gdx,name=c("vm_prodSe","v_seprod"),field="l",restore_zeros=FALSE,format="first_found")*TWa_2_EJ
-  prodSE <- mselect(prodSE,all_enty1=sety)
-  fuelex <- readGDX(gdx,c("vm_fuExtr","vm_fuelex"),field="l",format="first_found")*TWa_2_EJ
-  Mport  <- readGDX(gdx,c("vm_Mport"),field="l",format="first_found")*TWa_2_EJ
-  Xport  <- readGDX(gdx,c("vm_Xport"),field="l",format="first_found")*TWa_2_EJ
+  prodSE <- readGDX(gdx, name = c("vm_prodSe", "v_seprod"), field = "l", restore_zeros = FALSE, format = "first_found") * TWa_2_EJ
+  prodSE <- mselect(prodSE, all_enty1 = sety)
+  fuelex <- readGDX(gdx, c("vm_fuExtr", "vm_fuelex"), field = "l", format = "first_found") * TWa_2_EJ
+  Mport  <- readGDX(gdx, c("vm_Mport"), field = "l", format = "first_found") * TWa_2_EJ
+  Xport  <- readGDX(gdx, c("vm_Xport"), field = "l", format = "first_found") * TWa_2_EJ
   ####### calculate minimal temporal resolution #####
-  y <- Reduce(intersect,list(getYears(demPE),getYears(prodSE)))
-  demPE  <- demPE[,y,]
-  prodSE <- prodSE[,y,]
-  fuelex <- fuelex[,y,]
-  Mport  <- Mport[,y,]
-  Xport  <- Xport[,y,]
-  p_macBase <- p_macBase[,y,]
+  y <- Reduce(intersect, list(getYears(demPE), getYears(prodSE)))
+  demPE  <- demPE[, y, ]
+  prodSE <- prodSE[, y, ]
+  fuelex <- fuelex[, y, ]
+  Mport  <- Mport[, y, ]
+  Xport  <- Xport[, y, ]
+  p_macBase <- p_macBase[, y, ]
 #  p_macEmi  <- p_macEmi[,y,]
   ####### fix negative values to 0 ##################
   #### adjust regional dimension of dataoc
-  dataoc <- new.magpie(getRegions(prodSE),getYears(dataoc_tmp),magclass::getNames(dataoc_tmp),fill=0)
-  dataoc[getRegions(dataoc_tmp),,] <- dataoc_tmp
+  dataoc <- new.magpie(getRegions(prodSE), getYears(dataoc_tmp), magclass::getNames(dataoc_tmp), fill = 0)
+  dataoc[getRegions(dataoc_tmp), , ] <- dataoc_tmp
   getSets(dataoc) <- getSets(dataoc_tmp)
-  dataoc[dataoc<0] <- 0
+  dataoc[dataoc < 0] <- 0
   ####### internal function for reporting ###########
-  pe_carrier <- function(demPE,dataoc,oc2te,sety,pecarrier,secarrier,te=pe2se$all_te,name=NULL){
-    ## identify all techs with secarrier as a main product    
-    sub1_oc2te <- oc2te[(oc2te$all_enty %in% pecarrier) & (oc2te$all_enty1 %in% secarrier) & (oc2te$all_enty2 %in% sety)    & (oc2te$all_te %in% te),]
-    ## identify all techs with secarrier as a couple product        
-    sub2_oc2te <- oc2te[(oc2te$all_enty %in% pecarrier) & (oc2te$all_enty1 %in% sety)    & (oc2te$all_enty2 %in% secarrier) & (oc2te$all_te %in% te),]
+  pe_carrier <- function(demPE, dataoc, oc2te, sety, pecarrier, secarrier, te = pe2se$all_te, name = NULL) {
+    ## identify all techs with secarrier as a main product
+    sub1_oc2te <- oc2te[(oc2te$all_enty %in% pecarrier) & (oc2te$all_enty1 %in% secarrier) & (oc2te$all_enty2 %in% sety)    & (oc2te$all_te %in% te), ]
+    ## identify all techs with secarrier as a couple product
+    sub2_oc2te <- oc2te[(oc2te$all_enty %in% pecarrier) & (oc2te$all_enty1 %in% sety)    & (oc2te$all_enty2 %in% secarrier) & (oc2te$all_te %in% te), ]
     ## all primary energy demand with secarrier as a main product
-    x1 <- dimSums(mselect(demPE,all_enty=pecarrier,all_enty1=secarrier,all_te=te),dim=3)  
+    x1 <- dimSums(mselect(demPE, all_enty = pecarrier, all_enty1 = secarrier, all_te = te), dim = 3)
     ## negative term for couple products by technologies with secarrier as a main product
-    x2 <- dimSums(demPE[sub1_oc2te]*dataoc[sub1_oc2te]/(1+dataoc[sub1_oc2te]),dim=3)
+    x2 <- dimSums(demPE[sub1_oc2te] * dataoc[sub1_oc2te] / (1 + dataoc[sub1_oc2te]), dim = 3)
     ## additional pe demand for technologies with secarrier as a couple product
-    x3 <- dimSums(demPE[sub2_oc2te]*dataoc[sub2_oc2te]/(1+dataoc[sub2_oc2te]),dim=3)
-    out <- (x1-x2+x3)
-    if(!is.null(name)) magclass::getNames(out) <- name
+    x3 <- dimSums(demPE[sub2_oc2te] * dataoc[sub2_oc2te] / (1 + dataoc[sub2_oc2te]), dim = 3)
+    out <- (x1 - x2 + x3)
+    if (!is.null(name)) magclass::getNames(out) <- name
     return(out)
   }
   ####### calculate reporting parameters ############
-  tmp1 <- NULL 
+  tmp1 <- NULL
   tmp1 <- mbind(
-          setNames(dimSums(demPE[,,c("peoil","pecoal","pegas")],dim=3),          "PE|Fossil (EJ/yr)"),
-          setNames(dimSums(demPE[,,tefosccs],dim=3),                             "PE|Fossil|w/ CC (EJ/yr)"),
-          setNames(dimSums(demPE[,,c("peoil","pecoal","pegas")],dim=3) 
-                 - dimSums(demPE[,,tefosccs],dim=3),                             "PE|Fossil|w/o CC (EJ/yr)"),
-          setNames(dimSums(demPE[,,"pecoal"],dim=3),                             "PE|+|Coal (EJ/yr)"),
-          setNames(dimSums(mselect(demPE,all_enty="pecoal",all_te=teccs),dim=3), "PE|Coal|w/ CC (EJ/yr)"),
-          setNames(dimSums(demPE[,,"pecoal"],dim=3)
-                 - dimSums(mselect(demPE,all_enty="pecoal",all_te=teccs),dim=3), "PE|Coal|w/o CC (EJ/yr)"),
-          setNames(dimSums(demPE[,,"peoil"],dim=3),                              "PE|+|Oil (EJ/yr)"),
-          setNames(dimSums(mselect(demPE,all_enty="peoil",all_te=tenoccs),dim=3),"PE|Oil|w/o CC (EJ/yr)"),
-          setNames(dimSums(demPE[,,"pegas"],dim=3),                              "PE|+|Gas (EJ/yr)"),
-          setNames(dimSums(mselect(demPE,all_enty="pegas",all_te=teccs),dim=3),  "PE|Gas|w/ CC (EJ/yr)"),
-          setNames(dimSums(demPE[,,"pegas"],dim=3)
-                 - dimSums(mselect(demPE,all_enty="pegas",all_te=teccs),dim=3),  "PE|Gas|w/o CC (EJ/yr)"),
-          setNames(dimSums(demPE[,,pebio],dim=3),                                "PE|+|Biomass (EJ/yr)"),
-          setNames(dimSums(mselect(demPE,all_enty=pebio,all_te=teccs),dim=3),    "PE|Biomass|w/ CC (EJ/yr)"),
-          setNames(dimSums(demPE[,,pebio],dim=3)
-                 - dimSums(mselect(demPE,all_enty=pebio,all_te=teccs),dim=3),    "PE|Biomass|w/o CC (EJ/yr)"),
-          setNames(dimSums(mselect(demPE,all_enty=pebio,all_te="biotr"),dim=3),  "PE|Biomass|Traditional (EJ/yr)"),
-          setNames(dimSums(demPE[,,c("pebios","pebioil")],dim=3),                "PE|Biomass|1st Generation (EJ/yr)"),
-          setNames(dimSums(demPE[,,pebio],dim=3)
-                 - dimSums(mselect(demPE,all_enty=pebio,all_te="biotr"),dim=3),  "PE|Biomass|Modern (EJ/yr)")
+          setNames(dimSums(demPE[, , c("peoil", "pecoal", "pegas")], dim = 3),          "PE|Fossil (EJ/yr)"),
+          setNames(dimSums(demPE[, , tefosccs], dim = 3),                             "PE|Fossil|w/ CC (EJ/yr)"),
+          setNames(dimSums(demPE[, , c("peoil", "pecoal", "pegas")], dim = 3)
+                 - dimSums(demPE[, , tefosccs], dim = 3),                             "PE|Fossil|w/o CC (EJ/yr)"),
+          setNames(dimSums(demPE[, , "pecoal"], dim = 3),                             "PE|+|Coal (EJ/yr)"),
+          setNames(dimSums(mselect(demPE, all_enty = "pecoal", all_te = teccs), dim = 3), "PE|Coal|w/ CC (EJ/yr)"),
+          setNames(dimSums(demPE[, , "pecoal"], dim = 3)
+                 - dimSums(mselect(demPE, all_enty = "pecoal", all_te = teccs), dim = 3), "PE|Coal|w/o CC (EJ/yr)"),
+          setNames(dimSums(demPE[, , "peoil"], dim = 3),                              "PE|+|Oil (EJ/yr)"),
+          setNames(dimSums(mselect(demPE, all_enty = "peoil", all_te = tenoccs), dim = 3), "PE|Oil|w/o CC (EJ/yr)"),
+          setNames(dimSums(demPE[, , "pegas"], dim = 3),                              "PE|+|Gas (EJ/yr)"),
+          setNames(dimSums(mselect(demPE, all_enty = "pegas", all_te = teccs), dim = 3),  "PE|Gas|w/ CC (EJ/yr)"),
+          setNames(dimSums(demPE[, , "pegas"], dim = 3)
+                 - dimSums(mselect(demPE, all_enty = "pegas", all_te = teccs), dim = 3),  "PE|Gas|w/o CC (EJ/yr)"),
+          setNames(dimSums(demPE[, , pebio], dim = 3),                                "PE|+|Biomass (EJ/yr)"),
+          setNames(dimSums(mselect(demPE, all_enty = pebio, all_te = teccs), dim = 3),    "PE|Biomass|w/ CC (EJ/yr)"),
+          setNames(dimSums(demPE[, , pebio], dim = 3)
+                 - dimSums(mselect(demPE, all_enty = pebio, all_te = teccs), dim = 3),    "PE|Biomass|w/o CC (EJ/yr)"),
+          setNames(dimSums(mselect(demPE, all_enty = pebio, all_te = "biotr"), dim = 3),  "PE|Biomass|Traditional (EJ/yr)"),
+          setNames(dimSums(demPE[, , c("pebios", "pebioil")], dim = 3),                "PE|Biomass|1st Generation (EJ/yr)"),
+          setNames(dimSums(demPE[, , pebio], dim = 3)
+                 - dimSums(mselect(demPE, all_enty = pebio, all_te = "biotr"), dim = 3),  "PE|Biomass|Modern (EJ/yr)")
           )
   # Nuclear and Renewables
-  tmp2 <- NULL 
-  tmp2 <- mbind(tmp2,setNames(dimSums(mselect(prodSE,all_enty="peur"),dim=3),     "PE|+|Nuclear (EJ/yr)"))
-  tmp2 <- mbind(tmp2,setNames(dimSums(mselect(prodSE,all_enty=c("pegeo","pehyd","pewin","pesol")),dim=3),"PE|Non-Biomass Renewables (EJ/yr)"))
-  tmp2 <- mbind(tmp2,setNames(dimSums(mselect(prodSE,all_enty="pehyd"),dim=3),    "PE|+|Hydro (EJ/yr)"))
-  tmp2 <- mbind(tmp2,setNames(dimSums(mselect(prodSE,all_enty="pewin"),dim=3),    "PE|+|Wind (EJ/yr)"))
-  if ("windoff" %in% te) {
-    tmp2 <- mbind(tmp2,setNames(dimSums(mselect(prodSE,all_enty="pewin",all_te="wind"),dim=3),    "PE|Wind|+|Onshore (EJ/yr)"))  
-    tmp2 <- mbind(tmp2,setNames(dimSums(mselect(prodSE,all_enty="pewin",all_te="windoff"),dim=3), "PE|Wind|+|Offshore (EJ/yr)"))
+  tmp2 <- NULL
+  tmp2 <- mbind(tmp2, setNames(dimSums(mselect(prodSE, all_enty = "peur"), dim = 3),     "PE|+|Nuclear (EJ/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(mselect(prodSE, all_enty = c("pegeo", "pehyd", "pewin", "pesol")), dim = 3), "PE|Non-Biomass Renewables (EJ/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(mselect(prodSE, all_enty = "pehyd"), dim = 3),    "PE|+|Hydro (EJ/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(mselect(prodSE, all_enty = "pewin"), dim = 3),    "PE|+|Wind (EJ/yr)"))
+  if ("windon" %in% te) {
+    tmp2 <- mbind(tmp2, setNames(dimSums(mselect(prodSE, all_enty = "pewin", all_te = "windon"), dim = 3),    "PE|Wind|+|Onshore (EJ/yr)"))
+    tmp2 <- mbind(tmp2, setNames(dimSums(mselect(prodSE, all_enty = "pewin", all_te = "windoff"), dim = 3), "PE|Wind|+|Offshore (EJ/yr)"))
+  } else {
+    tmp2 <- mbind(tmp2, setNames(dimSums(mselect(prodSE, all_enty = "pewin", all_te = "wind"), dim = 3),    "PE|Wind|+|Onshore (EJ/yr)"))
+    tmp2 <- mbind(tmp2, setNames(dimSums(mselect(prodSE, all_enty = "pewin", all_te = "windoff"), dim = 3), "PE|Wind|+|Offshore (EJ/yr)"))
   }
-  tmp2 <- mbind(tmp2,setNames(dimSums(mselect(prodSE,all_enty="pesol"),dim=3),    "PE|+|Solar (EJ/yr)"))
-  tmp2 <- mbind(tmp2,setNames(dimSums(mselect(prodSE,all_enty="pegeo"),dim=3),    "PE|+|Geothermal (EJ/yr)"))
-                
+  tmp2 <- mbind(tmp2, setNames(dimSums(mselect(prodSE, all_enty = "pesol"), dim = 3),    "PE|+|Solar (EJ/yr)"))
+  tmp2 <- mbind(tmp2, setNames(dimSums(mselect(prodSE, all_enty = "pegeo"), dim = 3),    "PE|+|Geothermal (EJ/yr)"))
+
   # primary energy consumption per carrier  --- use function declared above
-  tmp3 <- mbind(pe_carrier(demPE,dataoc,oc2te,sety,pebio,"seel",                     name="PE|Biomass|Electricity (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,pebio,"seel",teccs,               name="PE|Biomass|Electricity|w/ CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,pebio,"seel",tenoccs,             name="PE|Biomass|Electricity|w/o CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,pebio,se_Gas,                     name="PE|Biomass|Gases (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,pebio,se_Gas,teccs,               name="PE|Biomass|Gases|w/ CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,pebio,se_Gas,tenoccs,             name="PE|Biomass|Gases|w/o CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,pebio,"seh2",                     name="PE|Biomass|Hydrogen (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,pebio,"seh2",teccs,               name="PE|Biomass|Hydrogen|w/ CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,pebio,"seh2",tenoccs,             name="PE|Biomass|Hydrogen|w/o CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,pebio,se_Liq ,                    name="PE|Biomass|Liquids (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,pebio,se_Liq,teccs,               name="PE|Biomass|Liquids|w/ CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,pebio,se_Liq,tenoccs,             name="PE|Biomass|Liquids|w/o CC (EJ/yr)"),
-                
-                pe_carrier(demPE,dataoc,oc2te,sety,"pebiolc",se_Liq ,                name="PE|Biomass|Liquids|Cellulosic (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pebiolc",se_Liq ,teccs,          name="PE|Biomass|Liquids|Cellulosic|w/ CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pebiolc",se_Liq ,tenoccs,        name="PE|Biomass|Liquids|Cellulosic|w/o CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,c("pebioil", "pebios"), se_Liq ,  name="PE|Biomass|Liquids|Non-Cellulosic (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pebios",se_Liq ,                 name="PE|Biomass|Liquids|Conventional Ethanol (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,pebio,se_Liq , c("bioftrec", "bioftcrec","biodiesel"),
-                                                                                     name="PE|Biomass|Liquids|Biodiesel (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,pebio,se_Liq , c("bioftcrec"),
-                                                                                     name="PE|Biomass|Liquids|Biodiesel|w/ CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,pebio,se_Liq , c("bioftrec","biodiesel"),
-                                                                                     name="PE|Biomass|Liquids|Biodiesel|w/o CC (EJ/yr)"),
-                
-                
-                
-                
-                pe_carrier(demPE,dataoc,oc2te,sety,pebio,c(se_Solids),                  name="PE|Biomass|Solids (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,pebio,c("sehe"),                  name="PE|Biomass|Heat (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pecoal","seel",                  name="PE|Coal|Electricity (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pecoal","seel",teccs,            name="PE|Coal|Electricity|w/ CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pecoal","seel",tenoccs,          name="PE|Coal|Electricity|w/o CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pecoal",se_Gas,                  name="PE|Coal|Gases (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pecoal",se_Gas,teccs,            name="PE|Coal|Gases|w/ CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pecoal",se_Gas,tenoccs,          name="PE|Coal|Gases|w/o CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pecoal",se_Liq,                  name="PE|Coal|Liquids (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pecoal",se_Liq,teccs,            name="PE|Coal|Liquids|w/ CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pecoal",se_Liq,tenoccs,          name="PE|Coal|Liquids|w/o CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pecoal","seh2",                  name="PE|Coal|Hydrogen (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pecoal","seh2",teccs,            name="PE|Coal|Hydrogen|w/ CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pecoal","seh2",tenoccs,          name="PE|Coal|Hydrogen|w/o CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pecoal",c("sehe"),               name="PE|Coal|Heat (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pecoal",c(se_Solids),               name="PE|Coal|Solids (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pegas","seel",                   name="PE|Gas|Electricity (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pegas","seel",teccs,             name="PE|Gas|Electricity|w/ CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pegas","seel",tenoccs,           name="PE|Gas|Electricity|w/o CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pegas",c(se_Gas),                name="PE|Gas|Gases (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pegas",se_Liq,                   name="PE|Gas|Liquids (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pegas",se_Liq,teccs,             name="PE|Gas|Liquids|w/ CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pegas",se_Liq,tenoccs,           name="PE|Gas|Liquids|w/o CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pegas",c("sehe"),                name="PE|Gas|Heat (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pegas",c("seh2"),                name="PE|Gas|Hydrogen (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pegas",c("seh2"),teccs,          name="PE|Gas|Hydrogen|w/ CC (EJ/yr)"),
-                pe_carrier(demPE,dataoc,oc2te,sety,"pegas",c("seh2"),tenoccs,        name="PE|Gas|Hydrogen|w/o CC (EJ/yr)"),
-                setNames(dimSums(mselect(prodSE,all_enty="pesol",all_enty1="seel"),dim=3),"PE|Solar|Electricity (EJ/yr)"))
+  tmp3 <- mbind(pe_carrier(demPE, dataoc, oc2te, sety, pebio, "seel",                     name = "PE|Biomass|Electricity (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, pebio, "seel", teccs,               name = "PE|Biomass|Electricity|w/ CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, pebio, "seel", tenoccs,             name = "PE|Biomass|Electricity|w/o CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, pebio, se_Gas,                     name = "PE|Biomass|Gases (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, pebio, se_Gas, teccs,               name = "PE|Biomass|Gases|w/ CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, pebio, se_Gas, tenoccs,             name = "PE|Biomass|Gases|w/o CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, pebio, "seh2",                     name = "PE|Biomass|Hydrogen (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, pebio, "seh2", teccs,               name = "PE|Biomass|Hydrogen|w/ CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, pebio, "seh2", tenoccs,             name = "PE|Biomass|Hydrogen|w/o CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, pebio, se_Liq,                    name = "PE|Biomass|Liquids (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, pebio, se_Liq, teccs,               name = "PE|Biomass|Liquids|w/ CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, pebio, se_Liq, tenoccs,             name = "PE|Biomass|Liquids|w/o CC (EJ/yr)"),
+
+                pe_carrier(demPE, dataoc, oc2te, sety, "pebiolc", se_Liq,                name = "PE|Biomass|Liquids|Cellulosic (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pebiolc", se_Liq, teccs,          name = "PE|Biomass|Liquids|Cellulosic|w/ CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pebiolc", se_Liq, tenoccs,        name = "PE|Biomass|Liquids|Cellulosic|w/o CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, c("pebioil", "pebios"), se_Liq,  name = "PE|Biomass|Liquids|Non-Cellulosic (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pebios", se_Liq,                 name = "PE|Biomass|Liquids|Conventional Ethanol (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, pebio, se_Liq, c("bioftrec", "bioftcrec", "biodiesel"),
+                                                                                     name = "PE|Biomass|Liquids|Biodiesel (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, pebio, se_Liq, c("bioftcrec"),
+                                                                                     name = "PE|Biomass|Liquids|Biodiesel|w/ CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, pebio, se_Liq, c("bioftrec", "biodiesel"),
+                                                                                     name = "PE|Biomass|Liquids|Biodiesel|w/o CC (EJ/yr)"),
+
+
+
+
+                pe_carrier(demPE, dataoc, oc2te, sety, pebio, c(se_Solids),                  name = "PE|Biomass|Solids (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, pebio, c("sehe"),                  name = "PE|Biomass|Heat (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pecoal", "seel",                  name = "PE|Coal|Electricity (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pecoal", "seel", teccs,            name = "PE|Coal|Electricity|w/ CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pecoal", "seel", tenoccs,          name = "PE|Coal|Electricity|w/o CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pecoal", se_Gas,                  name = "PE|Coal|Gases (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pecoal", se_Gas, teccs,            name = "PE|Coal|Gases|w/ CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pecoal", se_Gas, tenoccs,          name = "PE|Coal|Gases|w/o CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pecoal", se_Liq,                  name = "PE|Coal|Liquids (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pecoal", se_Liq, teccs,            name = "PE|Coal|Liquids|w/ CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pecoal", se_Liq, tenoccs,          name = "PE|Coal|Liquids|w/o CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pecoal", "seh2",                  name = "PE|Coal|Hydrogen (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pecoal", "seh2", teccs,            name = "PE|Coal|Hydrogen|w/ CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pecoal", "seh2", tenoccs,          name = "PE|Coal|Hydrogen|w/o CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pecoal", c("sehe"),               name = "PE|Coal|Heat (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pecoal", c(se_Solids),               name = "PE|Coal|Solids (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pegas", "seel",                   name = "PE|Gas|Electricity (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pegas", "seel", teccs,             name = "PE|Gas|Electricity|w/ CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pegas", "seel", tenoccs,           name = "PE|Gas|Electricity|w/o CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pegas", c(se_Gas),                name = "PE|Gas|Gases (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pegas", se_Liq,                   name = "PE|Gas|Liquids (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pegas", se_Liq, teccs,             name = "PE|Gas|Liquids|w/ CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pegas", se_Liq, tenoccs,           name = "PE|Gas|Liquids|w/o CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pegas", c("sehe"),                name = "PE|Gas|Heat (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pegas", c("seh2"),                name = "PE|Gas|Hydrogen (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pegas", c("seh2"), teccs,          name = "PE|Gas|Hydrogen|w/ CC (EJ/yr)"),
+                pe_carrier(demPE, dataoc, oc2te, sety, "pegas", c("seh2"), tenoccs,        name = "PE|Gas|Hydrogen|w/o CC (EJ/yr)"),
+                setNames(dimSums(mselect(prodSE, all_enty = "pesol", all_enty1 = "seel"), dim = 3), "PE|Solar|Electricity (EJ/yr)"))
   tmp4 <- NULL
-  tmp4 <- mbind(tmp4, setNames( dimSums(demPE[,,c("peoil","pecoal","pegas")],dim=3) 
-                              + dimSums(demPE[,,c("pebiolc","pebios","pebioil")],dim=3)   
-                              + dimSums(prodSE[,,c("pegeo","pehyd","pewin","pesol","peur")],dim=3),"PE (EJ/yr)"))
-  tmp4 <- mbind(tmp4,setNames(fuelex[,,"pebiolc.2"],"PE|Biomass|Residues (EJ/yr)"))
-# Moved to reportExtraction tmp4 <- mbind(tmp4,setNames(dimSums(fuelex[,,c("pebioil","pebios")][enty2rlf],dim=3),"PE|Production|Biomass|1st Generation (EJ/yr)")) 
-  tmp4 <- mbind(tmp4,setNames(( fuelex[,,"pebiolc.1"]
-                             + (1-p_costsPEtradeMp[,,"pebiolc"]) * Mport[,,"pebiolc"] - Xport[,,"pebiolc"]
-                             ),"PE|Biomass|Energy Crops (EJ/yr)"))
+  tmp4 <- mbind(tmp4, setNames(dimSums(demPE[, , c("peoil", "pecoal", "pegas")], dim = 3)
+                              + dimSums(demPE[, , c("pebiolc", "pebios", "pebioil")], dim = 3)
+                              + dimSums(prodSE[, , c("pegeo", "pehyd", "pewin", "pesol", "peur")], dim = 3), "PE (EJ/yr)"))
+  tmp4 <- mbind(tmp4, setNames(fuelex[, , "pebiolc.2"], "PE|Biomass|Residues (EJ/yr)"))
+# Moved to reportExtraction tmp4 <- mbind(tmp4,setNames(dimSums(fuelex[,,c("pebioil","pebios")][enty2rlf],dim=3),"PE|Production|Biomass|1st Generation (EJ/yr)"))
+  tmp4 <- mbind(tmp4, setNames((fuelex[, , "pebiolc.1"]
+                             + (1 - p_costsPEtradeMp[, , "pebiolc"]) * Mport[, , "pebiolc"] - Xport[, , "pebiolc"]
+                             ), "PE|Biomass|Energy Crops (EJ/yr)"))
 #  tmp4 <- mbind(tmp4,setNames(0.001638 * (p_macBase[,,"ch4gas"] - p_macEmi[,,"ch4gas"]),"PE|Gas|fromCH4MAC|Gas (EJ/yr)"))
 #  tmp4 <- mbind(tmp4,setNames(0.001638 * 0.5 *(p_macBase[,,"ch4coal"] - p_macEmi[,,"ch4coal"]),"PE|Gas|fromCH4MAC|Coalbed (EJ/yr)"))
 #  tmp4 <- mbind(tmp4,setNames(0.001638 * (p_macBase[,,"ch4wstl"] - p_macEmi[,,"ch4wstl"]) ,"PE|Gas|fromCH4MAC|Waste (EJ/yr)"))
-  
-  out <- mbind(tmp1,tmp2,tmp3,tmp4)
+
+  out <- mbind(tmp1, tmp2, tmp3, tmp4)
   # add global values
-  out <- mbind(out,dimSums(out,dim=1))
+  out <- mbind(out, dimSums(out, dim = 1))
   # add other region aggregations
   if (!is.null(regionSubsetList))
     out <- mbind(out, calc_regionSubset_sums(out, regionSubsetList))

--- a/R/reportSE.R
+++ b/R/reportSE.R
@@ -40,6 +40,12 @@ reportSE <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq
   pe2se    <- readGDX(gdx, "pe2se")
   se2se    <- readGDX(gdx, "se2se")
   all_te   <- readGDX(gdx, "all_te")
+  if ("windon" %in% as.vector(all_te)) { # remove wind when it should be called windon
+    all_te <- as.vector(all_te)
+    all_te <- all_te[all_te != "wind"]
+    all_te <- all_te[all_te != "storwind"]
+    all_te <- all_te[all_te != "gridwind"]
+  }
   te       <- readGDX(gdx, "te")
   tefosccs <- readGDX(gdx, c("teFosCCS", "tefosccs"), format = "first_found")
   teccs    <- readGDX(gdx, c("teCCS", "teccs"), format = "first_found")
@@ -217,20 +223,23 @@ reportSE <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq
     se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pesol", "seel", te = "spv",  name = "SE|Electricity|Curtailment|Solar|+|PV (EJ/yr)")
   )
 
-  if ("windoff" %in% te) {
+  if ("windon" %in% te) {
     tmp1 <- mbind(tmp1,
-      se.prod(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "wind",                   name = "SE|Electricity|Wind|+|Onshore (EJ/yr)"),
-      se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "wind",               name = "SE|Electricity|Curtailment|Wind|+|Onshore (EJ/yr)"),
-      se.prod(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "windoff",                name = "SE|Electricity|Wind|+|Offshore (EJ/yr)"),
-      se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "windoff",            name = "SE|Electricity|Curtailment|Wind|+|Offshore (EJ/yr)"),
-      se.prod(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = c("wind", "windoff"),      name = "SE|Electricity|+|Wind (EJ/yr)"),
-      se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = c("wind", "windoff"),  name = "SE|Electricity|Curtailment|+|Wind (EJ/yr)")
+      se.prod(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "windon",                   name = "SE|Electricity|Wind|+|Onshore (EJ/yr)"),
+      se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "windon",               name = "SE|Electricity|Curtailment|Wind|+|Onshore (EJ/yr)"),
+      se.prod(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "windoff",                  name = "SE|Electricity|Wind|+|Offshore (EJ/yr)"),
+      se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "windoff",              name = "SE|Electricity|Curtailment|Wind|+|Offshore (EJ/yr)"),
+      se.prod(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = c("windon", "windoff"),     name = "SE|Electricity|+|Wind (EJ/yr)"),
+      se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = c("windon", "windoff"), name = "SE|Electricity|Curtailment|+|Wind (EJ/yr)")
     )
   } else {
     tmp1 <- mbind(tmp1,
-      se.prod(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "wind",       name = "SE|Electricity|+|Wind (EJ/yr)"),
-      se.prod(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "wind",       name = "SE|Electricity|Wind|+|Onshore (EJ/yr)"),
-      se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "wind",   name = "SE|Electricity|Curtailment|+|Wind (EJ/yr)")
+      se.prod(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "wind",                     name = "SE|Electricity|Wind|+|Onshore (EJ/yr)"),
+      se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "wind",                 name = "SE|Electricity|Curtailment|Wind|+|Onshore (EJ/yr)"),
+      se.prod(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "windoff",                  name = "SE|Electricity|Wind|+|Offshore (EJ/yr)"),
+      se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "windoff",              name = "SE|Electricity|Curtailment|Wind|+|Offshore (EJ/yr)"),
+      se.prod(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = c("wind", "windoff"),       name = "SE|Electricity|+|Wind (EJ/yr)"),
+      se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = c("wind", "windoff"),   name = "SE|Electricity|Curtailment|+|Wind (EJ/yr)")
     )
   }
 

--- a/R/reportSE.R
+++ b/R/reportSE.R
@@ -40,18 +40,12 @@ reportSE <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq
   pe2se    <- readGDX(gdx, "pe2se")
   se2se    <- readGDX(gdx, "se2se")
   all_te   <- readGDX(gdx, "all_te")
-  if ("windon" %in% as.vector(all_te)) { # remove wind when it should be called windon
-    all_te <- as.vector(all_te)
-    all_te <- all_te[all_te != "wind"]
-    all_te <- all_te[all_te != "storwind"]
-    all_te <- all_te[all_te != "gridwind"]
-  }
   te       <- readGDX(gdx, "te")
   tefosccs <- readGDX(gdx, c("teFosCCS", "tefosccs"), format = "first_found")
   teccs    <- readGDX(gdx, c("teCCS", "teccs"), format = "first_found")
   tenoccs  <- readGDX(gdx, c("teNoCCS", "tenoccs"), format = "first_found")
   techp    <- readGDX(gdx, c("teChp", "techp"), format = "first_found")
-  terenew_nobio <- readGDX(gdx, c("teReNoBio", "terenew_nobio"), format = "first_found")
+  teReNoBio <- readGDX(gdx, c("teReNoBio", "terenew_nobio"), format = "first_found")
   pebio    <- readGDX(gdx, c("peBio", "pebio"), format = "first_found")
   entySe   <- readGDX(gdx, c("entySe", "sety"), format = "first_found")
   entyPe   <- readGDX(gdx, c("entyPe", "pety"), format = "first_found")
@@ -165,6 +159,9 @@ reportSE <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq
     se.prod(vm_prodSe, dataoc, oc2te, entySe, pebio, entySe, name = "SE|Biomass (EJ/yr)")
   )
 
+
+  windonStr <- ifelse ("windon" %in% te, "windon", "wind")
+
   ## Electricity
   tmp1 <- mbind(tmp1,
     se.prod(vm_prodSe, dataoc, oc2te, entySe, append(entyPe, "seh2"), "seel",   name = "SE|Electricity (EJ/yr)"), # seh2 to account for se2se production once we add h2 to elec technology
@@ -203,8 +200,7 @@ reportSE <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq
     se.prod(vm_prodSe, dataoc, oc2te, entySe, "peoil", "seel", te = tenoccs,    name = "SE|Electricity|Oil|w/o CC (EJ/yr)"),
     se.prod(vm_prodSe, dataoc, oc2te, entySe, "peoil", "seel", te = "dot",      name = "SE|Electricity|Oil|DOT (EJ/yr)"),
 
-    se.prod(vm_prodSe, dataoc, oc2te, entySe, entyPe, "seel", te = terenew_nobio,
-                                                                                name = "SE|Electricity|Non-Biomass Renewables (EJ/yr)"),
+    se.prod(vm_prodSe, dataoc, oc2te, entySe, entyPe, "seel", te = teReNoBio,   name = "SE|Electricity|Non-Biomass Renewables (EJ/yr)"),
 
     se.prod(vm_prodSe, dataoc, oc2te, entySe, "peur", "seel",                   name = "SE|Electricity|+|Nuclear (EJ/yr)"),
 
@@ -212,36 +208,25 @@ reportSE <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq
 
     se.prod(vm_prodSe, dataoc, oc2te, entySe, "pehyd", "seel",                  name = "SE|Electricity|+|Hydro (EJ/yr)"),
 
-    se.prod(vm_prodSe, dataoc, oc2te, entySe, "pesol", "seel",                  name = "SE|Electricity|+|Solar (EJ/yr)"),
-    se.prod(vm_prodSe, dataoc, oc2te, entySe, "pesol", "seel", te = "csp",      name = "SE|Electricity|Solar|+|CSP (EJ/yr)"),
-    se.prod(vm_prodSe, dataoc, oc2te, entySe, "pesol", "seel", te = "spv",      name = "SE|Electricity|Solar|+|PV (EJ/yr)"),
-    se.prod(vm_prodSe, dataoc, oc2te, entySe, c("pewin", "pesol"), "seel",      name = "SE|Electricity|WindSolar (EJ/yr)"),
+    se.prod(    vm_prodSe, dataoc, oc2te, entySe, c("pewin", "pesol"), "seel",  name = "SE|Electricity|WindSolar (EJ/yr)"),
+    se.prod(    vm_prodSe, dataoc, oc2te, entySe, "pesol", "seel",              name = "SE|Electricity|+|Solar (EJ/yr)"),
+    se.prod(    vm_prodSe, dataoc, oc2te, entySe, "pesol", "seel", te = "csp",  name = "SE|Electricity|Solar|+|CSP (EJ/yr)"),
+    se.prod(    vm_prodSe, dataoc, oc2te, entySe, "pesol", "seel", te = "spv",  name = "SE|Electricity|Solar|+|PV (EJ/yr)"),
 
     se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, c("pewin", "pesol"), "seel",  name = "SE|Electricity|Curtailment (EJ/yr)"),
     se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pesol", "seel",              name = "SE|Electricity|Curtailment|+|Solar (EJ/yr)"),
     se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pesol", "seel", te = "csp",  name = "SE|Electricity|Curtailment|Solar|+|CSP (EJ/yr)"),
-    se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pesol", "seel", te = "spv",  name = "SE|Electricity|Curtailment|Solar|+|PV (EJ/yr)")
+    se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pesol", "seel", te = "spv",  name = "SE|Electricity|Curtailment|Solar|+|PV (EJ/yr)"),
+
+    se.prod(    vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = c(windonStr, "windoff"), name = "SE|Electricity|+|Wind (EJ/yr)"),
+    se.prod(    vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = windonStr,               name = "SE|Electricity|Wind|+|Onshore (EJ/yr)"),
+    se.prod(    vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "windoff",               name = "SE|Electricity|Wind|+|Offshore (EJ/yr)"),
+    
+    se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = c(windonStr, "windoff"), name = "SE|Electricity|Curtailment|+|Wind (EJ/yr)"),
+    se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = windonStr,               name = "SE|Electricity|Curtailment|Wind|+|Onshore (EJ/yr)"),
+    se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "windoff",               name = "SE|Electricity|Curtailment|Wind|+|Offshore (EJ/yr)")
   )
 
-  if ("windon" %in% te) {
-    tmp1 <- mbind(tmp1,
-      se.prod(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "windon",                   name = "SE|Electricity|Wind|+|Onshore (EJ/yr)"),
-      se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "windon",               name = "SE|Electricity|Curtailment|Wind|+|Onshore (EJ/yr)"),
-      se.prod(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "windoff",                  name = "SE|Electricity|Wind|+|Offshore (EJ/yr)"),
-      se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "windoff",              name = "SE|Electricity|Curtailment|Wind|+|Offshore (EJ/yr)"),
-      se.prod(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = c("windon", "windoff"),     name = "SE|Electricity|+|Wind (EJ/yr)"),
-      se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = c("windon", "windoff"), name = "SE|Electricity|Curtailment|+|Wind (EJ/yr)")
-    )
-  } else {
-    tmp1 <- mbind(tmp1,
-      se.prod(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "wind",                     name = "SE|Electricity|Wind|+|Onshore (EJ/yr)"),
-      se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "wind",                 name = "SE|Electricity|Curtailment|Wind|+|Onshore (EJ/yr)"),
-      se.prod(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "windoff",                  name = "SE|Electricity|Wind|+|Offshore (EJ/yr)"),
-      se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = "windoff",              name = "SE|Electricity|Curtailment|Wind|+|Offshore (EJ/yr)"),
-      se.prod(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = c("wind", "windoff"),       name = "SE|Electricity|+|Wind (EJ/yr)"),
-      se.prodLoss(vm_prodSe, dataoc, oc2te, entySe, "pewin", "seel", te = c("wind", "windoff"),   name = "SE|Electricity|Curtailment|+|Wind (EJ/yr)")
-    )
-  }
 
   ## Gases
   if (!(is.null(vm_macBase) & is.null(vm_emiMacSector))) {

--- a/R/reportTechnology.R
+++ b/R/reportTechnology.R
@@ -94,7 +94,7 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(
 
   v_adjustteinv_avg <- collapseNames(readGDX(gdx, name = c("o_avgAdjCostInv"), field = "l", format = "first_found")[, y, ])
   if (is.null(v_adjustteinv_avg)) {
-    v_adjustteinv_avg <- v_investcost[,,]*0
+    v_adjustteinv_avg <- v_investcost[, , ] * 0
   }
 
   # build reporting ----
@@ -117,7 +117,7 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(
     "tnrs" = "Electricity|Nuclear",
     "spv" = "Electricity|Solar|PV",
     "csp" = "Electricity|Solar|CSP",
-	  "h2turb" = "Electricity|Hydrogen",
+          "h2turb" = "Electricity|Hydrogen",
     "storspv" = "Electricity|Storage|Battery|For PV",
     "storcsp" = "Electricity|Storage|Battery|For CSP",
     "biogas" = "Gases|Biomass|w/o CC",
@@ -168,14 +168,16 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(
     techmap[["refdip"]] <- "Liquids|Fossil|Oil"
   }
 
-  if ("windoff" %in% te) {
+  if ("windon" %in% te) {
+    techmap <- append(techmap, c("windon" = "Electricity|Wind|Onshore",
+                                 "storwindon" = "Electricity|Storage|Battery|For Wind Onshore",
+                                 "windoff" = "Electricity|Wind|Offshore",
+                                 "storwindoff" = "Electricity|Storage|Battery|For Wind Offshore"))
+  } else {
     techmap <- append(techmap, c("wind" = "Electricity|Wind|Onshore",
                                  "storwind" = "Electricity|Storage|Battery|For Wind Onshore",
                                  "windoff" = "Electricity|Wind|Offshore",
                                  "storwindoff" = "Electricity|Storage|Battery|For Wind Offshore"))
-  }  else {
-    techmap <- append(techmap, c("wind" = "Electricity|Wind",
-                                 "storwind" = "Electricity|Storage|Battery|For Wind"))
   }
 
   bar_and <- function(str) {
@@ -218,12 +220,8 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(
       int2ext[[report_str("Electricity|Storage|Battery|For PV", category, unit)]] <- report_str("Electricity|Solar|PV", unit = "EJ/yr", predicate = "SE")
       int2ext[[report_str("Electricity|Storage|Battery|For CSP", category, unit)]] <- report_str("Electricity|Solar|CSP", unit = "EJ/yr", predicate = "SE")
 
-      if ("windoff" %in% te) {
-        int2ext[[report_str("Electricity|Storage|Battery|For Wind Onshore", category, unit)]] <- report_str("Electricity|Wind|Onshore", unit = "EJ/yr", predicate = "SE")
-        int2ext[[report_str("Electricity|Storage|Battery|For Wind Offshore", category, unit)]] <- report_str("Electricity|Wind|Offshore", unit = "EJ/yr", predicate = "SE")
-      } else {
-        int2ext[[report_str("Electricity|Storage|Battery|For Wind", category, unit)]] <- report_str("Electricity|Wind", unit = "EJ/yr", predicate = "SE")
-      }
+      int2ext[[report_str("Electricity|Storage|Battery|For Wind Onshore", category, unit)]] <- report_str("Electricity|Wind|Onshore", unit = "EJ/yr", predicate = "SE")
+      int2ext[[report_str("Electricity|Storage|Battery|For Wind Offshore", category, unit)]] <- report_str("Electricity|Wind|Offshore", unit = "EJ/yr", predicate = "SE")
 
     } else if (all(map %in% carmap)) {
       ## cars need a special mapping, too
@@ -250,7 +248,7 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(
 
   tmp <- bind_category(tmp, v_investcost, category, unit, factor, techmap)
   int2ext <- get_global_mapping(category, unit, techmap)
-  
+
   if (CDR_mod != "off") {
     unit <- "US$2005/t CO2/yr"
     factor <- 1000 / 3.6
@@ -291,7 +289,7 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(
 
   in_dataeta <- c("bioigccc", "bioigcc", "igccc", "igcc", "pc", "ngccc", "ngcc", "ngt")
 
-  tech_exclude <- techmap[setdiff(names(techmap), 'tnrs')]   # exclude nuclear
+  tech_exclude <- techmap[setdiff(names(techmap), "tnrs")]   # exclude nuclear
 
   for (key in names(tech_exclude)) {
     if (key %in% in_dataeta) {
@@ -366,7 +364,7 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(
   tmp_GLO <- new.magpie("GLO", getYears(tmp), magclass::getNames(tmp), fill = 0)
 
   for (i2e in names(int2ext)) {
-    tmp_GLO["GLO", , i2e] <- toolAggregate(tmp[, , i2e], rel= map, weight = output[map$region, , int2ext[[i2e]]])
+    tmp_GLO["GLO", , i2e] <- toolAggregate(tmp[, , i2e], rel = map, weight = output[map$region, , int2ext[[i2e]]])
   }
   tmp <- mbind(tmp, tmp_GLO)
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
+<<<<<<< HEAD
 Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.155.0, <https://github.com/pik-piam/remind2>.
+=======
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.149.0, <https://github.com/pik-piam/remind2>.
+>>>>>>> 59268ed (activate windon, still compatible with wind)
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +62,11 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
   year = {2024},
+<<<<<<< HEAD
   note = {R package version 1.155.0},
+=======
+  note = {R package version 1.149.0},
+>>>>>>> 59268ed (activate windon, still compatible with wind)
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.155.0**
+R package **remind2**, version **1.155.0.9001**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -9,6 +9,7 @@ R package **remind2**, version **1.155.0**
 Contains the REMIND-specific routines for data and model
     output manipulation.
 
+
 ## Installation
 
 For installation of the most recent package version an additional repository has to be added in R:
@@ -16,18 +17,17 @@ For installation of the most recent package version an additional repository has
 ```r
 options(repos = c(CRAN = "@CRAN@", pik = "https://rse.pik-potsdam.de/r/packages"))
 ```
-
 The additional repository can be made available permanently by adding the line above to a file called `.Rprofile` stored in the home folder of your system (`Sys.glob("~")` in R returns the home directory).
 
 After that the most recent version of the package can be installed using `install.packages`:
 
-```r
+```r 
 install.packages("remind2")
 ```
 
 Package updates can be installed using `update.packages` (make sure that the additional repository has been added before running that command):
 
-```r
+```r 
 update.packages()
 ```
 
@@ -49,20 +49,16 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.155.0, [https://github.com/pik-piam/remind2](https://github.com/pik-piam/remind2).
-
-
-
-
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.155.0.9001, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
-```latex
+ ```latex
 @Manual{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
   year = {2024},
-  note = {R package version 1.155.0},
+  note = {R package version 1.155.0.9001},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.155.0.9001**
+R package **remind2**, version **1.156.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.155.0.9001, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.156.0, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
   year = {2024},
-  note = {R package version 1.155.0.9001},
+  note = {R package version 1.156.0},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ R package **remind2**, version **1.155.0**
 Contains the REMIND-specific routines for data and model
     output manipulation.
 
-
 ## Installation
 
 For installation of the most recent package version an additional repository has to be added in R:
@@ -17,17 +16,18 @@ For installation of the most recent package version an additional repository has
 ```r
 options(repos = c(CRAN = "@CRAN@", pik = "https://rse.pik-potsdam.de/r/packages"))
 ```
+
 The additional repository can be made available permanently by adding the line above to a file called `.Rprofile` stored in the home folder of your system (`Sys.glob("~")` in R returns the home directory).
 
 After that the most recent version of the package can be installed using `install.packages`:
 
-```r 
+```r
 install.packages("remind2")
 ```
 
 Package updates can be installed using `update.packages` (make sure that the additional repository has been added before running that command):
 
-```r 
+```r
 update.packages()
 ```
 
@@ -49,24 +49,20 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-<<<<<<< HEAD
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.155.0, <https://github.com/pik-piam/remind2>.
-=======
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.149.0, <https://github.com/pik-piam/remind2>.
->>>>>>> 59268ed (activate windon, still compatible with wind)
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.155.0, [https://github.com/pik-piam/remind2](https://github.com/pik-piam/remind2).
+
+
+
+
 
 A BibTeX entry for LaTeX users is
 
- ```latex
+```latex
 @Manual{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
   year = {2024},
-<<<<<<< HEAD
   note = {R package version 1.155.0},
-=======
-  note = {R package version 1.149.0},
->>>>>>> 59268ed (activate windon, still compatible with wind)
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/man/reportLCOE.Rd
+++ b/man/reportLCOE.Rd
@@ -27,8 +27,9 @@ The marginal LCOE are calculate in two versions: 1) with fuel prices and co2 tax
 or 2) with an intertemporal weighted-average of fuel price and co2 taxes over the lifetime of the plant (intertemporal prices).
 }
 \examples{
-
-\dontrun{reportLCOE(gdx)}
+\dontrun{
+reportLCOE(gdx)
+}
 
 }
 \seealso{

--- a/man/reportPE.Rd
+++ b/man/reportPE.Rd
@@ -26,8 +26,9 @@ Read in primary energy information from GDX file, information used in
 convGDX2MIF.R for the reporting
 }
 \examples{
-
-\dontrun{reportPE(gdx)}
+\dontrun{
+reportPE(gdx)
+}
 
 }
 \author{


### PR DESCRIPTION
Because *wind* is going to be renamed *windon* throughout remind, this PR allows for the two possibilities in reporting. It also deletes the very old situation where *windoff* didn't exist.
Note that many lines are updated only because of style formatting (`make format`).

<!-- Not sure if and what should be changed in those two files:
https://github.com/pik-piam/remind2/blob/1d5ae7835867bc5002dc03eb75c9bfaa77356355/R/runEmployment.R#L178-L179
https://github.com/pik-piam/remind2/blob/1d5ae7835867bc5002dc03eb75c9bfaa77356355/R/reportEmployment.R#L158-L159
Answer: Employment is not called in reporting `convGDX2MIF`
-->