### PR TITLE
Update Air Pollution Reporting

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '241457849'
+ValidationKey: '241534150'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -60,9 +60,31 @@ jobs:
           lucode2::check(runLinter = FALSE)
 
       - name: Test coverage
+        if: ${{ github.event_name != 'pull_request' }}
         shell: Rscript {0}
         run: |
           nonDummyTests <- setdiff(list.files("./tests/testthat/"), c("test-dummy.R", "_snaps"))
-          if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) covr::codecov(quiet = FALSE)
+          if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) {
+            coverage <- covr::package_coverage(quiet = FALSE)
+            # The following function might be unnecessary if r-lib/covr#616 gets merged
+            to_simple_codecov <- function(coverage) {
+              fullLineCoverage <- covr:::per_line(coverage)
+              data <- Map(function(fileCoverage) {
+                resultCoverage <- lapply(fileCoverage$coverage, jsonlite::unbox)
+                names(resultCoverage) <- seq_along(resultCoverage)
+                return(resultCoverage)
+              }, fullLineCoverage)
+              return(jsonlite::toJSON(list("coverage" = data), na = "null"))
+            }
+            writeLines(to_simple_codecov(coverage), "simple-codecov.json")
+          }
         env:
           NOT_CRAN: "true"
+
+      - uses: codecov/codecov-action@v4
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          file: ./simple-codecov.json
+          plugin: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.186.7
-date-released: '2025-09-16'
+version: 1.186.9
+date-released: '2025-09-19'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.186.7
-Date: 2025-09-16
+Version: 1.186.9
+Date: 2025-09-19
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportEmiAirPol.R
+++ b/R/reportEmiAirPol.R
@@ -24,15 +24,9 @@
 #' @importFrom gdx readGDX
 #' @importFrom magclass new.magpie mbind getNames<- setNames collapseNames getYears getItems
 reportEmiAirPol <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150)) {
-  # Get realisation name
-  realisation <- readGDX(gdx, "module2realisation")
-  realisation <- realisation[which(realisation[, 1] == "aerosols"), 2]
-
   ######### initialisation  ###########
   tmp <- NULL
   out <- NULL
-
-  if (!(realisation %in% c("exoGAINS", "exoGAINS2025"))) stop("not allowed air pollution realization.")
 
   ######### initialisation  ###########
   airpollutants <- c("so2", "bc", "oc", "CO", "VOC", "NOx", "NH3")
@@ -50,29 +44,59 @@ reportEmiAirPol <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 
     # add indprocess to indst
     emiAPexsolve[, , "indst"] <- emiAPexsolve[, , "indst"] + emiAPexsolve[, , "indprocess"]
 
-    # Replace REMIND sector names by reporting ones
-    mapping <- data.frame(
-      remind = c("power", "indst", "res", "trans", "solvents", "extraction"),
-      reporting = c(
-        paste0("Emi|", poll_rep, "|Energy Supply|Electricity (Mt ", poll_rep, "/yr)"),
-        paste0("Emi|", poll_rep, "|Energy Demand|Industry (Mt ", poll_rep, "/yr)"),
-        paste0("Emi|", poll_rep, "|Energy Demand|Buildings (Mt ", poll_rep, "/yr)"),
-        paste0("Emi|", poll_rep, "|Energy Demand|Transport|Ground Trans (Mt ", poll_rep, "/yr)"),
-        paste0("Emi|", poll_rep, "|Solvents (Mt ", poll_rep, "/yr)"),
-        paste0("Emi|", poll_rep, "|Energy Supply|Extraction (Mt ", poll_rep, "/yr)")
+    # Case distinction to ensure backwarsds compatibility with older REMIND versions
+    # The old version will be removed from remind2 with Release 3.5.2
+    if ("Waste" %in% getNames(emiAPexo)) {
+      ## Old version: Sector "Waste" is part of p11_emiAPexo
+      # Replace REMIND sector names by reporting ones
+      mapping <- data.frame(
+        remind = c("power", "indst", "res", "trans", "solvents", "extraction"),
+        reporting = c(
+          paste0("Emi|", poll_rep, "|Energy Supply|Electricity (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Energy Demand|Industry (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Energy Demand|Buildings (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Energy Demand|Transport|Ground Trans (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Solvents (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Energy Supply|Extraction (Mt ", poll_rep, "/yr)")
+        )
       )
-    )
 
-    emiAPexsolve <- setNames(emiAPexsolve[, , mapping$remind], as.character(mapping$reporting))
+      emiAPexsolve <- setNames(emiAPexsolve[, , mapping$remind], as.character(mapping$reporting))
 
-    tmp <- mbind(
-      emiAPexsolve,
-      setNames(emiAPexo[, , "AgWasteBurning"],   paste0("Emi|", poll_rep, "|Land Use|Agricultural Waste Burning (Mt ", poll_rep, "/yr)")),
-      setNames(emiAPexo[, , "Agriculture"],      paste0("Emi|", poll_rep, "|Land Use|Agriculture (Mt ", poll_rep, "/yr)")),
-      setNames(emiAPexo[, , "ForestBurning"],    paste0("Emi|", poll_rep, "|Land Use|Forest Burning (Mt ", poll_rep, "/yr)")),
-      setNames(emiAPexo[, , "GrasslandBurning"], paste0("Emi|", poll_rep, "|Land Use|Savannah Burning (Mt ", poll_rep, "/yr)")),
-      setNames(emiAPexo[, , "Waste"],            paste0("Emi|", poll_rep, "|Waste (Mt ", poll_rep, "/yr)"))
-    )
+      tmp <- mbind(
+        emiAPexsolve,
+        setNames(emiAPexo[, , "AgWasteBurning"], paste0("Emi|", poll_rep, "|Land Use|Agricultural Waste Burning (Mt ", poll_rep, "/yr)")),
+        setNames(emiAPexo[, , "Agriculture"], paste0("Emi|", poll_rep, "|Land Use|Agriculture (Mt ", poll_rep, "/yr)")),
+        setNames(emiAPexo[, , "ForestBurning"], paste0("Emi|", poll_rep, "|Land Use|Forest Burning (Mt ", poll_rep, "/yr)")),
+        setNames(emiAPexo[, , "GrasslandBurning"], paste0("Emi|", poll_rep, "|Land Use|Savannah Burning (Mt ", poll_rep, "/yr)")),
+        setNames(emiAPexo[, , "Waste"], paste0("Emi|", poll_rep, "|Waste (Mt ", poll_rep, "/yr)"))
+      )
+    } else {
+      ## New version: Sector "waste" is part of p11_emiAPexsolve
+      # Replace REMIND sector names by reporting ones
+      mapping <- data.frame(
+        remind = c("power", "indst", "res", "trans", "solvents", "extraction", "waste"),
+        reporting = c(
+          paste0("Emi|", poll_rep, "|Energy Supply|Electricity (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Energy Demand|Industry (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Energy Demand|Buildings (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Energy Demand|Transport|Ground Trans (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Solvents (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Energy Supply|Extraction (Mt ", poll_rep, "/yr)"),
+          paste0("Emi|", poll_rep, "|Waste (Mt ", poll_rep, "/yr)")
+        )
+      )
+
+      emiAPexsolve <- setNames(emiAPexsolve[, , mapping$remind], as.character(mapping$reporting))
+
+      tmp <- mbind(
+        emiAPexsolve,
+        setNames(emiAPexo[, , "AgWasteBurning"], paste0("Emi|", poll_rep, "|Land Use|Agricultural Waste Burning (Mt ", poll_rep, "/yr)")),
+        setNames(emiAPexo[, , "Agriculture"], paste0("Emi|", poll_rep, "|Land Use|Agriculture (Mt ", poll_rep, "/yr)")),
+        setNames(emiAPexo[, , "ForestBurning"], paste0("Emi|", poll_rep, "|Land Use|Forest Burning (Mt ", poll_rep, "/yr)")),
+        setNames(emiAPexo[, , "GrasslandBurning"], paste0("Emi|", poll_rep, "|Land Use|Savannah Burning (Mt ", poll_rep, "/yr)"))
+      )
+    }
 
     # Set NAs to 0
     tmp[is.na(tmp)] <- 0
@@ -91,10 +115,6 @@ reportEmiAirPol <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 
   p11_emiAPexo <- readGDX(
     gdx,
     name = c("p11_emiAPexo", "pm_emiAPexo"), field = "l", format = "first_found"
-  )[, ttot, airpollutants]
-  p11_emiAPexoGlob <- readGDX(
-    gdx,
-    name = c("p11_emiAPexoGlob", "pm_emiAPexoGlob"), field = "l", format = "first_found"
   )[, ttot, airpollutants]
 
   ####### prepare parameter ########################
@@ -115,32 +135,16 @@ reportEmiAirPol <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 
   # Loop over air pollutants and add some variables
   for (pollutant in airpollutants) {
     poll_rep <- toupper(pollutant)
-    tmp <- NULL
-    # Add Aviation and Int. Shipping emissions
-    tmp <- mbind(
-      tmp,
-      setNames(
-        p11_emiAPexoGlob["GLO", , "InternationalShipping"][, , pollutant],
-        paste0("Emi|", poll_rep, "|Energy Demand|Transport|International Shipping (Mt ", poll_rep, "/yr)")
-      ),
-      setNames(
-        p11_emiAPexoGlob["GLO", , "Aviation"][, , pollutant],
-        paste0("Emi|", poll_rep, "|Energy Demand|Transport|Aviation (Mt ", poll_rep, "/yr)")
-      )
-    )
-    tmp1 <- new.magpie(getItems(out, dim = 1), getYears(out), getNames(tmp), fill = 0)
-    tmp1["GLO", , ] <- tmp["GLO", , ]
-    out <- mbind(out, tmp1)
     # Aggregation: Transport and Energy Supply
+    ## Aviation and International Shipping air pollutant emissions are computed in reportExtraEmissions,
+    ## and thus neither included in Energy Demand|Transport not in the totals. 
     out <- mbind(
       out,
       setNames(
         dimSums(out[
           , ,
           c(
-            paste0("Emi|", poll_rep, "|Energy Demand|Transport|Ground Trans (Mt ", poll_rep, "/yr)"),
-            paste0("Emi|", poll_rep, "|Energy Demand|Transport|International Shipping (Mt ", poll_rep, "/yr)"),
-            paste0("Emi|", poll_rep, "|Energy Demand|Transport|Aviation (Mt ", poll_rep, "/yr)")
+            paste0("Emi|", poll_rep, "|Energy Demand|Transport|Ground Trans (Mt ", poll_rep, "/yr)")
           )
         ], dim = 3),
         paste0("Emi|", poll_rep, "|Energy Demand|Transport (Mt ", poll_rep, "/yr)")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.186.7**
+R package **remind2**, version **1.186.9**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.186.7, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.186.9, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
-  date = {2025-09-16},
+  date = {2025-09-19},
   year = {2025},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.186.7},
+  note = {Version: 1.186.9},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR

**Update Air Pollutant Emissions Reporting in line with https://github.com/remindmodel/remind/pull/2209**

1. Ensure that waste emissions are correctly reported based on current REMIND version and new REMIND version.
2. Remove International Shipping and Aviation Emissions from the reporting. The values that were currently reported came from an old, exogenous scenario and shall no longer be reported. A follow-up PR will compute them in reportExtraEmissions, which will require updates of the mapping files. --> https://github.com/pik-piam/piamInterfaces/issues/534


## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [ ] do not create new complaints about summation checks.
- [ ] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

