### PR TITLE
Bugfix: report PE prices reported pebios instead of pebioil

### DIFF
--- a/R/reportPrices.R
+++ b/R/reportPrices.R
@@ -275,7 +275,7 @@ reportPrices <- function(gdx, output = NULL, regionSubsetList = NULL,
                         "Price|Primary Energy|Biomass|Modern (US$2017/GJ)"),
                setNames(mselect(pm_PEPrice, all_enty = "pebios") * tdptwyr2dpgj,
                         "Price|Primary Energy|Biomass|1st Generation|Sugar and Starch (US$2017/GJ)"),
-               setNames(mselect(pm_PEPrice, all_enty = "pebios") * tdptwyr2dpgj,
+               setNames(mselect(pm_PEPrice, all_enty = "pebioil") * tdptwyr2dpgj,
                         "Price|Primary Energy|Biomass|1st Generation|Oil-based (US$2017/GJ)")
   )
 


### PR DESCRIPTION
## Purpose of this PR

report PE prices reported pebios instead of pebioil, so I changed it


## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [ ] do not create new complaints about summation checks.
- [ ] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

