### PR TITLE
Add line plots for FE demand

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '235576880'
+ValidationKey: '235620414'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.169.0
-date-released: '2025-03-05'
+version: 1.169.1
+date-released: '2025-03-07'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.169.0
-Date: 2025-03-05
+Version: 1.169.1
+Date: 2025-03-07
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.169.0**
+R package **remind2**, version **1.169.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,17 +49,17 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.169.0, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, FÃ¼hrlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, SchÃ¶tz C, Schreyer F, Siala K, SÃ¶rgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, RÃ¼ter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.169.1, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
-  author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
-  date = {2025-03-05},
+  author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal FÃ¼hrlich and Anastasis Giannousakis and Robin Hasse and JÃ©rome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and SimÃ³n Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof SchÃ¶tz and Felix Schreyer and Kais Siala and BjÃ¶rn SÃ¶rgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn RÃ¼ter},
+  date = {2025-03-07},
   year = {2025},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.169.0},
+  note = {Version: 1.169.1},
 }
 ```

--- a/inst/compareScenarios/cs_05_energy_demand.Rmd
+++ b/inst/compareScenarios/cs_05_energy_demand.Rmd
@@ -109,6 +109,11 @@ showAreaAndBarPlots(data, items2, tot, orderVars = "user", scales = "fixed")
 ```
 
 ### FE Buildings Line Plots
+```{r Buildings}
+showLinePlots(data, "FE|Buildings",
+              histModelsExclude = paste("IEA ETP", c("2DS", "B2DS", "RTS")))
+```
+
 #### Electricity
 ```{r Electricity}
 showLinePlots(data, "FE|Buildings|Electricity")
@@ -127,6 +132,8 @@ showLinePlots(data, "FE|Buildings|Gases")
 #### Solids
 ```{r Solids}
 showLinePlots(data, "FE|Buildings|Solids")
+showLinePlots(data, "FE|Buildings|Solids|Biomass")
+showLinePlots(data, "FE|Buildings|Solids|Fossil")
 ```
 
 #### Hydrogen
@@ -191,7 +198,11 @@ showAreaAndBarPlots(data, items, tot, orderVars = "user", fill = TRUE)
 showAreaAndBarPlots(data, items2, tot, orderVars = "user", scales = "fixed")
 ```
 
-#### FE Industry Line Plots
+### FE Industry Line Plots
+```{r Industry}
+showLinePlots(data, "FE|Industry")
+```
+
 #### Electricity
 ```{r Electricity}
 showLinePlots(data, "FE|Industry|Electricity")
@@ -524,6 +535,9 @@ showAreaAndBarPlots(data, items_bioliq, tot_bioliq, orderVars = "user", scales =
 ```
 
 ### FE Transport w/ Bunkers - Line Plots
+```{r Transport}
+showLinePlots(data, "FE|Transport")
+```
 
 #### Electricity
 ```{r Electricity}


### PR DESCRIPTION
With this PR, we add the plots that @gunnar-pik requested in the validation meeting from 28/11/2024
- add line plots for sectoral FE demand at the beginning of each sector's line plots
  - removed IEA ETP reference data for buildings as there are much more recent references and the big legends squeezes the plot a lot
- add line plots for biomass and coal in section of `FE|Buildings|Solids`
- minor fix of headline hierarchy in industry section