### PR TITLE
Updates to reportEmiForClimateAssessment

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '237269564'
+ValidationKey: '237457920'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.175.3
-date-released: '2025-04-10'
+version: 1.176.0
+date-released: '2025-04-14'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.175.3
-Date: 2025-04-10
+Version: 1.176.0
+Date: 2025-04-14
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/convGDX2MIF.R
+++ b/R/convGDX2MIF.R
@@ -75,6 +75,9 @@ convGDX2MIF <- function(gdx, gdx_ref = NULL, file = NULL, scenario = "default",
   message("running reportEmi...") # needs output from reportFE
   output <- mbind(output, reportEmi(gdx, output, regionSubsetList, t)[, t, ])
 
+  message("running reportEmiForClimateAssessment...") # minimal and specific set of emissions for CA
+  output <- mbind(output, reportEmiForClimateAssessment(gdx, output, regionSubsetList, t)[, t, ])
+
   message("running reportTechnology...")
   # needs output from reportSE
   output <- mbind(output, reportTechnology(gdx, output, regionSubsetList, t)[, t, ])

--- a/R/reportEmiForClimateAssessment.R
+++ b/R/reportEmiForClimateAssessment.R
@@ -1,6 +1,6 @@
 #' Reports emissions & air pollutant values from GDX for climate assessment in between Nash iterations before some of
 #' the energy system variables are defined. The report contains only a subset of reported emissions, with the main
-#' difference being that Emi|CO2|Energy and Industrial Processes is calculated from the difference between total and
+#' difference being that Emi|CA|CO2|Energy and Industrial Processes is calculated from the difference between total and
 #' LUC emissions. Only global values from this function should be used, as it also skips the subtraction
 #' of certain non-regional sources, such as bunkers, from the regional information
 #'
@@ -60,17 +60,17 @@ reportEmiForClimateAssessment <- function(gdx, output = NULL, regionSubsetList =
 
   out <- mbind(
     # Basic Total CO2 emissions
-    setNames(dimSums(sel_vm_emiAllMkt_co2, dim = 3) * GtC_2_MtCO2, "Emi|CO2 (Mt CO2/yr)"),
-    # Basic Land-use change CO2 emissions
-    setNames(dimSums(vm_emiMacSector[, , "co2luc"], dim = 3) * GtC_2_MtCO2, "Emi|CO2|+|Land-Use Change (Mt CO2/yr)")
+    setNames(dimSums(sel_vm_emiAllMkt_co2, dim = 3) * GtC_2_MtCO2, "Emi|CA|CO2 (Mt CO2/yr)"),
+    # Basic Land-use change CO2 emissions. Remove the + to avoid summation checks
+    setNames(dimSums(vm_emiMacSector[, , "co2luc"], dim = 3) * GtC_2_MtCO2, "Emi|CA|CO2|Land-Use Change (Mt CO2/yr)")
   )
   # Basic Get Energy and Industrial Processes from the difference between total and Land-use change emissions, for
   # climate assessment
   out <- mbind(
     out,
     setNames(
-      out[, , "Emi|CO2 (Mt CO2/yr)"] - out[, , "Emi|CO2|+|Land-Use Change (Mt CO2/yr)"],
-      "Emi|CO2|Energy and Industrial Processes (Mt CO2/yr)"
+      out[, , "Emi|CA|CO2 (Mt CO2/yr)"] - out[, , "Emi|CA|CO2|Land-Use Change (Mt CO2/yr)"],
+      "Emi|CA|CO2|Energy and Industrial Processes (Mt CO2/yr)"
     )
   )
 
@@ -112,34 +112,34 @@ reportEmiForClimateAssessment <- function(gdx, output = NULL, regionSubsetList =
     # total CH4 emissions
     setNames(
       dimSums(mselect(emiMAC, gas = "ch4"), dim = 3) + dimSums(sel_vm_emiTeDetailMkt_ch4, dim = 3),
-      "Emi|CH4 (Mt CH4/yr)"
+      "Emi|CA|CH4 (Mt CH4/yr)"
     ),
     # total N2O emissions
     setNames(
       (dimSums(mselect(emiMAC, gas = "n2o"), dim = 3) + dimSums(sel_vm_emiTeDetailMkt_n2o, dim = 3)) * MtN2_to_ktN2O,
-      "Emi|N2O (kt N2O/yr)"
+      "Emi|CA|N2O (kt N2O/yr)"
     )
   )
 
   out <- mbind(
     out,
     ### Basic PFCs
-    setNames(vm_emiFgas[, , "emiFgasCF4"],      "Emi|CF4 (kt CF4/yr)"),
-    setNames(vm_emiFgas[, , "emiFgasC2F6"],     "Emi|C2F6 (kt C2F6/yr)"),
-    setNames(vm_emiFgas[, , "emiFgasC6F14"],    "Emi|C6F14 (kt C6F14/yr)"),
-    setNames(vm_emiFgas[, , "emiFgasHFC"],      "Emi|HFC (kt HFC134a-equiv/yr)"),
-    setNames(vm_emiFgas[, , "emiFgasHFC125"],   "Emi|HFC|HFC125 (kt HFC125/yr)"),
-    setNames(vm_emiFgas[, , "emiFgasHFC134a"],  "Emi|HFC|HFC134a (kt HFC134a/yr)"),
-    setNames(vm_emiFgas[, , "emiFgasHFC143a"],  "Emi|HFC|HFC143a (kt HFC143a/yr)"),
-    setNames(vm_emiFgas[, , "emiFgasHFC227ea"], "Emi|HFC|HFC227ea (kt HFC227ea/yr)"),
-    setNames(vm_emiFgas[, , "emiFgasHFC23"],    "Emi|HFC|HFC23 (kt HFC23/yr)"),
-    setNames(vm_emiFgas[, , "emiFgasHFC245fa"], "Emi|HFC|HFC245fa (kt HFC245fa/yr)"),
-    setNames(vm_emiFgas[, , "emiFgasHFC32"],    "Emi|HFC|HFC32 (kt HFC32/yr)"),
-    setNames(vm_emiFgas[, , "emiFgasHFC43-10"], "Emi|HFC|HFC43-10 (kt HFC43-10/yr)"),
-    setNames(vm_emiFgas[, , "emiFgasPFC"],      "Emi|PFC (kt CF4-equiv/yr)"),
-    setNames(vm_emiFgas[, , "emiFgasSF6"],      "Emi|SF6 (kt SF6/yr)"),
+    setNames(vm_emiFgas[, , "emiFgasCF4"],      "Emi|CA|CF4 (kt CF4/yr)"),
+    setNames(vm_emiFgas[, , "emiFgasC2F6"],     "Emi|CA|C2F6 (kt C2F6/yr)"),
+    setNames(vm_emiFgas[, , "emiFgasC6F14"],    "Emi|CA|C6F14 (kt C6F14/yr)"),
+    setNames(vm_emiFgas[, , "emiFgasHFC"],      "Emi|CA|HFC (kt HFC134a-equiv/yr)"),
+    setNames(vm_emiFgas[, , "emiFgasHFC125"],   "Emi|CA|HFC|HFC125 (kt HFC125/yr)"),
+    setNames(vm_emiFgas[, , "emiFgasHFC134a"],  "Emi|CA|HFC|HFC134a (kt HFC134a/yr)"),
+    setNames(vm_emiFgas[, , "emiFgasHFC143a"],  "Emi|CA|HFC|HFC143a (kt HFC143a/yr)"),
+    setNames(vm_emiFgas[, , "emiFgasHFC227ea"], "Emi|CA|HFC|HFC227ea (kt HFC227ea/yr)"),
+    setNames(vm_emiFgas[, , "emiFgasHFC23"],    "Emi|CA|HFC|HFC23 (kt HFC23/yr)"),
+    setNames(vm_emiFgas[, , "emiFgasHFC245fa"], "Emi|CA|HFC|HFC245fa (kt HFC245fa/yr)"),
+    setNames(vm_emiFgas[, , "emiFgasHFC32"],    "Emi|CA|HFC|HFC32 (kt HFC32/yr)"),
+    setNames(vm_emiFgas[, , "emiFgasHFC43-10"], "Emi|CA|HFC|HFC43-10 (kt HFC43-10/yr)"),
+    setNames(vm_emiFgas[, , "emiFgasPFC"],      "Emi|CA|PFC (kt CF4-equiv/yr)"),
+    setNames(vm_emiFgas[, , "emiFgasSF6"],      "Emi|CA|SF6 (kt SF6/yr)"),
     ### Basic F-Gases (Mt CO2eq)
-    setNames(vm_emiFgas[, , "emiFgasTotal"],    "Emi|GHG|+|F-Gases (Mt CO2eq/yr)")
+    setNames(vm_emiFgas[, , "emiFgasTotal"],    "Emi|CA|GHG|F-Gases (Mt CO2eq/yr)")
   )
 
   # Add global values
@@ -151,7 +151,8 @@ reportEmiForClimateAssessment <- function(gdx, output = NULL, regionSubsetList =
 
   # Run air pollution report
   message("reportEmiForClimateAssessment executes reportEmiAirPol")
-  pollutants <- reportEmiAirPol(gdx)
+  pollutants <- reportEmiAirPol(gdx, regionSubsetList = regionSubsetList, t = t)
+  getItems(pollutants, "variable") <- sub("Emi\\|", "Emi\\|CA\\|", getItems(pollutants, "variable"))
   # Combine both reports
   out <- mbind(out, pollutants[getItems(out, dim = "all_regi"), getItems(out, dim = "tall"), ])
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.175.3**
+R package **remind2**, version **1.176.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.175.3, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.176.0, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
-  date = {2025-04-10},
+  date = {2025-04-14},
   year = {2025},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.175.3},
+  note = {Version: 1.176.0},
 }
 ```

--- a/man/reportEmiForClimateAssessment.Rd
+++ b/man/reportEmiForClimateAssessment.Rd
@@ -4,7 +4,7 @@
 \alias{reportEmiForClimateAssessment}
 \title{Reports emissions & air pollutant values from GDX for climate assessment in between Nash iterations before some of
 the energy system variables are defined. The report contains only a subset of reported emissions, with the main
-difference being that Emi|CO2|Energy and Industrial Processes is calculated from the difference between total and
+difference being that Emi|CA|CO2|Energy and Industrial Processes is calculated from the difference between total and
 LUC emissions. Only global values from this function should be used, as it also skips the subtraction
 of certain non-regional sources, such as bunkers, from the regional information}
 \usage{
@@ -29,7 +29,7 @@ be created.}
 \description{
 Reports emissions & air pollutant values from GDX for climate assessment in between Nash iterations before some of
 the energy system variables are defined. The report contains only a subset of reported emissions, with the main
-difference being that Emi|CO2|Energy and Industrial Processes is calculated from the difference between total and
+difference being that Emi|CA|CO2|Energy and Industrial Processes is calculated from the difference between total and
 LUC emissions. Only global values from this function should be used, as it also skips the subtraction
 of certain non-regional sources, such as bunkers, from the regional information
 }


### PR DESCRIPTION
## Purpose of this PR
This PR is meant to further separate the emissions reporting needed for the climate assessment from the normal `reportEmi` emissions. It updates `reportEmiForClimateAssessment`, renaming its generated emission variables to `Emi|CA|*`, which should now be used in `piamInterfaces` instead, and removes the `+` from `Emi|CA|CO2|Land-Use Change`.  It also fixes a EU runs-specific but on it. 

These emissions follow a slightly different logic from the usual reporting, most notably in `Emi|CA|CO2|Energy and Industrial Processes`. In `reportEmiForClimateAssessment`, its calculated as the difference between `Emi|CA|CO2` and `Emi|CA|CO2|Land-Use Change`, and so also includes emissions that are usually in `Emi|CO2|Other`, `Emi|CO2|Waste` and/or `Emi|CO2|CDR`. They also should always include bunkers.

To get the new `CA` emissions in the usual reporting for debugging, it also adds `reportEmiForClimateAssessment` to `convGDX2MIF`.


## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

