### PR TITLE
Adapt `reportEmiAirPol.R` to use renamed air pollution variables after MAGICC6 removal

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '233178540'
+ValidationKey: '233291575'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*
@@ -8,3 +8,4 @@ AutocreateReadme: yes
 allowLinterWarnings: yes
 enforceVersionUpdate: yes
 skipCoverage: yes
+AutocreateCITATION: yes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.162.0
-date-released: '2024-12-10'
+version: 1.162.1
+date-released: '2024-12-18'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.162.0
-Date: 2024-12-10
+Version: 1.162.1
+Date: 2024-12-18
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportEmiAirPol.R
+++ b/R/reportEmiAirPol.R
@@ -16,59 +16,63 @@
 #' @author Antoine Levesque, Jerome Hilaire
 #' @seealso \code{\link{convGDX2MIF}}
 #' @examples
-#' \dontrun{reportEmiAirPol(gdx)}
+#' \dontrun{
+#' reportEmiAirPol(gdx)
+#' }
 #'
 #' @export
 #' @importFrom gdx readGDX
-#' @importFrom magclass collapseNames getNames<- mbind setNames new.magpie getRegions getYears mbind setYears getItems<-
-reportEmiAirPol <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2070,2110,10),2130,2150)){
-
+#' @importFrom magclass new.magpie mbind getNames<- setNames collapseNames getYears getItems
+reportEmiAirPol <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150)) {
   # Get realisation name
   realisation <- readGDX(gdx, "module2realisation")
-  realisation <- realisation[which(realisation[,1] == "aerosols"),2]
+  realisation <- realisation[which(realisation[, 1] == "aerosols"), 2]
 
   ######### initialisation  ###########
   tmp <- NULL
   out <- NULL
 
-  if (! realisation == "exoGAINS") stop("not allowed air pollution realization.")
+  if (!realisation == "exoGAINS") stop("not allowed air pollution realization.")
 
   ######### initialisation  ###########
-  airpollutants <- c("so2","bc","oc","CO","VOC","NOx","NH3")
+  airpollutants <- c("so2", "bc", "oc", "CO", "VOC", "NOx", "NH3")
 
   ######### internal function  ###########
-  generateReportingEmiAirPol <- function(pollutant,i_emiAPexsolve=pm_emiAPexsolve,i_emiAPexo=pm_emiAPexo){
+  generateReportingEmiAirPol <- function(pollutant, i_emiAPexsolve = p11_emiAPexsolve, i_emiAPexo = p11_emiAPexo) {
     poll_rep <- toupper(pollutant)
     tmp <- NULL
 
     # reduce to the pollutant
-    emiAPexsolve <- collapseNames(i_emiAPexsolve[,,pollutant])
-    emiAPexo     <- collapseNames(i_emiAPexo[,,pollutant])
+    emiAPexsolve <- collapseNames(i_emiAPexsolve[, , pollutant])
+    emiAPexo <- collapseNames(i_emiAPexo[, , pollutant])
     getSets(emiAPexo) <- getSets(emiAPexsolve)
 
     # add indprocess to indst
-    emiAPexsolve[,,"indst"] <- emiAPexsolve[,,"indst"] + emiAPexsolve[,,"indprocess"]
+    emiAPexsolve[, , "indst"] <- emiAPexsolve[, , "indst"] + emiAPexsolve[, , "indprocess"]
 
     # Replace REMIND sector names by reporting ones
-    mapping = data.frame(
+    mapping <- data.frame(
       remind = c("power", "indst", "res", "trans", "solvents", "extraction"),
-      reporting = c(paste0("Emi|", poll_rep, "|Energy Supply|Electricity (Mt ", poll_rep, "/yr)"),
-                    paste0("Emi|", poll_rep, "|Energy Demand|Industry (Mt ", poll_rep, "/yr)"),
-                    paste0("Emi|", poll_rep, "|Energy Demand|Buildings (Mt ", poll_rep, "/yr)"),
-                    paste0("Emi|", poll_rep, "|Energy Demand|Transport|Ground Trans (Mt ", poll_rep, "/yr)"),
-                    paste0("Emi|", poll_rep, "|Solvents (Mt ", poll_rep, "/yr)"),
-                    paste0("Emi|", poll_rep, "|Energy Supply|Extraction (Mt ", poll_rep, "/yr)")))
+      reporting = c(
+        paste0("Emi|", poll_rep, "|Energy Supply|Electricity (Mt ", poll_rep, "/yr)"),
+        paste0("Emi|", poll_rep, "|Energy Demand|Industry (Mt ", poll_rep, "/yr)"),
+        paste0("Emi|", poll_rep, "|Energy Demand|Buildings (Mt ", poll_rep, "/yr)"),
+        paste0("Emi|", poll_rep, "|Energy Demand|Transport|Ground Trans (Mt ", poll_rep, "/yr)"),
+        paste0("Emi|", poll_rep, "|Solvents (Mt ", poll_rep, "/yr)"),
+        paste0("Emi|", poll_rep, "|Energy Supply|Extraction (Mt ", poll_rep, "/yr)")
+      )
+    )
 
-    emiAPexsolve <- setNames(emiAPexsolve[,,mapping$remind],as.character(mapping$reporting))
+    emiAPexsolve <- setNames(emiAPexsolve[, , mapping$remind], as.character(mapping$reporting))
 
-    tmp <-
-        mbind(emiAPexsolve,
-              setNames(emiAPexo[,,"AgWasteBurning"],  paste0("Emi|",poll_rep,"|Land Use|Agricultural Waste Burning (Mt ",poll_rep,"/yr)")),
-              setNames(emiAPexo[,,"Agriculture"],     paste0("Emi|",poll_rep,"|Land Use|Agriculture (Mt ",poll_rep,"/yr)")),
-              setNames(emiAPexo[,,"ForestBurning"],   paste0("Emi|",poll_rep,"|Land Use|Forest Burning (Mt ",poll_rep,"/yr)")),
-              setNames(emiAPexo[,,"GrasslandBurning"],paste0("Emi|",poll_rep,"|Land Use|Savannah Burning (Mt ",poll_rep,"/yr)")),
-              setNames(emiAPexo[,,"Waste"],           paste0("Emi|",poll_rep,"|Waste (Mt ",poll_rep,"/yr)")))
-
+    tmp <- mbind(
+      emiAPexsolve,
+      setNames(emiAPexo[, , "AgWasteBurning"],   paste0("Emi|", poll_rep, "|Land Use|Agricultural Waste Burning (Mt ", poll_rep, "/yr)")),
+      setNames(emiAPexo[, , "Agriculture"],      paste0("Emi|", poll_rep, "|Land Use|Agriculture (Mt ", poll_rep, "/yr)")),
+      setNames(emiAPexo[, , "ForestBurning"],    paste0("Emi|", poll_rep, "|Land Use|Forest Burning (Mt ", poll_rep, "/yr)")),
+      setNames(emiAPexo[, , "GrasslandBurning"], paste0("Emi|", poll_rep, "|Land Use|Savannah Burning (Mt ", poll_rep, "/yr)")),
+      setNames(emiAPexo[, , "Waste"],            paste0("Emi|", poll_rep, "|Waste (Mt ", poll_rep, "/yr)"))
+    )
 
     # Set NAs to 0
     tmp[is.na(tmp)] <- 0
@@ -76,76 +80,117 @@ reportEmiAirPol <- function(gdx,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2
     return(tmp)
   }
 
-  ####### conversion factors ##########
-  pm_conv_TWa_EJ    <- 31.536
-  conv_MtSO2_to_MtS <- 1/2     # 32/(32+2*16)
-
   ####### read in needed data #########
   ## sets
-  ttot  <-  as.numeric(readGDX(gdx, name=c("ttot"), format="first_found"))
+  ttot <- as.numeric(readGDX(gdx, name = c("ttot"), format = "first_found"))
   ## parameter
-  pm_emiAPexsolve   <- readGDX(gdx, name=c("pm_emiAPexsolve"), field="l", format="first_found")[,ttot,]
-  pm_emiAPexo       <- readGDX(gdx, name=c("pm_emiAPexo"), field="l", format="first_found")[,ttot,airpollutants]
-  pm_emiAPexoGlob   <- readGDX(gdx, name=c("pm_emiAPexoGlob"), field="l", format="first_found")[,ttot,airpollutants]
+  p11_emiAPexsolve <- readGDX(
+    gdx,
+    name = c("p11_emiAPexsolve", "pm_emiAPexsolve"), field = "l", format = "first_found"
+  )[, ttot, ]
+  p11_emiAPexo <- readGDX(
+    gdx,
+    name = c("p11_emiAPexo", "pm_emiAPexo"), field = "l", format = "first_found"
+  )[, ttot, airpollutants]
+  p11_emiAPexoGlob <- readGDX(
+    gdx,
+    name = c("p11_emiAPexoGlob", "pm_emiAPexoGlob"), field = "l", format = "first_found"
+  )[, ttot, airpollutants]
 
   ####### prepare parameter ########################
-  magclass::getNames(pm_emiAPexsolve) <- gsub("SOx","so2",magclass::getNames(pm_emiAPexsolve))
-  magclass::getNames(pm_emiAPexsolve) <- gsub("NMVOC","VOC",magclass::getNames(pm_emiAPexsolve))
+  getNames(p11_emiAPexsolve) <- gsub("SOx", "so2", getNames(p11_emiAPexsolve))
+  getNames(p11_emiAPexsolve) <- gsub("NMVOC", "VOC", getNames(p11_emiAPexsolve))
 
   ####### calculate reporting parameters ############
   # Loop over air pollutants and call reporting generating function
   out <- do.call("mbind", lapply(airpollutants, generateReportingEmiAirPol))
 
   # Add global values
-  out   <- mbind(out, dimSums(out,dim=1))
+  out <- mbind(out, dimSums(out, dim = 1))
   # add other region aggregations
-  if (!is.null(regionSubsetList))
+  if (!is.null(regionSubsetList)) {
     out <- mbind(out, calc_regionSubset_sums(out, regionSubsetList))
+  }
 
   # Loop over air pollutants and add some variables
   for (pollutant in airpollutants) {
-      poll_rep <- toupper(pollutant)
-      tmp <- NULL
-      # Add Aviation and Int. Shipping emissions
-      tmp <- mbind(tmp,setNames(pm_emiAPexoGlob["GLO",,"InternationalShipping"][,,pollutant],paste0("Emi|",poll_rep,"|Energy Demand|Transport|International Shipping (Mt ",poll_rep,"/yr)")),
-                       setNames(pm_emiAPexoGlob["GLO",,"Aviation"][,,pollutant],             paste0("Emi|",poll_rep,"|Energy Demand|Transport|Aviation (Mt ",poll_rep,"/yr)"))
-                    )
-      tmp1 <- new.magpie(getRegions(out),getYears(out),magclass::getNames(tmp),fill=0)
-      tmp1["GLO",,] <- tmp["GLO",,]
-      out  <- mbind(out,tmp1)
-      # Aggregation: Transport and Energy Supply
-      out <- mbind(out,
-                    setNames(dimSums(out[,,
-                                          c(paste0("Emi|",poll_rep,"|Energy Demand|Transport|Ground Trans (Mt ",poll_rep,"/yr)"),
-                                            paste0("Emi|",poll_rep,"|Energy Demand|Transport|International Shipping (Mt ",poll_rep,"/yr)"),
-                                            paste0("Emi|",poll_rep,"|Energy Demand|Transport|Aviation (Mt ",poll_rep,"/yr)"))],dim = 3),
-                             paste0("Emi|",poll_rep,"|Energy Demand|Transport (Mt ",poll_rep,"/yr)")),
-                    setNames(dimSums(out[,,
-                                          c(paste0("Emi|",poll_rep,"|Energy Supply|Electricity (Mt ",poll_rep,"/yr)"),
-                                            paste0("Emi|",poll_rep,"|Energy Supply|Extraction (Mt ",poll_rep,"/yr)"))],dim = 3),
-                             paste0("Emi|",poll_rep,"|Energy Supply (Mt ",poll_rep,"/yr)"))
-                    )
-      # Aggregation: Energy Demand + Energy Supply, Land Use
-      out <- mbind(out,
-                    setNames(dimSums(out[,,c(paste0("Emi|",poll_rep,"|Energy Demand|Industry (Mt ",poll_rep,"/yr)"),
-                                             paste0("Emi|",poll_rep,"|Energy Demand|Buildings (Mt ",poll_rep,"/yr)"),
-                                             paste0("Emi|",poll_rep,"|Energy Demand|Transport (Mt ",poll_rep,"/yr)"),
-                                             paste0("Emi|",poll_rep,"|Energy Supply (Mt ",poll_rep,"/yr)"))],dim = 3),
-                             paste0("Emi|",poll_rep,"|Energy Supply and Demand (Mt ",poll_rep,"/yr)")),
-                    setNames(dimSums(out[,,c(paste0("Emi|",poll_rep,"|Land Use|Savannah Burning (Mt ",poll_rep,"/yr)"),
-                                             paste0("Emi|",poll_rep,"|Land Use|Forest Burning (Mt ",poll_rep,"/yr)"),
-                                             paste0("Emi|",poll_rep,"|Land Use|Agriculture (Mt ",poll_rep,"/yr)"),
-                                             paste0("Emi|",poll_rep,"|Land Use|Agricultural Waste Burning (Mt ",poll_rep,"/yr)"))],dim = 3),
-                             paste0("Emi|",poll_rep,"|Land Use (Mt ",poll_rep,"/yr)"))
-                   )
-      # Compute total
-      out <- mbind(out,
-                    setNames(dimSums(out[,,c(paste0("Emi|",poll_rep,"|Energy Supply and Demand (Mt ",poll_rep,"/yr)"),
-                                             paste0("Emi|",poll_rep,"|Solvents (Mt ",poll_rep,"/yr)"),
-                                             paste0("Emi|",poll_rep,"|Land Use (Mt ",poll_rep,"/yr)"),
-                                             paste0("Emi|",poll_rep,"|Waste (Mt ",poll_rep,"/yr)"))],dim=3),
-                             paste0("Emi|",poll_rep," (Mt ",poll_rep,"/yr)"))
-                   )
+    poll_rep <- toupper(pollutant)
+    tmp <- NULL
+    # Add Aviation and Int. Shipping emissions
+    tmp <- mbind(
+      tmp,
+      setNames(
+        p11_emiAPexoGlob["GLO", , "InternationalShipping"][, , pollutant],
+        paste0("Emi|", poll_rep, "|Energy Demand|Transport|International Shipping (Mt ", poll_rep, "/yr)")
+      ),
+      setNames(
+        p11_emiAPexoGlob["GLO", , "Aviation"][, , pollutant],
+        paste0("Emi|", poll_rep, "|Energy Demand|Transport|Aviation (Mt ", poll_rep, "/yr)")
+      )
+    )
+    tmp1 <- new.magpie(getItems(out, dim = 1), getYears(out), getNames(tmp), fill = 0)
+    tmp1["GLO", , ] <- tmp["GLO", , ]
+    out <- mbind(out, tmp1)
+    # Aggregation: Transport and Energy Supply
+    out <- mbind(
+      out,
+      setNames(
+        dimSums(out[
+          , ,
+          c(
+            paste0("Emi|", poll_rep, "|Energy Demand|Transport|Ground Trans (Mt ", poll_rep, "/yr)"),
+            paste0("Emi|", poll_rep, "|Energy Demand|Transport|International Shipping (Mt ", poll_rep, "/yr)"),
+            paste0("Emi|", poll_rep, "|Energy Demand|Transport|Aviation (Mt ", poll_rep, "/yr)")
+          )
+        ], dim = 3),
+        paste0("Emi|", poll_rep, "|Energy Demand|Transport (Mt ", poll_rep, "/yr)")
+      ),
+      setNames(
+        dimSums(out[
+          , ,
+          c(
+            paste0("Emi|", poll_rep, "|Energy Supply|Electricity (Mt ", poll_rep, "/yr)"),
+            paste0("Emi|", poll_rep, "|Energy Supply|Extraction (Mt ", poll_rep, "/yr)")
+          )
+        ], dim = 3),
+        paste0("Emi|", poll_rep, "|Energy Supply (Mt ", poll_rep, "/yr)")
+      )
+    )
+    # Aggregation: Energy Demand + Energy Supply, Land Use
+    out <- mbind(
+      out,
+      setNames(
+        dimSums(out[, , c(
+          paste0("Emi|", poll_rep, "|Energy Demand|Industry (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Energy Demand|Buildings (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Energy Demand|Transport (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Energy Supply (Mt ", poll_rep, "/yr)")
+        )], dim = 3),
+        paste0("Emi|", poll_rep, "|Energy Supply and Demand (Mt ", poll_rep, "/yr)")
+      ),
+      setNames(
+        dimSums(out[, , c(
+          paste0("Emi|", poll_rep, "|Land Use|Savannah Burning (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Land Use|Forest Burning (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Land Use|Agriculture (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Land Use|Agricultural Waste Burning (Mt ", poll_rep, "/yr)")
+        )], dim = 3),
+        paste0("Emi|", poll_rep, "|Land Use (Mt ", poll_rep, "/yr)")
+      )
+    )
+    # Compute total
+    out <- mbind(
+      out,
+      setNames(
+        dimSums(out[, , c(
+          paste0("Emi|", poll_rep, "|Energy Supply and Demand (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Solvents (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Land Use (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Waste (Mt ", poll_rep, "/yr)")
+        )], dim = 3),
+        paste0("Emi|", poll_rep, " (Mt ", poll_rep, "/yr)")
+      )
+    )
   }
 
   getSets(out)[3] <- "variable"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.162.0**
+R package **remind2**, version **1.162.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,16 +49,17 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). _remind2: The REMIND R package (2nd generation)_. R package version 1.162.0, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). "remind2: The REMIND R package (2nd generation)." Version: 1.162.1, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
-@Manual{,
+@Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
+  date = {2024-12-18},
   year = {2024},
-  note = {R package version 1.162.0},
   url = {https://github.com/pik-piam/remind2},
+  note = {Version: 1.162.1},
 }
 ```

--- a/man/loadCs2Data.Rd
+++ b/man/loadCs2Data.Rd
@@ -17,7 +17,7 @@ loadCs2Data(
 If the vector has names, those are used to refer to the scenarios in the
 output file.}
 
-\item{mifHist}{\code{character(1)}. Path to historical mif.}
+\item{mifHist}{\code{character(1)}. Path to historical mif or \code{NULL}.}
 
 \item{cfgScen, cfgDefault}{See section "YAML Parameters" in \link[=compareScenarios]{compareScenarios()}.}
 

--- a/man/reportEmiAirPol.Rd
+++ b/man/reportEmiAirPol.Rd
@@ -29,7 +29,9 @@ Read in air pollution emission information from GDX file, information used in
 convGDX2MIF.R for the reporting
 }
 \examples{
-\dontrun{reportEmiAirPol(gdx)}
+\dontrun{
+reportEmiAirPol(gdx)
+}
 
 }
 \seealso{


### PR DESCRIPTION
*Note:* Draft PR since `buildLibrary` has not been run yet

Change log:
- During removal of [MAGICC6 from REMIND](https://github.com/remindmodel/remind/pull/1879), variables related to module `11_aerosols/exoGAINS` no longer act as an interface to the REMIND core and were renamed to from `pm_X` to `p11_X`. This affects `p11_emiAPexo`, `p11_emiAPexoGlob`, `p11_emiAPexsolve`
  - Variables `p11_emiFacAP`, `pm_emiExog`, `p11_emiAPexoAgricult` were also renamed in REMIND, but do not occur in reporting
- Removed unused conversion factors `pm_conv_TWa_EJ` & `conv_MtSO2_to_MtS`
- Replace `getRegions` with `getItems(..., dim = 1)`
- Revised `magclass` imports
- Some re-formatting to get rid of linter warnings
