### PR TITLE
Bugfix CH4 and N2O waste reporting

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '241683396'
+ValidationKey: '241703750'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.187.4
+version: 1.187.5
 date-released: '2025-09-23'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.187.4
+Version: 1.187.5
 Date: 2025-09-23
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -2227,6 +2227,13 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
   getSets(EmiMAC) <- c("region", "year", "macsector", "sector", "emiMkt", "gas") # rename dimensions for sake of understanding
   EmiMAC[, , mac.map$all_enty] <- vm_emiMacSector[, , mac.map$all_enty]
 
+  # Backwards compatibility: Will be removed from remind2 with Release 3.5.2
+    if ("Waste" %in% getNames(EmiMAC, dim = "sector")) {
+      tmp <- getNames(EmiMAC, dim = "sector")
+      tmp <- gsub("\\bWaste\\b", "waste", tmp)
+      getNames(EmiMAC, dim = "sector") <- tmp
+    }
+
   ### 5.1 non-CO2 GHG by sector ----
 
   sel_vm_emiTeDetailMkt_ch4 <- if (getSets(vm_emiTeDetailMkt)[[6]] == "emiAll") {
@@ -2256,7 +2263,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
     setNames(dimSums(mselect(EmiMAC, sector = "Agriculture", gas = "ch4"), dim = 3),
              "Emi|CH4|+|Agriculture (Mt CH4/yr)"),
     # waste CH4 emissions in MtCH4
-    setNames(dimSums(mselect(EmiMAC, sector = "Waste", gas = "ch4"), dim = 3),
+    setNames(dimSums(mselect(EmiMAC, sector = "waste", gas = "ch4"), dim = 3),
              "Emi|CH4|+|Waste (Mt CH4/yr)"),
     # land-use change CH4 emissions in MtCH4
     setNames(dimSums(mselect(EmiMAC, sector = "lulucf", gas = "ch4"), dim = 3),
@@ -2310,7 +2317,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
     setNames(dimSums(mselect(EmiMAC, sector = "lulucf", gas = "n2o"), dim = 3) * MtN2_to_ktN2O,
              "Emi|N2O|+|Land-Use Change (kt N2O/yr)"),
     # Waste N2O emissions in kt N2O
-    setNames(dimSums(mselect(EmiMAC, sector = "Waste", gas = "n2o"), dim = 3) * MtN2_to_ktN2O,
+    setNames(dimSums(mselect(EmiMAC, sector = "waste", gas = "n2o"), dim = 3) * MtN2_to_ktN2O,
              "Emi|N2O|+|Waste (kt N2O/yr)"),
     # Transport N2O emissions in kt N2O
     setNames(dimSums(mselect(EmiMAC, sector = "trans", gas = "n2o"), dim = 3) * MtN2_to_ktN2O,
@@ -2380,7 +2387,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
     setNames(dimSums(mselect(EmiMACEq, sector = "Agriculture", gas = "ch4"), dim = 3),
              "Emi|GHG|CH4|+|Agriculture (Mt CO2eq/yr)"),
     # waste CH4 emissions in Mt CO2eq
-    setNames(dimSums(mselect(EmiMACEq, sector = "Waste", gas = "ch4"), dim = 3),
+    setNames(dimSums(mselect(EmiMACEq, sector = "waste", gas = "ch4"), dim = 3),
              "Emi|GHG|CH4|+|Waste (Mt CO2eq/yr)"),
     # land-use change CH4 emissions in Mt CO2eq
     setNames(dimSums(mselect(EmiMACEq, sector = "lulucf", gas = "ch4"), dim = 3),
@@ -2395,7 +2402,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
     setNames(dimSums(mselect(EmiMACEq, sector = "Agriculture", gas = "n2o"), dim = 3),
              "Emi|GHG|N2O|+|Agriculture (Mt CO2eq/yr)"),
     # Waste N2O emissions in Mt CO2eq
-    setNames(dimSums(mselect(EmiMACEq, sector = "Waste", gas = "n2o"), dim = 3),
+    setNames(dimSums(mselect(EmiMACEq, sector = "waste", gas = "n2o"), dim = 3),
              "Emi|GHG|N2O|+|Waste (Mt CO2eq/yr)"),
     # land-use change N2O emissions in Mt CO2eq
     setNames(dimSums(mselect(EmiMACEq, sector = "lulucf", gas = "n2o"), dim = 3),
@@ -2735,7 +2742,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
                         "Emi|GHG|ETS|+|Industry (Mt CO2eq/yr)"),
 
                setNames(
-                        dimSums(mselect(EmiMACEq[, , "ETS"], sector = "Waste"), dim = 3),
+                        dimSums(mselect(EmiMACEq[, , "ETS"], sector = "waste"), dim = 3),
                         "Emi|GHG|ETS|+|Waste (Mt CO2eq/yr)"))
 
   #### 6.3.2 ESR Emissions ----
@@ -2803,7 +2810,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
     # + Waste CO2 emissions from non-incinerated plastics (not accounted as energy emissions)
     # + Waste CO2 emissions from non-plastics
     setNames(
-             dimSums(mselect(EmiMACEq[, , "ES"], sector = "Waste"), dim = 3)
+             dimSums(mselect(EmiMACEq[, , "ES"], sector = "waste"), dim = 3)
              + dimSums(mselect(vm_emiNonFosNonIncineratedPlastics * GtC_2_MtCO2,
                                all_enty = "co2"), dim = 3)
              + dimSums(mselect(v37_emiNonPlasticWaste  * GtC_2_MtCO2,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.187.4**
+R package **remind2**, version **1.187.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.187.4, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2025). "remind2: The REMIND R package (2nd generation)." Version: 1.187.5, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -60,6 +60,6 @@ A BibTeX entry for LaTeX users is
   date = {2025-09-23},
   year = {2025},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.187.4},
+  note = {Version: 1.187.5},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR

Bugfix CH4 and N2O waste reporting: The renaming in https://github.com/remindmodel/remind/pull/2209 from "Waste" to "waste" caused a bug in the CH4 and N2O waste reporting, i.e. variables were reported as zero.

## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

