### PR TITLE
Remove implicit tax on energy efficient capital from `reportTax.R` as it no longer exists in REMIND

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,8 +1,9 @@
-ValidationKey: '234942652'
+ValidationKey: '234962798'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*
 - .*to check if summation groups add up.*
+- Warning: package .* was built under R version
 AcceptedNotes: Imports includes .* non-default packages.
 AutocreateReadme: yes
 allowLinterWarnings: yes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.166.2
+version: 1.166.3
 date-released: '2025-02-27'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.166.2
+Version: 1.166.3
 Date: 2025-02-27
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/reportTax.R
+++ b/R/reportTax.R
@@ -232,10 +232,6 @@ reportTax <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,5)
   p21_taxrevBio0 <- readGDX(gdx, name=c("p21_taxrevBio0"), format= "first_found")[,t,]*1000
   out <- mbind(out, setNames(p21_taxrevBio0,"Net Taxes|Bioenergy (billion US$2017/yr)"))
 
-  # implicit tax on energy efficient capital
-  p21_implicitDiscRate0 <- readGDX(gdx, name=c("p21_implicitDiscRate0"), format= "first_found")[,t,]*1000
-  out <- mbind(out, setNames(p21_implicitDiscRate0,"Net Taxes|Implicit efficiency target (billion US$2017/yr)"))
-
   # co2 emission taxes per emission market
   p21_taxemiMkt0 <- readGDX(gdx, name=c("p21_taxemiMkt0"), format= "first_found")[,t,]*1000
   out <- mbind(out,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.166.2**
+R package **remind2**, version **1.166.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.166.2, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.166.3, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -60,6 +60,6 @@ A BibTeX entry for LaTeX users is
   date = {2025-02-27},
   year = {2025},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.166.2},
+  note = {Version: 1.166.3},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR

- Add `Warning: package .* was built under R version` to accepted warnings. The warning `Warning: package 'magclass' was built under R version 4.3.3` let to failure of `lucode2::buildLibrary()`. Since this is a mysterious problem with my local R setup on Windows, @fbenke-pik suggested to accept this warning.
- Remove implicit tax on energy efficient capital from `reportTax.R` as it no longer exists in REMIND: https://github.com/remindmodel/remind/pull/2001

## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [ ] do not create new complaints about summation checks.
- [ ] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

