### PR TITLE
Bug fix calculation of cumulated emissions in reportEmi

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '243369780'
+ValidationKey: '243425924'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 1.189.2
-date-released: '2026-01-12'
+version: 1.189.3
+date-released: '2026-01-15'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 1.189.2
-Date: 2026-01-12
+Version: 1.189.3
+Date: 2026-01-15
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -51,9 +51,6 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
   sm_tgch4_2_pgc <- readGDX(gdx, "sm_tgch4_2_pgc") # conversion of MtCH4 to GtC Co2eq
   MtN2_to_ktN2O <- 44 / 28 * 1000 # conversion from MtN to ktN2O
 
-  # other parameters required
-  pm_ts <- readGDX(gdx, "pm_ts") # years per time step of model
-
   # switches relevant for emissions reporting
   cm_multigasscen <- readGDX(gdx, "cm_multigasscen")
 
@@ -3923,17 +3920,19 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
 
   # 10. Cumulative Emissions ----
 
-  # function to calculate cumulated values
-  cumulatedValue <- function(var, i_pm_ts = pm_ts) {
-    ts <- i_pm_ts[, getYears(var), ]
+  # function to recursively calculate cumulated values
+  # for REMIND timesteps t = 2005, 2010, ... , 2055, 2060, ... , 2110, 2130, 2150,
+  # it calculates cumulated values from the middle of 2005 to the middle of the respective timesteps
+  cumulatedValue <- function(var) {
+    years <- getYears(var, as.integer = TRUE)
     tmp <- new.magpie(getRegions(var), getYears(var), magclass::getNames(var), fill = 0)
-    for (t in 2:length(getYears(var))) {
-      tmp[, t, ] <- setYears(
-        dimSums(na.rm = TRUE, x = var[, which(getYears(var) < getYears(var)[t]), ] * ts[, which(getYears(var) < getYears(var)[t]), ], dim = 2)
-        - setYears(var[, 2005, ] * ts[, 2005, ], NULL) / 2 # half of 2005 time step
-          + setYears(var[, t, ] * ts[, t, ], NULL) / 2 # half of last time step
-        , NULL
-      )
+    # First element is 0
+    tmp[, 1, ] <- 0
+    # Recursive calculation: cumulatedValue(timestep i) =
+    # cumulatedValue(timestep i-1) + (time interval between timesteps i-1 and i)/2 * (value(timestep i-1) + value(timestep i))
+    for (ts in 2:length(years)) {
+      dt <- years[ts] - years[ts - 1] # length of time interval
+      tmp[, ts, ] <- tmp[, ts - 1, ] + dt / 2 * (var[, ts - 1, ] + var[, ts, ])
     }
     return(tmp)
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **1.189.2**
+R package **remind2**, version **1.189.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2026). "remind2: The REMIND R package (2nd generation)." Version: 1.189.2, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P, Rüter T (2026). "remind2: The REMIND R package (2nd generation)." Version: 1.189.3, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann and Tonn Rüter},
-  date = {2026-01-12},
+  date = {2026-01-15},
   year = {2026},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 1.189.2},
+  note = {Version: 1.189.3},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR

Bug fix calculation of cumulated emissions in `reportEmi`. The previous calculation was incorrect for 2060, 2110 and 2150, i.e. for all timesteps at which the REMIND timestep length is changing. I double-checked that indeed only cumulated emissions for these timesteps change compared to the previous version. 

This resolves https://github.com/remindmodel/development_issues/issues/333.


## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

