### PR TITLE
add OAE quicklime use to reporting

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '233816760'
+ValidationKey: '233960710'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.162.4
-date-released: '2025-01-27'
+version: 1.163.0
+date-released: '2025-01-29'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.162.4
-Date: 2025-01-27
+Version: 1.163.0
+Date: 2025-01-29
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportTechnology.R
+++ b/R/reportTechnology.R
@@ -117,7 +117,7 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(
     "tnrs" = "Electricity|Nuclear",
     "spv" = "Electricity|Solar|PV",
     "csp" = "Electricity|Solar|CSP",
-          "h2turb" = "Electricity|Hydrogen",
+    "h2turb" = "Electricity|Hydrogen",
     "storspv" = "Electricity|Storage|Battery|For PV",
     "storcsp" = "Electricity|Storage|Battery|For CSP",
     "biogas" = "Gases|Biomass|w/o CC",
@@ -144,9 +144,9 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(
 
   if (tran_mod == "complex") {
     carmap <- c(
-      "apCarPeT" = "Transport|Pass|Road|LDV|ICE",
-      "apCarElT" = "Transport|Pass|Road|LDV|EV",
-      "apCarH2T" = "Transport|Pass|Road|LDV|H2")
+                "apCarPeT" = "Transport|Pass|Road|LDV|ICE",
+                "apCarElT" = "Transport|Pass|Road|LDV|EV",
+                "apCarH2T" = "Transport|Pass|Road|LDV|H2")
   } else {
     carmap <- c()
   }
@@ -157,7 +157,7 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(
 
   if (CDR_mod != "off") {
     cdrmap <- c("dac" = "DAC",
-      "ccsinje" = "CO2 Storage")
+                "ccsinje" = "CO2 Storage")
   } else {
     cdrmap <- c()
   }
@@ -390,58 +390,58 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(
   tmp[is.na(tmp)] <- 0  # tmp is NA if weight is zero for all regions within the GLO or the specific region aggregation. Therefore, we replace all NAs with zeros.
 
 
- # EW reporting: add info on rocks for enhanced weathering ----
-    tmp2 <- NULL
-    ## calculate totals of rocks spread
-    v33_EW_onfield <- readGDX(gdx, "v33_EW_onfield", restore_zeros = FALSE, field = "l", format = "first_found")[, t, ] # [Gt rock]
-    v33_EW_onfield_total <- dimSums(v33_EW_onfield, dim = 3)             # aggregate total rocks spread [Gt rock]
-    v33_EW_onfield_byClimateGrade <- dimSums(v33_EW_onfield, dim = 3.2)  # rocks spread by climate grade, aggregated across transportation grades [Gt rock]
+  # EW reporting: add info on rocks for enhanced weathering ----
+  tmp2 <- NULL
+  ## calculate totals of rocks spread
+  v33_EW_onfield <- readGDX(gdx, "v33_EW_onfield", restore_zeros = FALSE, field = "l", format = "first_found")[, t, ] # [Gt rock]
+  v33_EW_onfield_total <- dimSums(v33_EW_onfield, dim = 3)             # aggregate total rocks spread [Gt rock]
+  v33_EW_onfield_byClimateGrade <- dimSums(v33_EW_onfield, dim = 3.2)  # rocks spread by climate grade, aggregated across transportation grades [Gt rock]
 
-    ## calculate totals of rocks weathering on fields in each period
-    v33_EW_onfield_tot <- readGDX(gdx, "v33_EW_onfield_tot", restore_zeros = FALSE, field = "l", format = "first_found")[, t, ] # [Gt rock]
-    v33_EW_onfield_tot_total <- dimSums(v33_EW_onfield_tot, dim = 3)            # total of rocks weathering on fields  [Gt rock]
-    v33_EW_onfield_tot_byClimateGrade <- dimSums(v33_EW_onfield_tot, dim = 3.2) # rocks weathering on field by climate grade, aggregated across transportation grades [Gt rock]
+  ## calculate totals of rocks weathering on fields in each period
+  v33_EW_onfield_tot <- readGDX(gdx, "v33_EW_onfield_tot", restore_zeros = FALSE, field = "l", format = "first_found")[, t, ] # [Gt rock]
+  v33_EW_onfield_tot_total <- dimSums(v33_EW_onfield_tot, dim = 3)            # total of rocks weathering on fields  [Gt rock]
+  v33_EW_onfield_tot_byClimateGrade <- dimSums(v33_EW_onfield_tot, dim = 3.2) # rocks weathering on field by climate grade, aggregated across transportation grades [Gt rock]
 
-    tmp2 <- mbind(
-        setNames(v33_EW_onfield_total                 * 1000,  "CDR|Rocks spread (Mt rocks/yr)"),
-        setNames(v33_EW_onfield_byClimateGrade[, , "1"] * 1000,  "CDR|Rocks spread|+|warm regions (Mt rocks/yr)"),
-        setNames(v33_EW_onfield_byClimateGrade[, , "2"] * 1000,  "CDR|Rocks spread|+|temperate regions (Mt rocks/yr)"),
-        setNames(v33_EW_onfield_tot_total             * 1000,  "CDR|Rocks weathering (Mt rocks)"),
-        setNames(v33_EW_onfield_tot_byClimateGrade[, , "1"] * 1000,  "CDR|Rocks weathering|+|warm regions (Mt rocks)"),
-        setNames(v33_EW_onfield_tot_byClimateGrade[, , "2"] * 1000,  "CDR|Rocks weathering|+|temperate regions (Mt rocks)")
-    )
+  tmp2 <- mbind(
+    setNames(v33_EW_onfield_total                 * 1000,  "CDR|Rocks spread (Mt rocks/yr)"),
+    setNames(v33_EW_onfield_byClimateGrade[, , "1"] * 1000,  "CDR|Rocks spread|+|warm regions (Mt rocks/yr)"),
+    setNames(v33_EW_onfield_byClimateGrade[, , "2"] * 1000,  "CDR|Rocks spread|+|temperate regions (Mt rocks/yr)"),
+    setNames(v33_EW_onfield_tot_total             * 1000,  "CDR|Rocks weathering (Mt rocks)"),
+    setNames(v33_EW_onfield_tot_byClimateGrade[, , "1"] * 1000,  "CDR|Rocks weathering|+|warm regions (Mt rocks)"),
+    setNames(v33_EW_onfield_tot_byClimateGrade[, , "2"] * 1000,  "CDR|Rocks weathering|+|temperate regions (Mt rocks)")
+  )
 
-    ## add global and regional sums
-    tmp2 <- mbind(tmp2, dimSums(tmp2, dim = 1))
+  ## add global and regional sums
+  tmp2 <- mbind(tmp2, dimSums(tmp2, dim = 1))
 
-    if (!is.null(regionSubsetList))
-          tmp2 <- mbind(tmp2, calc_regionSubset_sums(tmp2, regionSubsetList))
+  if (!is.null(regionSubsetList))
+    tmp2 <- mbind(tmp2, calc_regionSubset_sums(tmp2, regionSubsetList))
 
-    ## combine main reporting and EW ----
-    tmp2 <- magclass::matchDim(tmp2, tmp, dim = c(1, 2))
-    tmp <- mbind(tmp, tmp2)
-  
-# OAE reporting: add info on quicklime and slacked lime needed for OAE ----
-    tmp3 <- NULL
-    ## read data and calculate total across technologies
-    vm_emiCdrTeDetail_oae <- readGDX(gdx, "vm_emiCdrTeDetail", restore_zeros = FALSE, field = "l", format = "first_found")[, t,c("oae_ng","oae_el")] # [Gt C ocean uptake]
-    vm_emiCdrTeDetail_oae <- dimSums(vm_emiCdrTeDetail_oae, dim = 3)     # GtC ocean uptake summed over the two oae technologies  
-    
-    s33_OAE_efficiency <- readGDX(gdx, "s33_OAE_efficiency") # tC / tCaO
-   
-    tmp3 <- mbind(
-      setNames(-vm_emiCdrTeDetail_oae / s33_OAE_efficiency * 1000,  "CDR|OAE quicklime (Mt CaO/yr)")
-    )
+  ## combine main reporting and EW ----
+  tmp2 <- magclass::matchDim(tmp2, tmp, dim = c(1, 2))
+  tmp <- mbind(tmp, tmp2)
 
-    ## add global and regional sums 
-    tmp3 <- mbind(tmp3, dimSums(tmp3, dim = 1))
-    
-    if (!is.null(regionSubsetList))
-          tmp3 <- mbind(tmp3, calc_regionSubset_sums(tmp3, regionSubsetList))
+  # OAE reporting: add info on quicklime and slacked lime needed for OAE ----
+  tmp3 <- NULL
+  ## read data and calculate total across technologies
+  vm_emiCdrTeDetail_oae <- readGDX(gdx, "vm_emiCdrTeDetail", restore_zeros = FALSE, field = "l", format = "first_found")[, t, c("oae_ng", "oae_el")] # [Gt C ocean uptake]
+  vm_emiCdrTeDetail_oae <- dimSums(vm_emiCdrTeDetail_oae, dim = 3)     # GtC ocean uptake summed over the two oae technologies
 
-    ## combine main reporting and OAE ----
-    tmp3 <- magclass::matchDim(tmp3, tmp, dim = c(1, 2))
-    tmp <- mbind(tmp, tmp3)
+  s33_OAE_efficiency <- readGDX(gdx, "s33_OAE_efficiency") # tC / tCaO
+
+  tmp3 <- mbind(
+    setNames(-vm_emiCdrTeDetail_oae / s33_OAE_efficiency * 1000,  "CDR|OAE quicklime (Mt CaO/yr)")
+  )
+
+  ## add global and regional sums
+  tmp3 <- mbind(tmp3, dimSums(tmp3, dim = 1))
+
+  if (!is.null(regionSubsetList))
+    tmp3 <- mbind(tmp3, calc_regionSubset_sums(tmp3, regionSubsetList))
+
+  ## combine main reporting and OAE ----
+  tmp3 <- magclass::matchDim(tmp3, tmp, dim = c(1, 2))
+  tmp <- mbind(tmp, tmp3)
 
 
   getSets(tmp)[3] <- "variable"

--- a/R/reportTechnology.R
+++ b/R/reportTechnology.R
@@ -411,16 +411,37 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(
         setNames(v33_EW_onfield_tot_byClimateGrade[, , "2"] * 1000,  "CDR|Rocks weathering|+|temperate regions (Mt rocks)")
     )
 
-    ## add global values
+    ## add global and regional sums
     tmp2 <- mbind(tmp2, dimSums(tmp2, dim = 1))
 
     if (!is.null(regionSubsetList))
           tmp2 <- mbind(tmp2, calc_regionSubset_sums(tmp2, regionSubsetList))
 
-
-  # combine main reporting and EW ----
+    ## combine main reporting and EW ----
     tmp2 <- magclass::matchDim(tmp2, tmp, dim = c(1, 2))
     tmp <- mbind(tmp, tmp2)
+  
+# OAE reporting: add info on quicklime and slacked lime needed for OAE ----
+    tmp3 <- NULL
+    ## read data and calculate total across technologies
+    vm_emiCdrTeDetail_oae <- readGDX(gdx, "vm_emiCdrTeDetail", restore_zeros = FALSE, field = "l", format = "first_found")[, t,c("oae_ng","oae_el")] # [Gt C ocean uptake]
+    vm_emiCdrTeDetail_oae <- dimSums(vm_emiCdrTeDetail_oae, dim = 3)     # GtC ocean uptake summed over the two oae technologies  
+    
+    s33_OAE_efficiency <- readGDX(gdx, "s33_OAE_efficiency") # tC / tCaO
+   
+    tmp3 <- mbind(
+      setNames(-vm_emiCdrTeDetail_oae / s33_OAE_efficiency * 1000,  "CDR|OAE quicklime (Mt CaO/yr)")
+    )
+
+    ## add global and regional sums 
+    tmp3 <- mbind(tmp3, dimSums(tmp3, dim = 1))
+    
+    if (!is.null(regionSubsetList))
+          tmp3 <- mbind(tmp3, calc_regionSubset_sums(tmp3, regionSubsetList))
+
+    ## combine main reporting and OAE ----
+    tmp3 <- magclass::matchDim(tmp3, tmp, dim = c(1, 2))
+    tmp <- mbind(tmp, tmp3)
 
 
   getSets(tmp)[3] <- "variable"

--- a/R/reportTechnology.R
+++ b/R/reportTechnology.R
@@ -423,21 +423,26 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(
 
   # OAE reporting: add info on quicklime and slacked lime needed for OAE ----
   tmp3 <- NULL
-  ## read data and calculate total across technologies
-  vm_emiCdrTeDetail_oae <- readGDX(gdx, "vm_emiCdrTeDetail", restore_zeros = FALSE, field = "l", format = "first_found")[, t, c("oae_ng", "oae_el")] # [Gt C ocean uptake]
+  te_oae33 <- readGDX(gdx, "te_oae33", react = "silent")
+  
+  if (!is.null(te_oae33)) {
+   ## read data and calculate total across technologies
+  vm_emiCdrTeDetail_oae <- readGDX(gdx, "vm_emiCdrTeDetail", restore_zeros = FALSE, field = "l", format = "first_found")[, t, te_oae33] # [Gt C ocean uptake]
   vm_emiCdrTeDetail_oae <- dimSums(vm_emiCdrTeDetail_oae, dim = 3)     # GtC ocean uptake summed over the two oae technologies
-
+  
   s33_OAE_efficiency <- readGDX(gdx, "s33_OAE_efficiency") # tC / tCaO
 
   tmp3 <- mbind(
     setNames(-vm_emiCdrTeDetail_oae / s33_OAE_efficiency * 1000,  "CDR|OAE quicklime (Mt CaO/yr)")
   )
-
   ## add global and regional sums
   tmp3 <- mbind(tmp3, dimSums(tmp3, dim = 1))
 
   if (!is.null(regionSubsetList))
     tmp3 <- mbind(tmp3, calc_regionSubset_sums(tmp3, regionSubsetList))
+  } else {
+    tmp3 <- new.magpie(getRegions(tmp), getYears(tmp), "CDR|OAE quicklime (Mt CaO/yr)", fill = 0)
+  }
 
   ## combine main reporting and OAE ----
   tmp3 <- magclass::matchDim(tmp3, tmp, dim = c(1, 2))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.162.4**
+R package **remind2**, version **1.163.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.162.4, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.163.0, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
-  date = {2025-01-27},
+  date = {2025-01-29},
   year = {2025},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.162.4},
+  note = {Version: 1.163.0},
 }
 ```


### PR DESCRIPTION
This PR adds the reporting of quicklime (Mt CaO/yr) to the reporting, analogous to use of rocks for enhanced weathering.

~~@fbenke-pik this limits reportTechnology backwards compatibility to before OAE was introduced. Is that an issue?~~
