### PR TITLE
add plus notation for types of biomass used

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '240028911'
+ValidationKey: '240353550'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.184.1
-date-released: '2025-07-02'
+version: 1.185.0
+date-released: '2025-07-14'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.184.1
-Date: 2025-07-02
+Version: 1.185.0
+Date: 2025-07-14
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportEmployment.R
+++ b/R/reportEmployment.R
@@ -185,7 +185,7 @@ remFilter <- remFilter[, , c("New Cap|Electricity|Hydro", "Cap|Electricity|Hydro
   )
   remindProd <- remindProd[regions, getYears(x), vars] # period >2010 and only select variables
 
-  pe <- reportPE(gdx)[regions, getYears(x), "PE|Biomass|Traditional (EJ/yr)"]
+  pe <- reportPE(gdx)[regions, getYears(x), "PE|Biomass|++++|Traditional (EJ/yr)"]
 
   # removing the traditional biomass component, where biomass isn't sold, thus no employment
   # in conventional sense

--- a/R/reportPE.R
+++ b/R/reportPE.R
@@ -139,8 +139,8 @@ reportPE <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq
     get_demPE(peBio,                                                 name = "PE|+|Biomass (EJ/yr)"),
     get_demPE(peBio, te = teCCS,                                     name = "PE|Biomass|++|w/ CC (EJ/yr)"),
     get_demPE(peBio, te = teNoCCS,                                   name = "PE|Biomass|++|w/o CC (EJ/yr)"),
-    get_demPE(c("pebioil", "pebios"),                                name = "PE|Biomass|1st Generation (EJ/yr)"),
-    get_demPE(peBio, te = "biotr",                                   name = "PE|Biomass|Traditional (EJ/yr)"),
+    get_demPE(c("pebioil", "pebios"),                                name = "PE|Biomass|+++|1st Generation (EJ/yr)"),
+    get_demPE(peBio, te = "biotr",                                   name = "PE|Biomass|++++|Traditional (EJ/yr)"),
     get_demPE(peBio, "seel",                                         name = "PE|Biomass|+|Electricity (EJ/yr)"),
     get_demPE(peBio, "seel", teCCS,                                  name = "PE|Biomass|Electricity|+|w/ CC (EJ/yr)"),
     get_demPE(peBio, "seel", teNoCCS,                                name = "PE|Biomass|Electricity|+|w/o CC (EJ/yr)"),
@@ -186,11 +186,11 @@ reportPE <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq
     setNames(dimSums(demPE[, , c(peFos, peBio)], dim = 3)
            + dimSums(prodSE[, , c("pegeo", "pehyd", "pewin", "pesol", "peur")], dim = 3), "PE (EJ/yr)"),
     setNames(dimSums(demPE[, , peBio], dim = 3)
-           - dimSums(mselect(demPE, all_enty = peBio, all_te = "biotr"), dim = 3),  "PE|Biomass|Modern (EJ/yr)"),
-    setNames(fuExtr[, , "pebiolc.2"], "PE|Biomass|Residues (EJ/yr)"),
+           - dimSums(mselect(demPE, all_enty = peBio, all_te = "biotr"), dim = 3),  "PE|Biomass|++++|Modern (EJ/yr)"),
+    setNames(fuExtr[, , "pebiolc.2"], "PE|Biomass|+++|Residues (EJ/yr)"),
     setNames((fuExtr[, , "pebiolc.1"]
               + (1 - pm_costsPEtradeMp[, , "pebiolc"]) * Mport[, , "pebiolc"]
-              - Xport[, , "pebiolc"]), "PE|Biomass|Energy Crops (EJ/yr)")
+              - Xport[, , "pebiolc"]), "PE|Biomass|+++|Energy Crops (EJ/yr)")
   )
 
   # add global values

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.184.1**
+R package **remind2**, version **1.185.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.184.1, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.185.0, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
-  date = {2025-07-02},
+  date = {2025-07-14},
   year = {2025},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.184.1},
+  note = {Version: 1.185.0},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR
This PR adds two new plus notation levels for the biomass use perspective (`PE|Biomass|...`). So far, the |+| and |++| levels differentiate what the biomass is used for (type of energy carrier and w//o CC). 
This PR adds:
`PE|+| Biomass` = `PE|Biomass|+++|Energy Crops` + `PE|Biomass|+++|Residues` + `PE|Biomass|+++|1st Generation`
`PE|+| Biomass` = PE`|Biomass|++++|Modern` + `PE|Biomass|++++|Traditional`

## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

