### PR TITLE
mini bugfix in compareScenConf() for mapping files

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '233291575'
+ValidationKey: '233451114'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.162.1
-date-released: '2024-12-18'
+version: 1.162.2
+date-released: '2024-12-30'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.162.1
-Date: 2024-12-18
+Version: 1.162.2
+Date: 2024-12-30
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/compareScenConf.R
+++ b/R/compareScenConf.R
@@ -1,15 +1,18 @@
 #' take two REMIND scenario-config*.csv files and print the difference,
 #' comparing it to a default.cfg
+#' Can also be used for piamInterfaces mapping files with row.names=NULL and expanddata=FALSE.
 #'
 #' @param fileList vector containing one csv file paths or two paths as c(oldfile, newfile)
 #' If one, searches same filename in defaultPath. If NULL, user can select
-#' @param remindPath path to REMIND directory containing main.gms
-#' @param row.names column in csv used for row.names. Use NULL for mapping files
+#' @param remindPath path to REMIND directory containing main.gms. Used for extracting the
+#'        default configuration and find a file for comparison if only one config file is supplied in fileList
+#' @param row.names column in csv used for row.names. Defaults to 1.
+#'        Use NULL for mapping files which either picks the 'variable' column or uses the first two columns.
 #' @param renamedCols vector with old and new column names such as c("old1" = "new1", "old2" = "new2"))
 #' @param renamedRows vector with old and new row names such as c("old3" = "new3", "old3" = "new4", "old5" = "new5"))
 #'        the "old" name can also remain in the new file, if you generated a variant
 #' @param printit boolean switch (default: TRUE) whether function prints its output
-#' @param expanddata fill empty cells with default values
+#' @param expanddata fill empty cells with default values. Use FALSE for mapping files
 #' @author Oliver Richters
 #' @examples
 #'
@@ -78,11 +81,11 @@ compareScenConf <- function(fileList = NULL, remindPath = "/p/projects/rd3mod/gi
   settings1 <- readCheckScenarioConfig(fileList[[1]], remindPath = remindPath, fillWithDefault = TRUE, testmode = TRUE)
   settings2 <- readCheckScenarioConfig(fileList[[2]], remindPath = remindPath, fillWithDefault = TRUE, testmode = TRUE)
 
-  # for mapping files use "Variable" if exists, else combine first two columns
+  # for mapping files use "variable" if exists, else combine first two columns
   if (is.null(row.names)) {
-    if ("Variable" %in% intersect(colnames(settings1), colnames(settings2))) {
-      rownames(settings1) <- make.unique(settings1[, "Variable"])
-      rownames(settings2) <- make.unique(settings2[, "Variable"])
+    if ("variable" %in% intersect(colnames(settings1), colnames(settings2))) {
+      rownames(settings1) <- make.unique(settings1[, "variable"], sep = " ")
+      rownames(settings2) <- make.unique(settings2[, "variable"], sep = " ")
     } else {
       rownames(settings1) <- make.unique(paste0(settings1[, 1], ": ", settings1[, 2]))
       rownames(settings2) <- make.unique(paste0(settings2[, 1], ": ", settings2[, 2]))
@@ -110,7 +113,7 @@ compareScenConf <- function(fileList = NULL, remindPath = "/p/projects/rd3mod/gi
     settings1[, c] <- if (is.null(cfg$gms[[c]])) NA else cfg$gms[[c]]
   }
   jointCols <- intersect(names(settings1), names(settings2))
-  m <- c(m, "", "Changes in the scenarios:")
+  m <- c(m, "", "Changes in the rows:")
   for (s in scenarios) {
     if (s %in% intersect(c(rownames(settings1), renamedRows), rownames(settings2))) {
       # scenario name, oldname -> newname if renamed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.162.1**
+R package **remind2**, version **1.162.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). "remind2: The REMIND R package (2nd generation)." Version: 1.162.1, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2024). "remind2: The REMIND R package (2nd generation)." Version: 1.162.2, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
-  date = {2024-12-18},
+  date = {2024-12-30},
   year = {2024},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.162.1},
+  note = {Version: 1.162.2},
 }
 ```

--- a/man/compareScenConf.Rd
+++ b/man/compareScenConf.Rd
@@ -3,7 +3,8 @@
 \name{compareScenConf}
 \alias{compareScenConf}
 \title{take two REMIND scenario-config*.csv files and print the difference,
-comparing it to a default.cfg}
+comparing it to a default.cfg
+Can also be used for piamInterfaces mapping files with row.names=NULL and expanddata=FALSE.}
 \usage{
 compareScenConf(
   fileList = NULL,
@@ -19,9 +20,11 @@ compareScenConf(
 \item{fileList}{vector containing one csv file paths or two paths as c(oldfile, newfile)
 If one, searches same filename in defaultPath. If NULL, user can select}
 
-\item{remindPath}{path to REMIND directory containing main.gms}
+\item{remindPath}{path to REMIND directory containing main.gms. Used for extracting the
+default configuration and find a file for comparison if only one config file is supplied in fileList}
 
-\item{row.names}{column in csv used for row.names. Use NULL for mapping files}
+\item{row.names}{column in csv used for row.names. Defaults to 1.
+Use NULL for mapping files which either picks the 'variable' column or uses the first two columns.}
 
 \item{renamedCols}{vector with old and new column names such as c("old1" = "new1", "old2" = "new2"))}
 
@@ -30,7 +33,7 @@ the "old" name can also remain in the new file, if you generated a variant}
 
 \item{printit}{boolean switch (default: TRUE) whether function prints its output}
 
-\item{expanddata}{fill empty cells with default values}
+\item{expanddata}{fill empty cells with default values. Use FALSE for mapping files}
 }
 \value{
 list with $allwarnings and $out
@@ -38,6 +41,7 @@ list with $allwarnings and $out
 \description{
 take two REMIND scenario-config*.csv files and print the difference,
 comparing it to a default.cfg
+Can also be used for piamInterfaces mapping files with row.names=NULL and expanddata=FALSE.
 }
 \examples{
 


### PR DESCRIPTION
- variable column is now consistently spelled with lower v
- improve documentation
- beautify: add " 1" in case of multiple lines with same variable, not ".1"