### PR TITLE
New steel FE variables with routes and energy carriers

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '237003826'
+ValidationKey: '237197250'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.174.1
-date-released: '2025-04-08'
+version: 1.175.0
+date-released: '2025-04-09'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.174.1
-Date: 2025-04-08
+Version: 1.175.0
+Date: 2025-04-09
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -780,6 +780,51 @@ reportFE <- function(gdx, regionSubsetList = NULL,
           .select_sum_name_multiply(o37_demFeIndRoute, .mixer_to_selector(mixer))
         ))
 
+      # FE steel demand by routes and carriers
+      mixer <- tribble(
+        ~variable,                                                ~all_enty,  ~all_te,  ~route,           ~secInd37,
+        "FE|Industry|Steel|BF-BOF|+|Electricity (EJ/yr)",         "feels",    NULL,     "bfbof",          "steel",
+        "FE|Industry|Steel|BF-BOF|+|Heat (EJ/yr)",                "fehes",    NULL,     "bfbof",          "steel",
+        "FE|Industry|Steel|BF-BOF|+|Solids (EJ/yr)",              "fesos",    NULL,     "bfbof",          "steel",
+        "FE|Industry|Steel|BF-BOF|+|Liquids (EJ/yr)",             "fehos",    NULL,     "bfbof",          "steel",
+        "FE|Industry|Steel|BF-BOF|+|Gases (EJ/yr)",               "fegas",    NULL,     "bfbof",          "steel",
+        "FE|Industry|Steel|BF-BOF|+|Hydrogen (EJ/yr)",            "feh2s",    NULL,     "bfbof",          "steel",
+        "FE|Industry|Steel|BF-BOF-CCS|+|Electricity (EJ/yr)",     "feels",    NULL,     "bfbof_ccs",      "steel",
+        "FE|Industry|Steel|BF-BOF-CCS|+|Heat (EJ/yr)",            "fehes",    NULL,     "bfbof_ccs",      "steel",
+        "FE|Industry|Steel|BF-BOF-CCS|+|Solids (EJ/yr)",          "fesos",    NULL,     "bfbof_ccs",      "steel",
+        "FE|Industry|Steel|BF-BOF-CCS|+|Liquids (EJ/yr)",         "fehos",    NULL,     "bfbof_ccs",      "steel",
+        "FE|Industry|Steel|BF-BOF-CCS|+|Gases (EJ/yr)",           "fegas",    NULL,     "bfbof_ccs",      "steel",
+        "FE|Industry|Steel|BF-BOF-CCS|+|Hydrogen (EJ/yr)",        "feh2s",    NULL,     "bfbof_ccs",      "steel",
+        "FE|Industry|Steel|DRI-NG-EAF|+|Electricity (EJ/yr)",     "feels",    NULL,     "idreaf_ng",      "steel",
+        "FE|Industry|Steel|DRI-NG-EAF|+|Heat (EJ/yr)",            "fehes",    NULL,     "idreaf_ng",      "steel",
+        "FE|Industry|Steel|DRI-NG-EAF|+|Solids (EJ/yr)",          "fesos",    NULL,     "idreaf_ng",      "steel",
+        "FE|Industry|Steel|DRI-NG-EAF|+|Liquids (EJ/yr)",         "fehos",    NULL,     "idreaf_ng",      "steel",
+        "FE|Industry|Steel|DRI-NG-EAF|+|Gases (EJ/yr)",           "fegas",    NULL,     "idreaf_ng",      "steel",
+        "FE|Industry|Steel|DRI-NG-EAF|+|Hydrogen (EJ/yr)",        "feh2s",    NULL,     "idreaf_ng",      "steel",
+        "FE|Industry|Steel|DRI-NG-EAF-CCS|+|Electricity (EJ/yr)", "feels",    NULL,     "idreaf_ng_ccs",  "steel",
+        "FE|Industry|Steel|DRI-NG-EAF-CCS|+|Heat (EJ/yr)",        "fehes",    NULL,     "idreaf_ng_ccs",  "steel",
+        "FE|Industry|Steel|DRI-NG-EAF-CCS|+|Solids (EJ/yr)",      "fesos",    NULL,     "idreaf_ng_ccs",  "steel",
+        "FE|Industry|Steel|DRI-NG-EAF-CCS|+|Liquids (EJ/yr)",     "fehos",    NULL,     "idreaf_ng_ccs",  "steel",
+        "FE|Industry|Steel|DRI-NG-EAF-CCS|+|Gases (EJ/yr)",       "fegas",    NULL,     "idreaf_ng_ccs",  "steel",
+        "FE|Industry|Steel|DRI-NG-EAF-CCS|+|Hydrogen (EJ/yr)",    "feh2s",    NULL,     "idreaf_ng_ccs",  "steel",
+        "FE|Industry|Steel|DRI-H2-EAF|+|Electricity (EJ/yr)",     "feels",    NULL,     "idreaf_h2",      "steel",
+        "FE|Industry|Steel|DRI-H2-EAF|+|Heat (EJ/yr)",            "fehes",    NULL,     "idreaf_h2",      "steel",
+        "FE|Industry|Steel|DRI-H2-EAF|+|Solids (EJ/yr)",          "fesos",    NULL,     "idreaf_h2",      "steel",
+        "FE|Industry|Steel|DRI-H2-EAF|+|Liquids (EJ/yr)",         "fehos",    NULL,     "idreaf_h2",      "steel",
+        "FE|Industry|Steel|DRI-H2-EAF|+|Gases (EJ/yr)",           "fegas",    NULL,     "idreaf_h2",      "steel",
+        "FE|Industry|Steel|DRI-H2-EAF|+|Hydrogen (EJ/yr)",        "feh2s",    NULL,     "idreaf_h2",      "steel",
+        "FE|Industry|Steel|SCRAP-EAF|+|Electricity (EJ/yr)",      "feels",    NULL,     "seceaf",         "steel",
+        "FE|Industry|Steel|SCRAP-EAF|+|Heat (EJ/yr)",             "fehes",    NULL,     "seceaf",         "steel",
+        "FE|Industry|Steel|SCRAP-EAF|+|Solids (EJ/yr)",           "fesos",    NULL,     "seceaf",         "steel",
+        "FE|Industry|Steel|SCRAP-EAF|+|Liquids (EJ/yr)",          "fehos",    NULL,     "seceaf",         "steel",
+        "FE|Industry|Steel|SCRAP-EAF|+|Gases (EJ/yr)",            "fegas",    NULL,     "seceaf",         "steel",
+        "FE|Industry|Steel|SCRAP-EAF|+|Hydrogen (EJ/yr)",         "feh2s",    NULL,     "seceaf",         "steel")
+
+      out <- mbind(
+        c(list(out), # pass a list of magpie objects
+          .select_sum_name_multiply(o37_demFeIndRoute, .mixer_to_selector(mixer))
+        ))
+
     } else {
 
       # mapping of industrial output to energy production factors in CES tree

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.174.1**
+R package **remind2**, version **1.175.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.174.1, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.175.0, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
-  date = {2025-04-08},
+  date = {2025-04-09},
   year = {2025},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.174.1},
+  note = {Version: 1.175.0},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR

This PR simply adds FE variables for each steel production route and each FE carrier. They are introduced with summation groups.


## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

