### PR TITLE
deal with floating point comparison in test_ranges

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '240353550'
+ValidationKey: '240551598'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.185.0
-date-released: '2025-07-14'
+version: 1.185.1
+date-released: '2025-07-29'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.185.0
-Date: 2025-07-14
+Version: 1.185.1
+Date: 2025-07-29
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/test_ranges.R
+++ b/R/test_ranges.R
@@ -56,8 +56,10 @@ test_ranges <- function(data, tests, reaction = c('message', 'stop'),
          'must be a string.')
   }
 
-  # Test all variables in data_variables agains low and up
+  # Test all variables in data_variables against low and up
   .test <- function(data_variables, low, up) {
+
+    tolerance <- 1e-10
 
     # get the name of the variable dimension in the magpie object
     variable_name <- data_variables %>%
@@ -68,7 +70,7 @@ test_ranges <- function(data, tests, reaction = c('message', 'stop'),
     low_data <- if (!is.null(low) && any(data_variables < low)) {
       data_variables %>%
         magclass_to_tibble() %>%
-        filter(.data$value < low) %>%
+        filter(.data$value < low - tolerance) %>%
         distinct(!!sym(variable_name), .keep_all = TRUE) %>%
         unite('text', everything(), sep = '   ') %>%
         pull('text')
@@ -80,7 +82,7 @@ test_ranges <- function(data, tests, reaction = c('message', 'stop'),
     up_data <- if (!is.null(up) && any(data_variables > up)) {
       data_variables %>%
         magclass_to_tibble() %>%
-        filter(.data$value > up) %>%
+        filter(.data$value > up + tolerance) %>%
         distinct(!!sym(variable_name), .keep_all = TRUE) %>%
         unite('text', everything(), sep = '   ') %>%
         pull('text')
@@ -100,6 +102,7 @@ test_ranges <- function(data, tests, reaction = c('message', 'stop'),
   data_names <- last(getNames(data, fulldim = TRUE))
   msg <- list()
   for (t in tests) {
+
     # if t has no 'ignore.case' element, or it is not set to FALSE, do not
     # ignore the case
     ignore.case <- !'ignore.case' %in% names(t) || !isFALSE(t$ignore.case)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.185.0**
+R package **remind2**, version **1.185.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.185.0, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.185.1, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
-  date = {2025-07-14},
+  date = {2025-07-29},
   year = {2025},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.185.0},
+  note = {Version: 1.185.1},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR

Deal with floating point comparison in test_ranges so that it no longer produces false positives as happened here `/p/projects/remind/modeltests/remind/output/SSP2-EU21-NPi-AMT_2025-07-25_22.18.56`

## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

