### PR TITLE
handle warning in reportTechnology

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '236687940'
+ValidationKey: '236790235'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.173.0
-date-released: '2025-03-31'
+version: 1.173.1
+date-released: '2025-04-07'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.173.0
-Date: 2025-03-31
+Version: 1.173.1
+Date: 2025-04-07
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportTechnology.R
+++ b/R/reportTechnology.R
@@ -26,7 +26,8 @@
 #' @importFrom madrat toolAggregate
 #'
 
-reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150)) {
+reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL,
+                             t = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150)) {
 
   if (is.null(output)) {
     output <- mbind(
@@ -352,7 +353,7 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(
   # write to output ----
   ## substitute NA by 1E-30 to avoid that if in 2005, 2010, 2015, 2130, 2150,
   ## output is 0 in each region, the sum is returned by toolAggregate
-  output[is.na(output) | output == 0] <- 1E-30
+  output[is.na(output) | output == 0 | output < 0] <- 1E-30
   ## delete "+" and "++" from variable names
   output <- deletePlus(output)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.173.0**
+R package **remind2**, version **1.173.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.173.0, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.173.1, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
-  date = {2025-03-31},
+  date = {2025-04-07},
   year = {2025},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.173.0},
+  note = {Version: 1.173.1},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR

Avoid a warning in `reportTechnology` that causes buildLibrary to fail.

```
test "Test if REMIND reporting is produced as it should and check data integrity": Negative numbers in weight. Dangerous, was it really intended?
```

Cause: Some SE variables like `SE|Electricity|Solar|CSP` can have negative values (e.g. for OAS). In reportTechnology, the data it is used as a weight for calculation of GLO values. 
![image](https://github.com/user-attachments/assets/6c26a2e1-7fd3-4f80-9f01-c337b5778d85)


Workaround: set negative values to a close-to-zero positive value to avoid the warning in the weight (but not in the reported data itself)