### PR TITLE
remove building cs2 pdf from convGDX2mif test

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '234910845'
+ValidationKey: '234942652'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.166.1
-date-released: '2025-02-26'
+version: 1.166.2
+date-released: '2025-02-27'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.166.1
-Date: 2025-02-26
+Version: 1.166.2
+Date: 2025-02-27
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.166.1**
+R package **remind2**, version **1.166.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.166.1, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.166.2, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
-  date = {2025-02-26},
+  date = {2025-02-27},
   year = {2025},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.166.1},
+  note = {Version: 1.166.2},
 }
 ```

--- a/tests/testthat/test-convGDX2mif.R
+++ b/tests/testthat/test-convGDX2mif.R
@@ -84,38 +84,7 @@ test_that("Test if REMIND reporting is produced as it should and check data inte
       model = "REMIND"
     )
   }
-  # create a second file, so we can actually check the comparison code
-  if (numberOfMifs == 1) {
-    numberOfMifs <- numberOfMifs + 1
-    magclass::write.report(
-      x = magclass::collapseNames(mifContent),
-      file = file.path(tempdir(), paste0(numberOfMifs, ".mif")),
-      scenario = paste0(magclass::getItems(mifContent, dim = "scenario"), numberOfMifs),
-      model = "REMIND"
-    )
-  }
 
-  message("Checking compareScenarios...")
-  myMifs <- file.path(tempdir(), paste0(seq_len(numberOfMifs), ".mif"))
-  histMif <- file.path(tempdir(), "historical.mif")
-  if (!file.exists(histMif)) {
-    utils::download.file("https://rse.pik-potsdam.de/data/example/historical.mif", histMif, quiet = TRUE)
-  }
-
-  suppressWarnings(
-    capture.output( # Do not show stdout text.
-      piamPlotComparison::compareScenarios(
-        projectLibrary = "remind2",
-        mifScen = myMifs,
-        mifHist = histMif,
-        outputFormat = "pdf",
-        outputFile = "cs2_test",
-        outputDir = tempdir(),
-        sections = 0
-      )
-    ) # Render only the info section.
-  )
-  expect_true(file.exists(file.path(tempdir(), "cs2_test.pdf")))
   unlink(tempdir(), recursive = TRUE)
   tempdir(TRUE)
 })


### PR DESCRIPTION
Removes running compareScenarios to create a dummy file from convGDX2mif test. This check adds little insight, but can cause hard to track and fix for Windows users who do not have the right Tex Version installed locally.