### PR TITLE
bugfix waste emissions reporting which did not take waste-CCU flows correctly into account

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '229693560'
+ValidationKey: '229736538'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '229425000'
+ValidationKey: '229502455'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.151.0
-date-released: '2024-08-21'
+version: 1.151.1
+date-released: '2024-08-23'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.150.0
-date-released: '2024-08-15'
+version: 1.150.1
+date-released: '2024-08-20'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.150.0
-Date: 2024-08-15
+Version: 1.150.1
+Date: 2024-08-20
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.151.0
-Date: 2024-08-21
+Version: 1.151.1
+Date: 2024-08-23
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -437,9 +437,22 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
     }
 
 
-    # total fossil waste incineration emissions
+    # total fossil waste incineration emissions + CCU from captured waste carbon
+    # as CCU gets accounted at CO2 origin (see above)
     # (non-fossil waste incineration emissions currently not accounted)
-    EmiWasteInc <- setNames(dimSums(vm_incinerationEmi[,,entySEfos], dim=3) * GtC_2_MtCO2,
+
+    if (exists('vm_incinerationCCS')) {
+      # calculate captured waste carbon used for CCU (not stored but released)
+      WasteCCU <- dimSums(vm_incinerationCCS, dim=3) * (1 - dimSums(vm_co2CCS, dim=3) / dimSums(vm_co2capture, dim=3))
+      WasteCCU[is.na(WasteCCU)] <- 0
+    } else {
+      # set to zero for GDXs where no waste carbon capture implemented
+      WasteCCU <- dimSums(vm_incinerationEmi[,,entySEfos], dim=3) * 0
+    }
+
+    EmiWasteInc <- setNames(( dimSums(vm_incinerationEmi[,,entySEfos], dim=3)
+                              + WasteCCU
+                              )* GtC_2_MtCO2,
                               "Emi|CO2|Energy|Waste|Plastics Incineration (Mt CO2/yr)")
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.151.0**
+R package **remind2**, version **1.151.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.151.0, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.151.1, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
   year = {2024},
-  note = {R package version 1.151.0},
+  note = {R package version 1.151.1},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.150.0**
+R package **remind2**, version **1.150.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.150.0, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.150.1, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
   year = {2024},
-  note = {R package version 1.150.0},
+  note = {R package version 1.150.1},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/inst/compareScenarios/cs_03_emissions.Rmd
+++ b/inst/compareScenarios/cs_03_emissions.Rmd
@@ -91,7 +91,6 @@ items <- c(
   "Emi|CO2|Energy|Supply|Electricity w/ couple prod",
   "Emi|CO2|CDR|DACCS",
   "Emi|CO2|CDR|EW",
-  "Emi|CO2|Energy|Waste"
   )
 showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```

--- a/inst/extdata/additional_summation_checks.csv
+++ b/inst/extdata/additional_summation_checks.csv
@@ -17,7 +17,6 @@ Emi|GHG;Emi|GHG|Energy|Demand|+|Buildings;1
 Emi|GHG;Emi|GHG|Gross|Energy|Demand|+|Industry;1
 Emi|GHG;Emi|GHG|Energy|Demand|+|Transport;1
 Emi|GHG;Emi|GHG|Energy|Demand|+|CDR;1
-Emi|GHG;Emi|GHG|Gross|Energy|+|Waste;1
 Emi|GHG;Emi|GHG|+++|Industrial Processes;1
 Emi|GHG;Emi|GHG|+++|Waste;1
 Emi|GHG;Emi|GHG|+++|Agriculture;1
@@ -41,7 +40,6 @@ Emi|CO2;Emi|CO2|CDR|BECCS;1
 Emi|CO2;Emi|CO2|CDR|Industry CCS|Synthetic Fuels;1
 Emi|CO2;Emi|CO2|CDR|DACCS;1
 Emi|CO2;Emi|CO2|CDR|EW;1
-Emi|CO2;Emi|CO2|Gross|Energy|+|Waste;1
 Emi|CO2;Emi|CO2|CDR|Materials|+|Plastics;1
 ;;
 # total GHG emissions by CO2 sectors and non-CO2 gases;;
@@ -62,7 +60,6 @@ Emi|CO2|Cumulated;Emi|CO2|Cumulated|Energy|Demand|Buildings;1
 Emi|CO2|Cumulated;Emi|CO2|Cumulated|Energy|Demand|CDR;1
 Emi|CO2|Cumulated;Emi|CO2|Cumulated|Gross|Energy|Supply|Non-electric;1
 Emi|CO2|Cumulated;Emi|CO2|Cumulated|Gross|Energy|Supply|Electricity;1
-Emi|CO2|Cumulated;Emi|CO2|Cumulated|Gross|Energy|Waste;1
 Emi|CO2|Cumulated;Emi|CO2|Cumulated|CDR|BECCS;1
 Emi|CO2|Cumulated;Emi|CO2|Cumulated|CDR|Industry CCS|Synthetic Fuels;1
 Emi|CO2|Cumulated;Emi|CO2|Cumulated|CDR|DACCS;1
@@ -106,10 +103,10 @@ Carbon Management|Carbon Capture;Carbon Management|Storage;1
 Carbon Management|Carbon Capture;Carbon Management|Usage;1
 Carbon Management|Carbon Capture;Carbon Management|Venting of Captured Carbon;1
 ;;
-# check consistency of DACCS reporting
+# check consistency of DACCS reporting;;
 Carbon Sequestration|Direct Air Capture;Emi|CO2|CDR|DACCS;-1
 ;;
-# check Energy Investments subcategories
+# check Energy Investments subcategories;;
 Energy Investments|Electricity|Fossil;Energy Investments|Electricity|Coal;1
 Energy Investments|Electricity|Fossil;Energy Investments|Electricity|Gas;1
 Energy Investments|Electricity|Fossil;Energy Investments|Electricity|Oil;1


### PR DESCRIPTION
This addresses #645. Check ``/p/projects/remind/modeltests/remind/output/SSP2-PkBudg650-AMT_2024-08-17_00.02.30/REMIND_generic_SSP2-PkBudg650-AMT_summation_errors_afterFix.csv`` for summation errors of reporting produced with this branch. This did not show before as test GDX did not include waste CC. 

Moreover, it removes waste emissions variables from some stacked barplots in cs2 and in the additional summation checks as these emissions  are now subsumed under ``Energy|Demand`` and ``Energy|Supply``. 

