### PR TITLE
Bugfix to PR726

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '237671610'
+ValidationKey: '237715345'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.177.0
-date-released: '2025-04-15'
+version: 1.177.1
+date-released: '2025-04-17'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.177.0
-Date: 2025-04-15
+Version: 1.177.1
+Date: 2025-04-17
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.177.0**
+R package **remind2**, version **1.177.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.177.0, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.177.1, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
-  date = {2025-04-15},
+  date = {2025-04-17},
   year = {2025},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.177.0},
+  note = {Version: 1.177.1},
 }
 ```

--- a/inst/compareScenarios/cs_04_energy_supply.Rmd
+++ b/inst/compareScenarios/cs_04_energy_supply.Rmd
@@ -239,22 +239,22 @@ showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
 
 ### PE Biomass Production - Energy Crops
 ```{r PE Biomass - Energy Crops}
-showLinePlots(data, "PE|Production|Biomass|Lignocellulosic|+|Energy Crops")
+showLinePlots(data, "PE|Production|Biomass|Lignocellulosic|Energy Crops")
 ```
 
 ### PE Biomass Production - Residues
 ```{r PE Biomass - Residues}
-showLinePlots(data, "PE|Production|Biomass|Lignocellulosic|+|Residues")
+showLinePlots(data, "PE|Production|Biomass|Lignocellulosic|Residues")
 ```
 
 ### PE Biomass Production - SugarAndStarch
 ```{r PE Biomass - Sugar and Starch Crops}
-showLinePlots(data, "PE|Production|Biomass|1st Generation|+|SugarAndStarch")
+showLinePlots(data, "PE|Production|Biomass|1st Generation|SugarAndStarch")
 ```
 
 ### PE Biomass Production - Sunflowers_PalmOil_others
 ```{r PE Biomass - Oil Crops}
-showLinePlots(data, "PE|Production|Biomass|1st Generation|+|Sunflowers_PalmOil_others")
+showLinePlots(data, "PE|Production|Biomass|1st Generation|Sunflowers_PalmOil_others")
 ```
 
 


### PR DESCRIPTION
## Purpose of this PR
Removes `+|` from the added `PE|Production|Biomass|...` variables in compare scenarios.


## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [ ] do not create new complaints about summation checks.
- [ ] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

