### PR TITLE
fix summation error for 'Total Energy costs|Electricity', add |+|

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '230430720'
+ValidationKey: '230473770'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '230473770'
+ValidationKey: '230562992'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.154.0
-date-released: '2024-09-02'
+version: 1.154.1
+date-released: '2024-09-04'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.154.1
-date-released: '2024-09-04'
+version: 1.154.2
+date-released: '2024-09-10'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.154.1
-Date: 2024-09-04
+Version: 1.154.2
+Date: 2024-09-10
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.154.0
-Date: 2024-09-02
+Version: 1.154.1
+Date: 2024-09-04
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportCosts.R
+++ b/R/reportCosts.R
@@ -31,7 +31,7 @@ reportCosts <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,
   if(is.null(output)){
     message("reportCosts executes reportExtraction ", appendLF = FALSE)
     output <- mbind(output, reportExtraction(gdx, regionSubsetList = regionSubsetList, t = t))
-    message("- reportPrices ", appendLF = FALSE)
+    message("- reportPrices: ", appendLF = FALSE)
     output <- mbind(output, reportPrices(gdx, regionSubsetList = regionSubsetList, t = t))
     message("- reportEnergyInvestments")
     output <- mbind(output, reportEnergyInvestment(gdx, regionSubsetList = regionSubsetList, t = t)[, getYears(output), ])
@@ -58,6 +58,8 @@ reportCosts <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,
   tenoccs      <- readGDX(gdx,c("teNoCCS","tenoccs"),format="first_found")
   temapall     <- readGDX(gdx,c("en2en","temapall"),format="first_found")
   tenotransform<- readGDX(gdx,c("teNoTransform","tenotransform"),format="first_found")
+  teNoTransform33 <- readGDX(gdx, "teNoTransform33", format = "first_found", react = "silent")
+  tenotransform <- setdiff(tenotransform, teNoTransform33)
   stor         <- readGDX(gdx,c("teStor","stor"),format="first_found")
   grid         <- readGDX(gdx,c("teGrid","grid"),format="first_found")
   trade_pe     <- readGDX(gdx,c("tradePe","trade_pe"),format="first_found")
@@ -304,23 +306,23 @@ reportCosts <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,
 
   ###### Import fuel costs|Coal
   cost<- cost_Mport("pecoal",pm_petradecost2_Mp_fin,pm_pvp,budget.m,Mport)
-  tmp  <- mbind(tmp,setNames(cost, "Import Fuel costs|Coal (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost, "Import Fuel costs|+|Coal (billion US$2005/yr)"))
 
   ###### Import fuel costs|Gas
   cost<- cost_Mport("pegas",pm_petradecost2_Mp_fin,pm_pvp,budget.m,Mport)
-  tmp  <- mbind(tmp,setNames(cost, "Import Fuel costs|Gas (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost, "Import Fuel costs|+|Gas (billion US$2005/yr)"))
 
   ###### Import fuel costs|Oil
   cost<- cost_Mport("peoil",pm_petradecost2_Mp_fin,pm_pvp,budget.m,Mport)
-  tmp  <- mbind(tmp,setNames(cost, "Import Fuel costs|Oil (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost, "Import Fuel costs|+|Oil (billion US$2005/yr)"))
 
   ###### Import fuel costs|Uranium
   cost<- cost_Mport("peur",pm_petradecost2_Mp_fin,pm_pvp,budget.m,Mport)
-  tmp  <- mbind(tmp,setNames(cost, "Import Fuel costs|Uranium (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost, "Import Fuel costs|+|Uranium (billion US$2005/yr)"))
 
   ###### Import fuel costs|Pebiolc
   cost<- cost_Mport("pebiolc",pm_petradecost2_Mp_fin,pm_pvp,budget.m,Mport)
-  tmp  <- mbind(tmp,setNames(cost, "Import Fuel costs|Biomass (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost, "Import Fuel costs|+|Biomass (billion US$2005/yr)"))
 
   ###### Export Fuel Costs|Coal
   cost <- output[regi_on_gdx,,"Res|Average Supply Costs|Coal ($/GJ)"] * Xport[,,"pecoal"] * pm_conv_TWa_EJ
@@ -388,12 +390,6 @@ reportCosts <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,
   cost3 <- op_costs(ei=NULL,eo=NULL,te=tenotransform,e2e=NULL,teall2rlf=teall2rlf,vm_prodE=NULL,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
   tmp  <- mbind(tmp,setNames(cost1 + cost2 + cost3 + output[regi_on_gdx,,"Energy Investments|Supply (billion US$2005/yr)"], "Total Energy costs (billion US$2005/yr)"))
 
-  ##### Electricity
-  cost1 <- op_costs(ei=pe2se$all_enty,eo="seel",te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  cost2 <- op_costs(ei="seel",eo=se2fe$all_enty1,te=se2fe$all_te,e2e=se2fe,teall2rlf=teall2rlf,vm_prodE=vm_prodFe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  cost3 <- op_costs(ei=NULL,eo=NULL,te=tenotransform,e2e=NULL,teall2rlf=teall2rlf,vm_prodE=NULL,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost1 + cost2 + cost3 + output[regi_on_gdx,,"Energy Investments|Electricity (billion US$2005/yr)"], "Total Energy costs|Electricity (billion US$2005/yr)"))
-
   ##### Electricity|Fossil
   cost <- op_costs(ei=petyf,eo="seel",te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
   tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Fossil (billion US$2005/yr)"], "Total Energy costs|Electricity|Fossil (billion US$2005/yr)"))
@@ -404,47 +400,47 @@ reportCosts <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,
 
   ##### Electricity|Biomass
   cost <- op_costs(ei="pebiolc",eo="seel",te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Biomass (billion US$2005/yr)"], "Total Energy costs|Electricity|Biomass (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Biomass (billion US$2005/yr)"], "Total Energy costs|Electricity|+|Biomass (billion US$2005/yr)"))
 
   cost <- op_costs(ei="pebiolc",eo="seel",te=teccs,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Biomass|w/ CC (billion US$2005/yr)"], "Total Energy costs|Electricity|Biomass|w/ CC (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Biomass|w/ CC (billion US$2005/yr)"], "Total Energy costs|Electricity|Biomass|+|w/ CC (billion US$2005/yr)"))
 
   cost <- op_costs(ei="pebiolc",eo="seel",te=tenoccs,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Biomass|w/o CC (billion US$2005/yr)"], "Total Energy costs|Electricity|Biomass|w/o CC (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Biomass|w/o CC (billion US$2005/yr)"], "Total Energy costs|Electricity|Biomass|+|w/o CC (billion US$2005/yr)"))
 
   ##### Electricity|Coal
   cost <- op_costs(ei="pecoal",eo="seel",te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
   cost <- cost + output[regi_on_gdx,,"Energy Investments|Electricity|Coal (billion US$2005/yr)"]
-  tmp  <- mbind(tmp,setNames(cost, "Total Energy costs|Electricity|Coal (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost, "Total Energy costs|Electricity|+|Coal (billion US$2005/yr)"))
 
   cost <- op_costs(ei="pecoal",eo="seel",te=teccs,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
   cost <- cost + output[regi_on_gdx,,"Energy Investments|Electricity|Coal|w/ CC (billion US$2005/yr)"]
-  tmp  <- mbind(tmp,setNames(cost, "Total Energy costs|Electricity|Coal|w/ CC (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost, "Total Energy costs|Electricity|Coal|+|w/ CC (billion US$2005/yr)"))
 
   cost <- op_costs(ei="pecoal",eo="seel",te=tenoccs,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
   cost <- cost + output[regi_on_gdx,,"Energy Investments|Electricity|Coal|w/o CC (billion US$2005/yr)"]
-  tmp  <- mbind(tmp,setNames(cost, "Total Energy costs|Electricity|Coal|w/o CC (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost, "Total Energy costs|Electricity|Coal|+|w/o CC (billion US$2005/yr)"))
 
   ##### Electricity|Gas
   cost <- op_costs(ei="pegas",eo="seel",te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Gas (billion US$2005/yr)"], "Total Energy costs|Electricity|Gas (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Gas (billion US$2005/yr)"], "Total Energy costs|Electricity|+|Gas (billion US$2005/yr)"))
 
   cost <- op_costs(ei="pegas",eo="seel",te=teccs,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Gas|w/ CC (billion US$2005/yr)"], "Total Energy costs|Electricity|Gas|w/ CC (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Gas|w/ CC (billion US$2005/yr)"], "Total Energy costs|Electricity|Gas|+|w/ CC (billion US$2005/yr)"))
 
   cost <- op_costs(ei="pegas",eo="seel",te=tenoccs,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Gas|w/o CC (billion US$2005/yr)"], "Total Energy costs|Electricity|Gas|w/o CC (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Gas|w/o CC (billion US$2005/yr)"], "Total Energy costs|Electricity|Gas|+|w/o CC (billion US$2005/yr)"))
 
   ##### Electricity|Oil
   cost <- op_costs(ei="peoil",eo="seel",te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Oil (billion US$2005/yr)"], "Total Energy costs|Electricity|Oil (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Oil (billion US$2005/yr)"], "Total Energy costs|Electricity|+|Oil (billion US$2005/yr)"))
 
   cost <- op_costs(ei="peoil",eo="seel",te=tenoccs,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Oil|w/o CC (billion US$2005/yr)"], "Total Energy costs|Electricity|Oil|w/o CC (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Oil|w/o CC (billion US$2005/yr)"], "Total Energy costs|Electricity|Oil|+|w/o CC (billion US$2005/yr)"))
 
   ##### Electricity|Nuclear
   cost <- op_costs(ei="peur",eo="seel",te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Nuclear (billion US$2005/yr)"], "Total Energy costs|Electricity|Nuclear (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Nuclear (billion US$2005/yr)"], "Total Energy costs|Electricity|+|Nuclear (billion US$2005/yr)"))
 
   ##### Electricity|Non-biomass renewables
   cost <- op_costs(ei=setdiff(perenew,pebio),eo="seel",te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
@@ -452,46 +448,52 @@ reportCosts <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,
 
   ##### Electricity|Solar
   cost <- op_costs(ei="pesol",eo="seel",te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Solar (billion US$2005/yr)"], "Total Energy costs|Electricity|Solar (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Solar (billion US$2005/yr)"], "Total Energy costs|Electricity|+|Solar (billion US$2005/yr)"))
 
   ##### Electricity|Wind
   cost <- op_costs(ei="pewin",eo="seel",te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Wind (billion US$2005/yr)"], "Total Energy costs|Electricity|Wind (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Wind (billion US$2005/yr)"], "Total Energy costs|Electricity|+|Wind (billion US$2005/yr)"))
 
   ##### Electricity|Hydro
   cost <- op_costs(ei="pehyd",eo="seel",te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Hydro (billion US$2005/yr)"], "Total Energy costs|Electricity|Hydro (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Hydro (billion US$2005/yr)"], "Total Energy costs|Electricity|+|Hydro (billion US$2005/yr)"))
 
   ##### Electricity|Geothermal
   cost <- op_costs(ei="pegeo",eo="seel",te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Geothermal (billion US$2005/yr)"], "Total Energy costs|Electricity|Geothermal (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Geothermal (billion US$2005/yr)"], "Total Energy costs|Electricity|+|Geothermal (billion US$2005/yr)"))
 
+  costH2 <- NULL
   ##### Electricity|Hydrogen
   if ("h2turb" %in% se2se$all_te) {
-    cost <- op_costs(ei="seh2",eo="seel",te=se2se$all_te,e2e=se2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-    tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Hydrogen (billion US$2005/yr)"], "Total Energy costs|Electricity|Hydrogen (billion US$2005/yr)"))
+    costH2 <- op_costs(ei="seh2",eo="seel",te=se2se$all_te,e2e=se2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
+    tmp  <- mbind(tmp,setNames(costH2 + output[regi_on_gdx,,"Energy Investments|Electricity|Hydrogen (billion US$2005/yr)"], "Total Energy costs|Electricity|+|Hydrogen (billion US$2005/yr)"))
   }
 
   ##### Electricity|Storage
-  cost <- op_costs(ei=NULL,eo=NULL,te=stor,e2e=NULL,teall2rlf=teall2rlf,vm_prodE=NULL,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|Electricity|Storage (billion US$2005/yr)"], "Total Energy costs|Electricity|Storage (billion US$2005/yr)"))
+  cost2 <- op_costs(ei=NULL,eo=NULL,te=stor,e2e=NULL,teall2rlf=teall2rlf,vm_prodE=NULL,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
+  tmp  <- mbind(tmp,setNames(cost2 + output[regi_on_gdx,,"Energy Investments|Electricity|Storage (billion US$2005/yr)"], "Total Energy costs|Electricity|+|Storage (billion US$2005/yr)"))
 
   ##### Electricity|Grid
-  cost1 <- op_costs(ei=NULL,eo=NULL,te=grid,e2e=NULL,teall2rlf=teall2rlf,vm_prodE=NULL,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  cost2 <- op_costs(ei="seel",eo=se2fe$all_enty1,te=se2fe$all_te,e2e=se2fe,teall2rlf=teall2rlf,vm_prodE=NULL,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost1 + cost2 + output[regi_on_gdx,,"Energy Investments|Electricity|Grid (billion US$2005/yr)"], "Total Energy costs|Electricity|Grid (billion US$2005/yr)"))
+  cost2 <- op_costs(ei=NULL,eo=NULL,te=grid,e2e=NULL,teall2rlf=teall2rlf,vm_prodE=NULL,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
+  costGrid3 <- op_costs(ei="seel",eo=se2fe$all_enty1,te=se2fe$all_te,e2e=se2fe,teall2rlf=teall2rlf,vm_prodE=NULL,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
+  tmp  <- mbind(tmp,setNames(cost2 + costGrid3 + output[regi_on_gdx,,"Energy Investments|Electricity|Grid (billion US$2005/yr)"], "Total Energy costs|Electricity|+|Grid (billion US$2005/yr)"))
+
+  ##### Electricity
+  cost <- op_costs(ei=pe2se$all_enty,eo="seel",te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
+  cost2 <- op_costs(ei=NULL,eo=NULL,te=tenotransform,e2e=NULL,teall2rlf=teall2rlf,vm_prodE=NULL,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost) # grid and storage
+  tmp  <- mbind(tmp,setNames(cost + cost2 + costGrid3 + costH2 + output[regi_on_gdx,,"Energy Investments|Electricity (billion US$2005/yr)"], "Total Energy costs|+|Electricity (billion US$2005/yr)"))
 
   ##### Heat
   #TiA: including investments, and operation and maintenance, BUT excluding input fuel costs
   cost_pe2se <- op_costs(ei=pe2se$all_enty,eo="sehe",te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
   cost_se2fe <- op_costs(ei="sehe",eo=se2fe$all_enty1,te=se2fe$all_te,e2e=se2fe,teall2rlf=teall2rlf,vm_prodE=vm_prodFe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost_pe2se + cost_se2fe + output[regi_on_gdx,,"Energy Investments|Heat (billion US$2005/yr)"], "Total Energy costs|Heat (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost_pe2se + cost_se2fe + output[regi_on_gdx,,"Energy Investments|Heat (billion US$2005/yr)"], "Total Energy costs|+|Heat (billion US$2005/yr)"))
 
   ##### Hydrogen
   #TiA: including investments, and operation and maintenance, BUT excluding input fuel costs
   cost_pe2se <- op_costs(ei=pe2se$all_enty,eo="seh2",te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
   cost_se2fe <- op_costs(ei="seh2",eo=se2fe$all_enty1,te=se2fe$all_te,e2e=se2fe,teall2rlf=teall2rlf,vm_prodE=vm_prodFe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost_pe2se + cost_se2fe + output[regi_on_gdx,,"Energy Investments|Hydrogen (billion US$2005/yr)"], "Total Energy costs|Hydrogen (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost_pe2se + cost_se2fe + output[regi_on_gdx,,"Energy Investments|Hydrogen (billion US$2005/yr)"], "Total Energy costs|+|Hydrogen (billion US$2005/yr)"))
 
   ##### Hydrogen|Fossil
   cost <- op_costs(ei=petyf,eo="seh2",te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
@@ -505,7 +507,7 @@ reportCosts <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,
   #TiA: including investments, and operation and maintenance, BUT excluding input fuel costs
   cost_pe2se <- op_costs(ei=pe2se$all_enty,eo=se_Liq,te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
   cost_se2fe <- op_costs(ei=se_Liq,eo=se2fe$all_enty1,te=se2fe$all_te,e2e=se2fe,teall2rlf=teall2rlf,vm_prodE=vm_prodFe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost_pe2se + cost_se2fe + output[regi_on_gdx,,"Energy Investments|Liquids (billion US$2005/yr)"], "Total Energy costs|Liquids (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost_pe2se + cost_se2fe + output[regi_on_gdx,,"Energy Investments|Liquids (billion US$2005/yr)"], "Total Energy costs|+|Liquids (billion US$2005/yr)"))
 
   ##### Liquids|Oil Ref
   costoil <- op_costs(ei="peoil",eo=se_Liq,te=pe2se$all_te,e2e=pe2se,teall2rlf=teall2rlf,vm_prodE=vm_prodSe,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
@@ -524,16 +526,16 @@ reportCosts <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,
 
   ##### CO2 Trans&Stor
   cost <- op_costs(ei=ccs2te$all_enty,eo=ccs2te$all_enty1,te=ccs2te$all_te,e2e=ccs2te,teall2rlf=teall2rlf,vm_prodE=NULL,pm_data=pm_data,vm_cap=vm_cap,v_investcost=v_investcost)
-  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|CO2 Trans&Stor (billion US$2005/yr)"], "Total Energy costs|CO2 Trans&Stor (billion US$2005/yr)"))
+  tmp  <- mbind(tmp,setNames(cost + output[regi_on_gdx,,"Energy Investments|CO2 Trans&Stor (billion US$2005/yr)"], "Total Energy costs|+|CO2 Trans&Stor (billion US$2005/yr)"))
 
   ##### Other
   tmp  <- mbind(tmp,setNames(tmp[,,"Total Energy costs (billion US$2005/yr)"]-
-                               tmp[,,"Total Energy costs|Electricity (billion US$2005/yr)"]-
-                               tmp[,,"Total Energy costs|Hydrogen (billion US$2005/yr)"]-
-                               tmp[,,"Total Energy costs|Liquids (billion US$2005/yr)"]-
-                               tmp[,,"Total Energy costs|Heat (billion US$2005/yr)"]-
-                               tmp[,,"Total Energy costs|CO2 Trans&Stor (billion US$2005/yr)"],
-                             "Total Energy costs|Other (billion US$2005/yr)"))
+                               tmp[,,"Total Energy costs|+|Electricity (billion US$2005/yr)"]-
+                               tmp[,,"Total Energy costs|+|Hydrogen (billion US$2005/yr)"]-
+                               tmp[,,"Total Energy costs|+|Liquids (billion US$2005/yr)"]-
+                               tmp[,,"Total Energy costs|+|Heat (billion US$2005/yr)"]-
+                               tmp[,,"Total Energy costs|+|CO2 Trans&Stor (billion US$2005/yr)"],
+                             "Total Energy costs|+|Other (billion US$2005/yr)"))
 
   #####################################
   ########## O & M costs ##############

--- a/R/switchValuesScenConf.R
+++ b/R/switchValuesScenConf.R
@@ -1,7 +1,7 @@
 #' searches all scenario config files of REMIND directory for a switch and prints the occurences
 #'
 #' @param switchname string with switch that is searched in scenario config files.
-#'                   If NULL, prints all switches with only one value in main.gms and scenario config files
+#'                   If NULL or '', prints all switches with only one value in main.gms and scenario config files
 #' @param directory path to REMIND directory
 #' @author Oliver Richters
 #' @importFrom gms readDefaultConfig
@@ -10,8 +10,8 @@
 #' @export
 switchValuesScenConf <- function(switchname = NULL, directory = ".") {
   csvfiles <- Sys.glob(c(file.path(directory, "scenario_config*.csv"),
-                            file.path(directory, "config", "scenario_config*.csv"),
-                            file.path(directory, "config", "*", "scenario_config*.csv")))
+                         file.path(directory, "config", "scenario_config*.csv"),
+                         file.path(directory, "config", "*", "scenario_config*.csv")))
   maingmsdirectory <- directory
   if (! file.exists(file.path(directory, "main.gms")) && file.exists(file.path(dirname(directory), "main.gms"))) {
     maingmsdirectory <- dirname(directory)
@@ -27,7 +27,7 @@ switchValuesScenConf <- function(switchname = NULL, directory = ".") {
     message("\n### No main.gms found in directory ", maingmsdirectory, ". Please specify REMIND directory.")
     return(NULL)
   }
-  if (is.null(switchname)) {
+  if (is.null(switchname) || switchname == "") {
     message("\n### Printing all switches with only one value in main.gms and ",
             length(csvfiles), " scenario config files:")
     switchesUniqueValue <- NULL

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.154.0**
+R package **remind2**, version **1.154.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.154.0, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.154.1, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
   year = {2024},
-  note = {R package version 1.154.0},
+  note = {R package version 1.154.1},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.154.1**
+R package **remind2**, version **1.154.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.154.1, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.154.2, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
   year = {2024},
-  note = {R package version 1.154.1},
+  note = {R package version 1.154.2},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/man/switchValuesScenConf.Rd
+++ b/man/switchValuesScenConf.Rd
@@ -8,7 +8,7 @@ switchValuesScenConf(switchname = NULL, directory = ".")
 }
 \arguments{
 \item{switchname}{string with switch that is searched in scenario config files.
-If NULL, prints all switches with only one value in main.gms and scenario config files}
+If NULL or '', prints all switches with only one value in main.gms and scenario config files}
 
 \item{directory}{path to REMIND directory}
 }


### PR DESCRIPTION
`Energy Investments|Electricity` did not match its child elements, and wasn't using `|+|` notation so nobody noticed:
```
Total Energy costs|Electricity <
   + Total Energy costs|Electricity|Biomass
   + Total Energy costs|Electricity|Coal
   + Total Energy costs|Electricity|Gas
   + Total Energy costs|Electricity|Geothermal
   + Total Energy costs|Electricity|Grid
   + Total Energy costs|Electricity|Hydro
   + Total Energy costs|Electricity|Hydrogen
   + Total Energy costs|Electricity|Nuclear
   + Total Energy costs|Electricity|Oil
   + Total Energy costs|Electricity|Solar
   + Total Energy costs|Electricity|Storage
   + Total Energy costs|Electricity|Wind
The child sum differs by 1.06% to 1.29% from the parent, absolute difference up to 6.43 billion US$2005/yr.
```

There were the following reasons:
- `dac` was part of `tenotransform` and therefore added to `Total Energy costs|Electricity`, similar to https://github.com/pik-piam/remind2/pull/579
- The `Total Energy costs|Electricity|Hydrogen` part was not summed to it
- I added quite some `|+|` stuff where it was not set yet. All those new summations work.
- At some point, one might add `DAC` as an own category. It is now summarized under `Total Energy costs|+|Other`
- minor update in switchValuesScenConf: Treat an empty string for the switch name like it was `NULL`