### PR TITLE
Emission vars bunker fix

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '237197250'
+ValidationKey: '237229188'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.175.0
-date-released: '2025-04-09'
+version: 1.175.1
+date-released: '2025-04-10'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.175.0
-Date: 2025-04-09
+Version: 1.175.1
+Date: 2025-04-10
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.175.0**
+R package **remind2**, version **1.175.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.175.0, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.175.1, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
-  date = {2025-04-09},
+  date = {2025-04-10},
   year = {2025},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.175.0},
+  note = {Version: 1.175.1},
 }
 ```

--- a/inst/compareScenarios/cs_03_emissions.Rmd
+++ b/inst/compareScenarios/cs_03_emissions.Rmd
@@ -6,16 +6,17 @@
 
 ### GHG total w/o Bunkers w/ national LULUCF accounting - should match UNFCCC
 ```{r GHG total w/o Bunkers w/ national LULUCF accounting - should match UNFCCC}
-showLinePlots(data, "Emi|GHG|w/o Bunkers|LULUCF national accounting", histVars = "Emi|GHG")
+showLinePlots(data, "Emi|GHG|w/o Bunkers|LULUCF national accounting")
 ```
 
 ### GHG total w/ Bunkers w/ national LULUCF accounting - should match UNFCCC
 ```{r GHG total w/ Bunkers w/ national LULUCF accounting - should match UNFCCC}
-showLinePlots(data, "Emi|GHG|w/ Bunkers|LULUCF national accounting", histVars = "Emi|GHG|w/ Bunkers")
+showLinePlots(data, "Emi|GHG|w/ Bunkers|LULUCF national accounting")
 ```
 
 ### GHG total w/o Bunkers
 ```{r GHG total w/o Bunkers}
+# TODO: EU sources and PRIMAP still exclude bunkers in default vars -> update
 showLinePlots(data, "Emi|GHG|w/o Bunkers", histVars = "Emi|GHG")
 ```
 
@@ -46,7 +47,7 @@ showLinePlotsWithTarget(data, items)
 
 ### GHG Energy w/o Bunkers
 ```{r GHG Energy w/o Bunkers}
-showLinePlots(data, "Emi|GHG|w/o Bunkers|Energy", histVars = "Emi|GHG|Energy")
+showLinePlots(data, "Emi|GHG|w/o Bunkers|Energy")
 ```
 
 ### GHG Energy w/ Bunkers
@@ -104,7 +105,7 @@ items <- c(
   "Emi|CO2|Land-Use Change",
   "Emi|CO2|Industrial Processes",
   "Emi|CO2|Waste",
-  "Emi|CO2|Energy|Demand|Transport",
+  "Emi|CO2|w/ Bunkers|Energy|Demand|Transport",
   "Emi|CO2|Energy|Demand|Industry",
   "Emi|CO2|Energy|Demand|Buildings",
   "Emi|CO2|Energy|Demand|CDR Sector",
@@ -117,15 +118,25 @@ items <- c(
 showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```
 
-
-### CO2 total w/o Bunkers 
+### CO2 total w/o Bunkers w/ national LULUCF accounting - should match UNFCCC
 ```{r CO2 total w/o Bunkers}
+showLinePlots(data, "Emi|CO2|w/o Bunkers|LULUCF national accounting")
+```
+
+### CO2 total w/ Bunkers w/ national LULUCF accounting - should match UNFCCC
+```{r CO2 total w/o Bunkers}
+showLinePlots(data, "Emi|CO2|w/ Bunkers|LULUCF national accounting")
+```
+
+### CO2 total w/o Bunkers
+```{r CO2 total w/o Bunkers}
+# TODO: EU sources and PRIMAP still exclude bunkers in default vars -> update
 showLinePlots(data, "Emi|CO2|w/o Bunkers", histVars = "Emi|CO2")
 ```
 
 ### CO2 total w/ Bunkers 
 ```{r CO2 total w/ Bunkers}
-showLinePlots(data, "Emi|CO2|w/ Bunkers", histVars = "Emi|CO2||w/ Bunkers")
+showLinePlots(data, "Emi|CO2|w/ Bunkers")
 ```
 
 ### Total CO2 (for comparison with old REMIND versions)
