### PR TITLE
let Emi|CO2 and Emi|GHG have bunkers in GLO + regi

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '236140604'
+ValidationKey: '236357240'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.171.1
-date-released: '2025-03-17'
+version: 1.172.0
+date-released: '2025-03-20'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.171.1
-Date: 2025-03-17
+Version: 1.172.0
+Date: 2025-03-20
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportCapacity.R
+++ b/R/reportCapacity.R
@@ -29,7 +29,7 @@
 
 reportCapacity <- function(gdx, regionSubsetList = NULL,
                            t = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150),
-                           gdx_ref = gdx_ref) {
+                           gdx_ref = gdx) {
   # read sets
   teall2rlf <- readGDX(gdx, name = c("te2rlf", "teall2rlf"), format = "first_found")
   ttot <- readGDX(gdx, name = "ttot")

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -3054,34 +3054,29 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
 
   }
 
-  # variable names for emission variables with bunkers, insert w/ Bunkers
-  names.wBunkers <- emi.vars.wBunkers
-  names.wBunkers <- gsub("Emi\\|CO2", "Emi|CO2|w/ Bunkers", names.wBunkers)
-  names.wBunkers <- gsub("Emi\\|GHG", "Emi|GHG|w/ Bunkers", names.wBunkers)
+  addBunkerString <- function(vars, add) {
+    vars <- deletePlus(vars)
+    vars <- gsub("^Emi\\|CO2", paste0("Emi|CO2|", add), vars)
+    vars <- gsub("^Emi\\|GHG", paste0("Emi|GHG|", add), vars)
+    return(vars)
+  }
 
-  # emissions variables with bunkers
+  # emissions variables with bunkers. Insert 'w/ Bunkers' into variable name
+  names.wBunkers <- addBunkerString(emi.vars.wBunkers, "w/ Bunkers")
   out.wBunkers <- setNames(out[, , emi.vars.wBunkers], names.wBunkers)
-  # remove all pluses from variables with bunkers the "Emi w/ Bunkers" variables do not cover sectors in which bunkers are not relevant and checking aggregation does not make sense
-  getNames(out.wBunkers) <- deletePlus(getNames(out.wBunkers))
 
-  # subtract bunkers for standard emissions variables for regional values
-  regs.wo.glob <- getRegions(out)
-  regs.wo.glob <- regs.wo.glob[regs.wo.glob != "GLO"]
-  out[regs.wo.glob, , emi.vars.wBunkers] <- out[regs.wo.glob, , emi.vars.wBunkers] - out[regs.wo.glob, , "Emi|CO2|Energy|Demand|Transport|International Bunkers (Mt CO2/yr)"]
+  # emissions variables without bunkers. Insert 'w/o Bunkers' into variable name
+  names.woBunkers <- addBunkerString(emi.vars.wBunkers, "w/o Bunkers")
+  var.bunker <- "Emi|CO2|Energy|Demand|Transport|International Bunkers (Mt CO2/yr)"
+  out.woBunkers <- setNames(out[, , emi.vars.wBunkers] - out[, , var.bunker], names.woBunkers)
 
-  out <- mbind(out, out.wBunkers)
+  names.wIntraRegionBunkers <- addBunkerString(emi.vars.wBunkers, "w/ Intra-region Bunkers")
+  regs.wo.glob <- getRegions(out)[! getRegions(out) == "GLO"]
+  out.irBunkers <- out[, , emi.vars.wBunkers]
+  out.irBunkers[regs.wo.glob, , ] <- out.irBunkers[regs.wo.glob, , ] - out[regs.wo.glob, , var.bunker]
+  out.irBunkers <- setNames(out.irBunkers, names.wIntraRegionBunkers)
 
-  # adding intra-regional bunker variables
-  names.wIntraRegionBunkers <- emi.vars.wBunkers
-  names.wIntraRegionBunkers <- gsub("Emi\\|CO2", "Emi|CO2|w/ Intra-region Bunkers", names.wIntraRegionBunkers)
-  names.wIntraRegionBunkers <- gsub("Emi\\|GHG", "Emi|GHG|w/ Intra-region Bunkers", names.wIntraRegionBunkers)
-
-  # emissions variables with bunkers
-  out.wIntraRegionBunkers <- setNames(out[, , emi.vars.wBunkers], names.wIntraRegionBunkers)
-  # remove all pluses from variables with intra reg bunkers
-  getNames(out.wIntraRegionBunkers) <- deletePlus(getNames(out.wIntraRegionBunkers))
-
-  out <- mbind(out, out.wIntraRegionBunkers)
+  out <- mbind(out, out.wBunkers, out.woBunkers, out.irBunkers)
 
   # 10. Cumulative Emissions ----
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.171.1**
+R package **remind2**, version **1.172.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.171.1, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.172.0, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
-  date = {2025-03-17},
+  date = {2025-03-20},
   year = {2025},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.171.1},
+  note = {Version: 1.172.0},
 }
 ```

--- a/man/reportCapacity.Rd
+++ b/man/reportCapacity.Rd
@@ -8,7 +8,7 @@ reportCapacity(
   gdx,
   regionSubsetList = NULL,
   t = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150),
-  gdx_ref = gdx_ref
+  gdx_ref = gdx
 )
 }
 \arguments{

--- a/man/test_ranges.Rd
+++ b/man/test_ranges.Rd
@@ -46,7 +46,7 @@ require(tidyr)
   mutate(year = 2000 + (1:n())) \%>\%
   ungroup() \%>\%
   select(year, variable, value) \%>\%
-  as.magpie(spatial = 0, temporal = 1, data = 3))
+  as.magpie(spatial = 0, temporal = 1, datacol = 3))
 
 tests <- list(list("Share.*\\\\((\%|Percent)\\\\)$", low = 0, up = 100))
 


### PR DESCRIPTION
## Purpose of this PR

- big step for https://github.com/remindmodel/development_issues/issues/260
- removes the correction that `Emi|CO2`, `Emi|GHG` and sub-variables have bunkers included only on the global level, but not on the regional
- `Emi|CO2`, `Emi|GHG` and the like are now with bunkers (and identical to `Emi|CO2|w/ Bunkers`
- New variables: `Emi|CO2|w/o Bunkers` etc. that don't have any bunkers, neither on global nor on regional level
- remaining variables with this problem are those based on `p11_emiAPexoGlob` calculated in [reportEmiAirPol](https://github.com/pik-piam/remind2/blob/master/R/reportEmiAirPol.R)

It also has an effect on:
- `Price|Carbon|AggregatedByGrossCO2`
- `Revenue|Government|Tax|Carbon` (up to 20%)
- `Intensity|Final Energy|CO2` (up to 20%)
- `Intensity|GDP|GHG` and `Intensity Growth|GDP|CO2-equiv`

Should we switch any of them to `w/o Bunkers`?

## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [ ] do not create new complaints about summation checks.
- [ ] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

