### PR TITLE
Add remaining Air Pollutant emissions

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '241601980'
+ValidationKey: '241622334'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.187.0
+version: 1.187.1
 date-released: '2025-09-23'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.187.0
+Version: 1.187.1
 Date: 2025-09-23
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/reportExtraEmissions.R
+++ b/R/reportExtraEmissions.R
@@ -213,7 +213,7 @@ reportExtraEmissions <- function(mif, extraData, gdx) {
   # if-clause will be removed with Release 3.5.2
   if (file.exists(file.path(extraData, "emi2020_sectNOGAINS_sourceCEDS.cs4r"))) {
     # Calculate AP emissions that are based on ratio to CO2 emissions.  ----
-    # Derive ratio based on CEDS 2020 AP emissions and REMIND 2020 CO2 emissions
+    # Derive emission ratio (ER) based on CEDS 2020 AP emissions and REMIND 2020 CO2 emissions
     .deriveER <- function(emiAPrefyear, emico2, refyear = 2020, convyear = "never") {
       # regional ER in the reference year
       rer2020 <- emiAPrefyear / emico2[, refyear, ]
@@ -273,6 +273,23 @@ reportExtraEmissions <- function(mif, extraData, gdx) {
         setNames(
           report[, , "Emi|CO2|Energy|Demand|Transport|Bunkers|Pass|International Aviation"] * er,
           paste0("Emi|", spec, "|Extra|Energy|Demand|Transport|Bunkers|Pass|International Aviation (Mt ", toupper(spec), "/yr)")
+        )
+      )
+    }
+
+    # Aggregation: Domestic Aviation + International Aviation
+    for (spec in c("BC", "CO", "NH3", "NOx", "OC", "SO2", "VOC")) {
+      out <- mbind(
+        out,
+        setNames(
+          dimSums(out[
+            , ,
+            c(
+              paste0("Emi|", spec, "|Extra|Energy|Demand|Transport|Bunkers|Pass|International Aviation (Mt ", toupper(spec), "/yr)"),
+              paste0("Emi|", spec, "|Extra|Energy|Demand|Transport|Pass|Domestic Aviation (Mt ", toupper(spec), "/yr)")
+            )
+          ], dim = 3),
+          paste0("Emi|", spec, "|Extra|Energy|Demand|Transport|Pass|Aviation (Mt ", toupper(spec), "/yr)")
         )
       )
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.187.0**
+R package **remind2**, version **1.187.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.187.0, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.187.1, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -60,6 +60,6 @@ A BibTeX entry for LaTeX users is
   date = {2025-09-23},
   year = {2025},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.187.0},
+  note = {Version: 1.187.1},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR

Add air pollutant emissions from Domestic Aviation, International Aviation and International Shipping via reportExtraEmissions. 

For these sectors, no GAINS emission factors are available. We use the following simple approach: Take 2020 AP emissions as starting point and project future AP emissions based on changes in CO2 emissions in the respective sector.

## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

