### PR TITLE
avoid unwanted use of newly introduced maglass::pmax and magclass:pmin

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '240551598'
+ValidationKey: '240583748'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v4

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.185.1
-date-released: '2025-07-29'
+version: 1.185.2
+date-released: '2025-07-30'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.185.1
-Date: 2025-07-29
+Version: 1.185.2
+Date: 2025-07-30
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -1013,7 +1013,7 @@ reportFE <- function(gdx, regionSubsetList = NULL,
   # split sectoral biomass in modern and traditional for exogains
   # allocate tradional biomass to buildings first and only consider industry if
   # all biomass in buildings is traditional. All fossil solids are coal.
-  out <- mbind(out, setNames(asS4(pmin(out[, , "FE|Solids|Biomass|+|Traditional (EJ/yr)"],
+  out <- mbind(out, setNames(asS4(base::pmin(out[, , "FE|Solids|Biomass|+|Traditional (EJ/yr)"],
                                        out[, , "FE|Buildings|Solids|+|Biomass (EJ/yr)"])),
                              "FE|Buildings|Solids|Biomass|+|Traditional (EJ/yr)"))
   out <- mbind(out, setNames(out[, , "FE|Solids|Biomass|+|Traditional (EJ/yr)"] -

--- a/R/reportPrices.R
+++ b/R/reportPrices.R
@@ -667,7 +667,7 @@ reportPrices <- function(gdx, output = NULL, regionSubsetList = NULL,
                                   unitsplit(getNames(out.rawdata))$unit, ")")
 
   ## calculate reporting prices
-  out.reporting <- pmax(out, 0) # avoid negative prices
+  out.reporting <- base::pmax(out, 0) # avoid negative prices
 
   # for cm_startyear and non-SSP2, replace price by average of period before and after
   # this is a workaround to avoid spikes caused by https://github.com/remindmodel/remind/issues/1068
@@ -783,7 +783,7 @@ reportPrices <- function(gdx, output = NULL, regionSubsetList = NULL,
       pm_taxCO2eqMport <- pm_taxCO2eqMport + dimSums(p21_tau_Import[, , "CO2taxmarkup"], dim = 3.2) * pm_taxCO2eqSum
     }
     if ("avCO2taxmarkup" %in% tax_import_type_21) {
-      pm_taxCO2eqMport <- pm_taxCO2eqMport + dimSums(p21_tau_Import[, , "avCO2taxmarkup"], dim = 3.2) * pmax(pm_taxCO2eqSum, magpie_expand(colMeans(pm_taxCO2eqSum), pm_taxCO2eqSum))
+      pm_taxCO2eqMport <- pm_taxCO2eqMport + dimSums(p21_tau_Import[, , "avCO2taxmarkup"], dim = 3.2) * base::pmax(pm_taxCO2eqSum, magpie_expand(colMeans(pm_taxCO2eqSum), pm_taxCO2eqSum))
     }
     pm_taxCO2eqMport <- pm_taxCO2eqMport * 1000 * 12 / 44
     # use unweighted average, because weighing according to import volumes might lead to big jumps

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.185.1**
+R package **remind2**, version **1.185.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.185.1, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.185.2, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
-  date = {2025-07-29},
+  date = {2025-07-30},
   year = {2025},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.185.1},
+  note = {Version: 1.185.2},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR

This magclass enhancement causes problems for some madrat functions: https://github.com/pik-piam/magclass/pull/181

This PR makes sure that all instances of `pmax` and `pmin` are prepended with base:: so that the new functions are not used by accident, leading to unexpected behaviour.

## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

