### PR TITLE
cs2: light structural changes, a few plots added

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '230652226'
+ValidationKey: '230815200'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.154.3
-date-released: '2024-09-16'
+version: 1.155.0
+date-released: '2024-09-18'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.154.3
-Date: 2024-09-16
+Version: 1.155.0
+Date: 2024-09-18
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.154.3**
+R package **remind2**, version **1.155.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2)  [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.154.3, <URL: https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.155.0, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +58,7 @@ A BibTeX entry for LaTeX users is
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
   year = {2024},
-  note = {R package version 1.154.3},
+  note = {R package version 1.155.0},
   url = {https://github.com/pik-piam/remind2},
 }
 ```

--- a/inst/compareScenarios/cs_01_summary.Rmd
+++ b/inst/compareScenarios/cs_01_summary.Rmd
@@ -17,7 +17,7 @@ items <- c(
 showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
-## GHG by sector
+### GHG by sector
 
 ```{r GHG by sector (w/ gross emissions, excl. negative emissions from CCS of non-fossil carbon)}
 tot <- "Emi|GHG"
@@ -107,7 +107,7 @@ items <- c(
 showAreaAndBarPlots(data, items, scales = "fixed")
 ```
 
-## FE per capita (by sector, time domain, area plot)
+### FE per capita - area plot, time domain
 
 ```{r FE per capita (by sector, time domain, area plot)}
 items <- c(
@@ -118,7 +118,7 @@ items <- c(
 showAreaAndBarPlots(data, items, tot = "FE pCap", scales = "fixed")
 ```
 
-## FE per capita (by sector, time domain, line graph)
+### FE per capita - line graph, time domain
 
 ```{r FE per capita (by sector, time domain, line graph)}
 dIea <- data %>%
@@ -132,7 +132,7 @@ items <- c(
 showMultiLinePlots(dIea, items, scales = "fixed")
 ```
 
-## FE per capita (by sector, GDP)
+### FE per capita - line graph, GDP domain
 
 ```{r FE per capita (by sector, GDP)}
 dIea <- data %>%
@@ -162,7 +162,7 @@ items <- c(
 showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
 ```
 
-## FE by carrier (detailed)
+### FE by carrier (detailed)
 
 ```{r FE by carrier (detailed)}
 items <- c(
@@ -187,7 +187,7 @@ items <- c(
 showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
 ```
 
-## FE Industry by carrier (incl. non-energy use)
+### FE Industry by carrier (incl. non-energy use)
 
 ```{r FE Industry by carrier (incl. non-energy use)}
 items <- c(
@@ -202,7 +202,7 @@ items <- c(
 showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
 ```
 
-## FE Buildings by carrier
+### FE Buildings by carrier
 
 ```{r FE Buildings by carrier}
 items <- c(
@@ -217,7 +217,7 @@ items <- c(
 showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
 ```
 
-## FE Transport by carrier
+### FE Transport by carrier
 
 ```{r FE Transport by carrier}
 items <- c(
@@ -230,7 +230,7 @@ items <- c(
 showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
 ```
 
-## FE CDR by carrier
+### FE CDR by carrier
 
 
 ```{r FE CDR by carrier}
@@ -245,14 +245,14 @@ showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
 ```
 
 
-## FE Non-energy Use by carrier
+### FE Non-energy Use by carrier
 
 ```{r FE Non-energy Use by carrier}
 items <- c(
-  "FE|Non-energy Use|Industry|Solids",
+  "FE|Non-energy Use|Industry|Gases",
   "FE|Non-energy Use|Industry|Liquids",
-  "FE|Non-energy Use|Industry|Gases")
-showAreaAndBarPlots(data, items)
+  "FE|Non-energy Use|Industry|Solids")
+showAreaAndBarPlots(data, items, orderVars = "user")
 ```
 
 ## SE Electricity by carrier
@@ -263,19 +263,19 @@ tot <- "SE|Electricity"
 
 items <- c(
   "SE|Electricity|Net Imports",
+  "SE|Electricity|Hydrogen",
   "SE|Electricity|Solar|CSP",
   "SE|Electricity|Solar|PV",
   "SE|Electricity|Wind|Onshore",
   "SE|Electricity|Wind|Offshore",
   "SE|Electricity|Hydro",  
-  "SE|Electricity|Hydrogen",
   "SE|Electricity|Nuclear",  
   "SE|Electricity|Geothermal",  
   "SE|Electricity|Biomass|w/ CC",
   "SE|Electricity|Biomass|w/o CC",
-  "SE|Electricity|Oil",  
   "SE|Electricity|Gas|w/ CC",
   "SE|Electricity|Gas|w/o CC",
+  "SE|Electricity|Oil",  
   "SE|Electricity|Coal|w/ CC",
   "SE|Electricity|Coal|w/o CC",
   NULL)
@@ -295,8 +295,8 @@ items <- c(
   "PE|Nuclear",  
   "PE|Geothermal",
   "PE|Biomass",  
-  "PE|Oil",
   "PE|Gas",  
+  "PE|Oil",
   "PE|Coal",
   NULL)
 

--- a/inst/compareScenarios/cs_04_energy_supply.Rmd
+++ b/inst/compareScenarios/cs_04_energy_supply.Rmd
@@ -8,8 +8,8 @@ items <- c(
   "Energy Investments|Electricity|Grid|BEV Chargers",
   "Energy Investments|Electricity|Grid|VRE support",
   "Energy Investments|Electricity|Grid|Normal",
-  "Energy Investments|Electricity|Hydrogen",
   "Energy Investments|Electricity|Storage",
+  "Energy Investments|Electricity|Hydrogen",
   "Energy Investments|Electricity|Solar",
   "Energy Investments|Electricity|Wind",
   "Energy Investments|Electricity|Hydro",
@@ -17,9 +17,9 @@ items <- c(
   "Energy Investments|Electricity|Geothermal",
   "Energy Investments|Electricity|Biomass|w/ CC",
   "Energy Investments|Electricity|Biomass|w/o CC",
-  "Energy Investments|Electricity|Oil",
   "Energy Investments|Electricity|Gas|w/ CC",
   "Energy Investments|Electricity|Gas|w/o CC",
+  "Energy Investments|Electricity|Oil",
   "Energy Investments|Electricity|Coal|w/ CC",
   "Energy Investments|Electricity|Coal|w/o CC",
   NULL)
@@ -28,20 +28,19 @@ showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
 ```
 
 ## Capacities Electricity
-
+### Mix of Electricity Capacities
 ```{r Capacities Electricity}
 items <- c(
-  "Cap|Electricity|Solar",
-  if ("Cap|Electricity|Wind|Offshore" %in% levels(data$variable))
-    c("Cap|Electricity|Wind|Onshore", "Cap|Electricity|Wind|Offshore")
-  else
-    "Cap|Electricity|Wind",
   "Cap|Electricity|Storage|Battery",
+  "Cap|Electricity|Hydrogen",
+  "Cap|Electricity|Solar|CSP",
+  "Cap|Electricity|Solar|PV",
+  "Cap|Electricity|Wind|Offshore",
+  "Cap|Electricity|Wind|Onshore",
   "Cap|Electricity|Hydro",
   "Cap|Electricity|Nuclear",  
   "Cap|Electricity|Geothermal",
   "Cap|Electricity|Biomass",
-  "Cap|Electricity|Hydrogen",
   "Cap|Electricity|Gas|w/ CC",
   "Cap|Electricity|Gas|w/o CC",
   "Cap|Electricity|Oil|w/o CC",
@@ -52,7 +51,30 @@ items <- c(
 showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
 ```
 
-## Capacities electricity line plots
+### Coal
+```{r Cap Coal}
+showLinePlots(data, "Cap|Electricity|Coal")
+```
+
+### Oil
+```{r Cap Oil}
+showLinePlots(data, "Cap|Electricity|Oil")
+```
+
+### Gas
+```{r Cap Gas}
+showLinePlots(data, "Cap|Electricity|Gas")
+```
+
+### Biomass
+```{r Cap Biomass}
+showLinePlots(data, "Cap|Electricity|Biomass")
+```
+
+### Geothermal
+```{r Cap Geothermal}
+showLinePlots(data, "Cap|Electricity|Geothermal")
+```
 
 ### Nuclear
 ```{r Cap Nuclear}
@@ -74,26 +96,8 @@ showLinePlots(data, "Cap|Electricity|Wind|Offshore")
 ### Solar
 ```{r Cap Solar}
 showLinePlots(data, "Cap|Electricity|Solar")
-```
-
-### Coal
-```{r Cap Coal}
-showLinePlots(data, "Cap|Electricity|Coal")
-```
-
-### Gas
-```{r Cap Gas}
-showLinePlots(data, "Cap|Electricity|Gas")
-```
-
-### Oil
-```{r Cap Oil}
-showLinePlots(data, "Cap|Electricity|Oil")
-```
-
-### Biomass
-```{r Cap Biomass}
-showLinePlots(data, "Cap|Electricity|Biomass")
+showLinePlots(data, "Cap|Electricity|Solar|PV")
+showLinePlots(data, "Cap|Electricity|Solar|CSP")
 ```
 
 ### Hydrogen
@@ -101,7 +105,45 @@ showLinePlots(data, "Cap|Electricity|Biomass")
 showLinePlots(data, "Cap|Electricity|Hydrogen")
 ```
 
-## PE Mix
+### Storage Battery
+```{r Cap Hydro}
+showLinePlots(data, "Cap|Electricity|Storage|Battery")
+```
+
+
+## PE Extraction (before trade)
+### PE Coal Extraction
+```{r PE Coal Extraction}
+showLinePlots(data, "Res|Extraction|Coal")
+```
+
+### PE Oil Extraction
+```{r PE Oil Extraction}
+showLinePlots(data, "Res|Extraction|Oil")
+```
+
+### PE Gas Extraction
+```{r PE Gas Extraction}
+showLinePlots(data, "Res|Extraction|Gas")
+```
+
+### PE Biomass Production
+```{r PE Biomass Production}
+items <- c(
+  "PE|Production|Biomass|Lignocellulosic|Energy Crops",
+  "PE|Production|Biomass|Lignocellulosic|Residues",
+  "PE|Production|Biomass|1st Generation",
+  NULL)
+showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
+```
+
+### PE Biomass Production - Energy Crops
+```{r PE Biomass - Energy Crops}
+showLinePlots(data, "Primary Energy Production|Biomass|Energy Crops")
+```
+
+
+## PE Consumption (after trade)
 ### PE Coal
 ```{r PE Coal}
 items <- c(
@@ -131,6 +173,13 @@ items <- c(
 showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
 ```
 
+### PE Oil
+```{r PE Oil}
+items <- c(
+  "PE|Oil",
+  NULL)
+showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
+```
 
 ### PE Biomass
 ```{r PE Biomass}
@@ -148,15 +197,6 @@ items <- c(
 showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
 ```
 
-### PE Oil
-```{r PE Oil}
-items <- c(
-  "PE|Oil",
-  NULL)
-showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
-```
-
-## Primary Energy line plots
 ### PE Coal - Line
 ```{r PE Coal}
 showLinePlots(data, "PE|Coal")
@@ -177,32 +217,13 @@ showLinePlots(data, "PE|Gas")
 showLinePlots(data, "PE|Biomass")
 ```
 
-### PE Biomass - Energy Crops - Line
-```{r PE Biomass - Energy Crops}
-showLinePlots(data, "Primary Energy Production|Biomass|Energy Crops")
-```
-
 ### PE Geothermal - Line
 ```{r PE Geothermal}
 showLinePlots(data, "PE|Geothermal")
 ```
 
-### PE Coal Extraction
-```{r PE Coal Extraction}
-showLinePlots(data, "Res|Extraction|Coal")
-```
 
-### PE Oil Extraction
-```{r PE Oil Extraction}
-showLinePlots(data, "Res|Extraction|Oil")
-```
-
-### PE Gas Extraction
-```{r PE Gas Extraction}
-showLinePlots(data, "Res|Extraction|Gas")
-```
-
-## Secondary Energy Mixes
+## SE Mix
 
 ### SE Electricity
 ```{r SE Electricity}
@@ -211,19 +232,19 @@ tot <- "SE|Electricity"
 
 items <- c(
   "SE|Electricity|Net Imports",
+  "SE|Electricity|Hydrogen",
   "SE|Electricity|Solar|CSP",
   "SE|Electricity|Solar|PV",
   "SE|Electricity|Wind|Onshore",
   "SE|Electricity|Wind|Offshore",
   "SE|Electricity|Hydro",  
-  "SE|Electricity|Hydrogen",
   "SE|Electricity|Nuclear",  
   "SE|Electricity|Geothermal",  
   "SE|Electricity|Biomass|w/ CC",
   "SE|Electricity|Biomass|w/o CC",
-  "SE|Electricity|Oil",  
   "SE|Electricity|Gas|w/ CC",
   "SE|Electricity|Gas|w/o CC",
+  "SE|Electricity|Oil",  
   "SE|Electricity|Coal|w/ CC",
   "SE|Electricity|Coal|w/o CC",
   NULL)
@@ -402,9 +423,7 @@ showAreaAndBarPlots(data, items, tot, orderVars = "user", scales = "fixed")
 ```
 
 
-
-
-## Secondary Energy line plots - totals
+## SE Totals - line plots
 
 ### SE Electricity
 ```{r SE Electricity total line}
@@ -421,12 +440,10 @@ showLinePlots(data, "SE|Heat")
 showLinePlots(data, "SE|Hydrogen")
 ```
 
-
 ### SE Solids
 ```{r SE Solids total line}
 showLinePlots(data, "SE|Solids")
 ```
-
 
 ### SE Liquids
 ```{r SE Liquids total line}
@@ -441,24 +458,26 @@ showLinePlots(data, "SE|Gases")
 
 
 
-## Secondary Energy line plots - detail
+## SE Details - line plots
 
 
 ### SE Electricity
 ```{r SE Electricity detail line}
-showLinePlots(data, "SE|Electricity|Gas")
+
 showLinePlots(data, "SE|Electricity|Coal")
 showLinePlots(data, "SE|Electricity|Oil")
+showLinePlots(data, "SE|Electricity|Gas")
+showLinePlots(data, "SE|Electricity|Biomass")
+showLinePlots(data, "SE|Electricity|Geothermal")
 showLinePlots(data, "SE|Electricity|Nuclear")
 showLinePlots(data, "SE|Electricity|Hydro")
-showLinePlots(data, "SE|Electricity|Hydrogen")
 showLinePlots(data, "SE|Electricity|Wind")
 showLinePlots(data, "SE|Electricity|Wind|Onshore")
 showLinePlots(data, "SE|Electricity|Wind|Offshore")
 showLinePlots(data, "SE|Electricity|Solar")
 showLinePlots(data, "SE|Electricity|Solar|PV")
 showLinePlots(data, "SE|Electricity|Solar|CSP")
-showLinePlots(data, "SE|Electricity|Biomass")
+showLinePlots(data, "SE|Electricity|Hydrogen")
 ```
 
 
@@ -475,29 +494,28 @@ showLinePlots(data, "SE|Heat|Electricity|Heat Pump")
 ### SE Hydrogen
 ```{r SE Hydrogen detail line}
 
-showLinePlots(data,  "SE|Hydrogen|Biomass|w/ CC")
-showLinePlots(data,  "SE|Hydrogen|Biomass|w/o CC")
 showLinePlots(data,  "SE|Hydrogen|Coal|w/ CC")
 showLinePlots(data,  "SE|Hydrogen|Coal|w/o CC")
-showLinePlots(data,  "SE|Hydrogen|Electricity|VRE Storage Electrolysis")
-showLinePlots(data,  "SE|Hydrogen|Electricity|Standard Electrolysis")
 showLinePlots(data,  "SE|Hydrogen|Gas|w/ CC")
 showLinePlots(data,  "SE|Hydrogen|Gas|w/o CC")
+showLinePlots(data,  "SE|Hydrogen|Biomass|w/ CC")
+showLinePlots(data,  "SE|Hydrogen|Biomass|w/o CC")
+showLinePlots(data,  "SE|Hydrogen|Electricity|VRE Storage Electrolysis")
+showLinePlots(data,  "SE|Hydrogen|Electricity|Standard Electrolysis")
 showLinePlots(data,  "SE|Hydrogen|Net Imports")
 
 ```
 
 ### SE Solids
 ```{r SE Solids detail line}
+
 showLinePlots(data, "SE|Solids|Coal")
 showLinePlots(data, "SE|Solids|Biomass")
 showLinePlots(data, "SE|Solids|Traditional Biomass")
 ```
 
 ### SE Liquids
-
 ```{r SE Liquids detail line}
-
 
 showLinePlots(data, "SE|Liquids|Fossil|Oil")
 showLinePlots(data, "SE|Liquids|Fossil|Coal|w/ CC")
@@ -507,13 +525,12 @@ showLinePlots(data, "SE|Liquids|Fossil|Gas|w/o CC")
 showLinePlots(data, "SE|Liquids|Biomass|w/ CC")
 showLinePlots(data, "SE|Liquids|Biomass|w/o CC")
 showLinePlots(data, "SE|Liquids|Hydrogen")
-
-
 ```
 
 
 ### SE Gases
 ```{r SE Gases detail line}
+
 showLinePlots(data,  c("SE|Gases|Fossil|Natural Gas", "SE|Gases|Gas"))
 showLinePlots(data, "SE|Gases|Fossil|Coal")
 showLinePlots(data, "SE|Gases|Biomass")

--- a/inst/compareScenarios/cs_10_tech_cost.Rmd
+++ b/inst/compareScenarios/cs_10_tech_cost.Rmd
@@ -42,9 +42,13 @@ showLinePlots(data, "Tech|Heat|Coal|Capital Costs")
 ## Learning renewables and storage vs. cumulative capacity (regional comparison)
 ```{r Learning renewables and storage vs. cumulative capacity (regional comparison)}
 showMultiLinePlotsByVariable(data, "Tech|Electricity|Solar|PV|Capital Costs", "Cumulative Cap|Electricity|Solar", scales = "fixed")
-showMultiLinePlotsByVariable(data, "Tech|Electricity|Wind|Onshore|Capital Costs", "Cumulative Cap|Electricity|Wind|Onshore", scales = "fixed", showHistorical = FALSE)
-showMultiLinePlotsByVariable(data, "Tech|Electricity|Wind|Offshore|Capital Costs", "Cumulative Cap|Electricity|Wind|Offshore", scales = "fixed", showHistorical = FALSE)
-showMultiLinePlotsByVariable(data, "Tech|Electricity|Storage|Battery|For PV|Capital Costs", "Cumulative Cap|Electricity|Storage|Battery|For PV", scales = "fixed", showHistorical = FALSE)
+showMultiLinePlotsByVariable(data, "Tech|Electricity|Solar|PV|Capital Costs", "Cumulative Cap|Electricity|Solar", scales = "fixed", logscale = "xy")
+showMultiLinePlotsByVariable(data, "Tech|Electricity|Wind|Onshore|Capital Costs", "Cumulative Cap|Electricity|Wind|Onshore", scales = "fixed")
+showMultiLinePlotsByVariable(data, "Tech|Electricity|Wind|Onshore|Capital Costs", "Cumulative Cap|Electricity|Wind|Onshore", scales = "fixed", logscale = "xy")
+showMultiLinePlotsByVariable(data, "Tech|Electricity|Wind|Offshore|Capital Costs", "Cumulative Cap|Electricity|Wind|Offshore", scales = "fixed")
+showMultiLinePlotsByVariable(data, "Tech|Electricity|Wind|Offshore|Capital Costs", "Cumulative Cap|Electricity|Wind|Offshore", scales = "fixed", logscale = "xy")
+showMultiLinePlotsByVariable(data, "Tech|Electricity|Storage|Battery|For PV|Capital Costs", "Cumulative Cap|Electricity|Storage|Battery|For PV", scales = "fixed")
+showMultiLinePlotsByVariable(data, "Tech|Electricity|Storage|Battery|For PV|Capital Costs", "Cumulative Cap|Electricity|Storage|Battery|For PV", scales = "fixed", logscale = "xy")
 ```
 
 ## Capital cost of non-renewables vs. years (regional comparison)


### PR DESCRIPTION
Cleaning the structure of cs2 a little bit:
- Summary: different FE plots go in subsection
- Energy supply: PE is separated into before/after trade
- Energy supply: the order of energy variables is more consistent (trying to follow the order coal-oil-gas-biomass-geoth-nuc-hydro-wind-solar-h2-others)
- Tech costs: new plots using https://github.com/pik-piam/mip/pull/112 