### PR TITLE
adjust reportEmi to renaming of v37_emiNonFosNonIncineratedPlastics

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '234809080'
+ValidationKey: '234910845'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.166.0
-date-released: '2025-02-19'
+version: 1.166.1
+date-released: '2025-02-26'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues
@@ -17,6 +17,8 @@ authors:
   given-names: Jan Philipp
 - family-names: Dirnaichner
   given-names: Alois
+- family-names: Dorndorf
+  given-names: Tabea
 - family-names: Duerrwaechter
   given-names: Jakob
 - family-names: Führlich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,15 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.166.0
-Date: 2025-02-19
+Version: 1.166.1
+Date: 2025-02-26
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),
     person("Falk", "Benke", role = "aut"),
     person("Jan Philipp", "Dietrich", role = "aut"),
     person("Alois", "Dirnaichner", role = "aut"),
+    person("Tabea", "Dorndorf", role = "aut"),
     person("Jakob", "Duerrwaechter", role = "aut"),
     person("Pascal", "Führlich", role = "aut"),
     person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -302,11 +302,11 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
   ## Read-in chemical feedstocks variables ----
   v37_plasticsCarbon <- readGDX(gdx, "v37_plasticsCarbon", field = "l", temporal = 1, spatial = 2,
                                 restore_zeros = FALSE, react = "silent")[, t, ]
-
-  v37_emiNonFosNonIncineratedPlastics <- readGDX(gdx, "v37_emiNonFosNonIncineratedPlastics", field = "l",
+  
+  vm_emiNonFosNonIncineratedPlastics <- readGDX(gdx, c("v37_emiNonFosNonIncineratedPlastics","vm_emiNonFosNonIncineratedPlastics"), field = "l",
                                                  restore_zeros = FALSE, react = "silent")[, t, ]
 
-  v37_emiNonFosNonIncineratedPlastics <- magclass::matchDim(v37_emiNonFosNonIncineratedPlastics,
+  vm_emiNonFosNonIncineratedPlastics <- magclass::matchDim(vm_emiNonFosNonIncineratedPlastics,
                                                             v37_plasticsCarbon, fill = 0, dim = 1)
 
   v37_emiNonPlasticWaste <- readGDX(gdx, "v37_emiNonPlasticWaste", field = "l",
@@ -1225,7 +1225,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
   # This includes waste incineration without energy recovery and negative emissions from
   # non-incinerated (non-fossil) plastics.
   out <- mbind(out,
-               setNames(dimSums(mselect(v37_emiNonFosNonIncineratedPlastics * GtC_2_MtCO2,
+               setNames(dimSums(mselect(vm_emiNonFosNonIncineratedPlastics * GtC_2_MtCO2,
                                         all_enty = "co2"), dim = 3),
                         "Emi|CO2|Waste|+|Non-Incinerated Plastic (Mt CO2/yr)"))
 
@@ -2786,7 +2786,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
     # + Waste CO2 emissions from non-plastics
     setNames(
              dimSums(mselect(EmiMACEq[, , "ES"], sector = "Waste"), dim = 3)
-             + dimSums(mselect(v37_emiNonFosNonIncineratedPlastics * GtC_2_MtCO2,
+             + dimSums(mselect(vm_emiNonFosNonIncineratedPlastics * GtC_2_MtCO2,
                                all_enty = "co2"), dim = 3)
              + dimSums(mselect(v37_emiNonPlasticWaste  * GtC_2_MtCO2,
                                all_enty = "co2"), dim = 3),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.166.0**
+R package **remind2**, version **1.166.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,17 +49,17 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.166.0, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.166.1, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
-  author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
-  date = {2025-02-19},
+  author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
+  date = {2025-02-26},
   year = {2025},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.166.0},
+  note = {Version: 1.166.1},
 }
 ```

--- a/man/remind2-package.Rd
+++ b/man/remind2-package.Rd
@@ -24,6 +24,7 @@ Authors:
   \item Falk Benke
   \item Jan Philipp Dietrich
   \item Alois Dirnaichner
+  \item Tabea Dorndorf
   \item Jakob Duerrwaechter
   \item Pascal Führlich
   \item Anastasis Giannousakis


### PR DESCRIPTION
## Purpose of this PR
Adjust naming of `v37_emiNonFosNonIncineratedPlastics` in `reportEmi `according to [this PR](https://github.com/remindmodel/remind/pull/2004) in remind


## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [ ] do not create new complaints about summation checks.
- [ ] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

