### PR TITLE
Add zero emissions

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '238343274'
+ValidationKey: '238607800'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.179.1
-date-released: '2025-05-06'
+version: 1.180.0
+date-released: '2025-05-13'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.179.1
-Date: 2025-05-06
+Version: 1.180.0
+Date: 2025-05-13
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportExtraEmissions.R
+++ b/R/reportExtraEmissions.R
@@ -190,6 +190,32 @@ reportExtraEmissions <- function(mif, extraData, gdx) {
   # Aggregate to global. Since all variables are emissions, we can just sum them
   out <- mbind(out, setItems(dimSums(out, dim = 1), dim = 1, value = "World"))
 
+  # Set emissions to zero that are not represented but that are required for
+  # earth system harmonization
+  out <- add_columns(out, addnm = "Emi|BC|Extra|Land Use|Peat Burning (Mt BC/yr)",                  dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|CH4|Extra|Land Use|Peat Burning (Mt CH4/yr)",                dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|CH4|Extra|Energy Demand|International Aviation (Mt CH4/yr)", dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|CH4|Extra|Energy Demand|Domestic Aviation (Mt CH4/yr)",      dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|CH4|Extra|Energy Demand|Transport (Mt CH4/yr)",              dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|CH4|Extra|Energy Demand|Industry (Mt CH4/yr)",               dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|CH4|Extra|Industrial Processes (Mt CH4/yr)",                 dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|CH4|Extra|Solvents (Mt CH4/yr)",                             dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|CO2|Extra|Land Use|Agriculture (Mt CO2/yr)",                 dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|CO2|Extra|Land Use|Agricultural Waste Burning (Mt CO2/yr)",  dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|CO2|Extra|Land Use|Forest Burning (Mt CO2/yr)",              dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|CO2|Extra|Land Use|Savannah Burning (Mt CO2/yr)",            dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|CO2|Extra|Land Use|Peat Burning (Mt CO2/yr)",                dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|CO2|Extra|Solvents (Mt CO2/yr)",                             dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|CO|Extra|Land Use|Peat Burning (Mt CO/yr)",                  dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|N2O|Extra|Land Use|Peat Burning (kt N2O/yr)",                dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|N2O|Extra|Energy Demand|Industry (kt N2O/yr)",               dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|N2O|Extra|Solvents (kt N2O/yr)",                             dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|NH3|Extra|Land Use|Peat Burning (Mt NH3/yr)",                dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|NOX|Extra|Land Use|Peat Burning (Mt NOX/yr)",                dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|OC|Extra|Land Use|Peat Burning (Mt OC/yr)",                  dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|SO2|Extra|Land Use|Peat Burning (Mt SO2/yr)",                dim = 3.1, fill = 0)
+  out <- add_columns(out, addnm = "Emi|VOC|Extra|Land Use|Peat Burning (Mt VOC/yr)",                dim = 3.1, fill = 0)
+
   # Convert to quitte and ensure it has the same model and scenario as the original report
   out <- as.quitte(out)
   out$model <- model

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.179.1**
+R package **remind2**, version **1.180.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.179.1, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.180.0, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
-  date = {2025-05-06},
+  date = {2025-05-13},
   year = {2025},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.179.1},
+  note = {Version: 1.180.0},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR
This PR adds Emissions variables that are not represented but should be stated explicitly as zero for Earth System Model harmonization.


## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