@@ -137,8 +148,7 @@ showLinePlots(data, "Emi|CO2")
 ```{r Energy and Industrial Processes w/o bunkers - Net (incl BECCS)}
 showLinePlots(
   data, 
-  vars = "Emi|CO2|w/o Bunkers|Energy and Industrial Processes", 
-  histVars = "Emi|CO2|Energy and Industrial Processes"
+  vars = "Emi|CO2|w/o Bunkers|Energy and Industrial Processes"
 )
 ```
 
@@ -146,8 +156,7 @@ showLinePlots(
 ```{r Energy and Industrial Processes w/ bunkers - Net (incl BECCS)}
 showLinePlots(
   data, 
-  vars = "Emi|CO2|w/ Bunkers|Energy and Industrial Processes", 
-  histVars = "Emi|CO2|w/ Bunkers|Energy and Industrial Processes"
+  vars = "Emi|CO2|w/ Bunkers|Energy and Industrial Processes"
 )
 ```
 
@@ -164,13 +173,13 @@ showLinePlots(
 ### Energy without bunkers
 
 ```{r CO2 Energy w/o bunkers}
-showLinePlots(data, "Emi|CO2|w/o Bunkers|Energy", histVars = "Emi|CO2|Energy")
+showLinePlots(data, "Emi|CO2|w/o Bunkers|Energy")
 ```
 
 ### Energy with bunkers
 
 ```{r CO2 Energy w/ bunkers}
-showLinePlots(data, "Emi|CO2|w/ Bunkers|Energy", histVars = "Emi|CO2|w/ Bunkers|Energy")
+showLinePlots(data, "Emi|CO2|w/ Bunkers|Energy")
 ```
 
 
@@ -246,13 +255,13 @@ showLinePlots(data, "Emi|CO2|Industry")
 ### Transport without bunkers
 
 ```{r CO2 Transport}
-showLinePlots(data, "Emi|CO2|w/o Bunkers|Energy|Demand|Transport", histVars = "Emi|CO2|Energy|Demand|Transport")
+showLinePlots(data, "Emi|CO2|w/o Bunkers|Energy|Demand|Transport")
 ```
 
 ### Transport with bunkers
 
 ```{r CO2 Transport}
-showLinePlots(data, "Emi|CO2|w/ Bunkers|Energy|Demand|Transport", histVars = "Emi|CO2|w/ Bunkers|Energy|Demand|Transport")
+showLinePlots(data, "Emi|CO2|w/ Bunkers|Energy|Demand|Transport")
 ```
 
 
@@ -285,7 +294,8 @@ showAreaAndBarPlots(data, items, tot, scales = "fixed")
 showLinePlots(
   data, 
   vars = "Emi|CO2|Industrial Processes|Industry|Cement", 
-  histVars = c("Emi|CO2|Industrial Processes|Cement", "Emi|CO2|Industrial Processes|Minerals")
+  histVars = c("Emi|CO2|Industrial Processes|Cement", 
+               "Emi|CO2|Industrial Processes|Minerals")
 )
 ```
 
@@ -360,8 +370,7 @@ showLinePlots(
 ```{r CO2 Land-Use Change - LULUCF national accounting}
 showLinePlots(
   data, 
-  vars = "Emi|CO2|Land-Use Change|LULUCF national accounting",
-  histVars = "Emi|CO2|Land Use"
+  vars = "Emi|CO2|Land-Use Change|LULUCF national accounting"
 )
 ```
 


### PR DESCRIPTION
## Purpose of this PR

Adjust emission variable name of historical data in cs2, following https://github.com/pik-piam/mrremind/pull/670. Historical variables of EDAGR, CEDS and UNFCCC should now be consistent with REMIND again, PRIMAPhist and EU-specific sources still need to be updated.

## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

-> no reporting changes