### PR TITLE
Add DACCS, ERW and OAE to Revenue|Government|Tax|Carbon|non-ES CDR

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,4 @@
 ^.*CITATION.cff$
 pull_request_template.md
 ^_pkgdown\.yml$
+^\.claude$

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4227738'
+ValidationKey: '4248468'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 2.0.6
-date-released: '2026-03-11'
+version: 2.0.7
+date-released: '2026-03-12'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 2.0.6
-Date: 2026-03-11
+Version: 2.0.7
+Date: 2026-03-12
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportTax.R
+++ b/R/reportTax.R
@@ -255,12 +255,17 @@ reportTax <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,5)
                           "Revenue|Government|Tax|Carbon|+|Demand|Transport (billion US$2017/yr)"),
                setNames(output_wo_GLO[, , "Price|Carbon|Demand|Industry (US$2017/t CO2)"]  * output_wo_GLO[, , "Emi|GHG|Industry (Mt CO2eq/yr)"] / 1000,
                           "Revenue|Government|Tax|Carbon|+|Demand|Industry (billion US$2017/yr)"),
+               # AM: novel CDR (excluding biochar and BECCS), i.e. DACCS, ERW ad OAE (BECCS and biochar are accounted under energy supply)
+               # For now no separate price for removals, identical to Energy supply CO2 price. 
+               setNames(output_wo_GLO[, , "Price|Carbon|Supply (US$2017/t CO2)"]  * output_wo_GLO[, , "Emi|GHG|+++|non-ES CDR (Mt CO2eq/yr)"] / 1000,
+                        "Revenue|Government|Tax|Carbon|+|non-ES CDR (billion US$2017/yr)"),
                setNames(output_wo_GLO[, , "Price|Carbon|Supply (US$2017/t CO2)"]           * output_wo_GLO[, , "Emi|GHG|Energy|+|Supply (Mt CO2eq/yr)"] / 1000,
                           "Revenue|Government|Tax|Carbon|+|Supply (billion US$2017/yr)")
                )
   out <- mbind(out, setNames(out[, , "Revenue|Government|Tax|Carbon|+|Demand|Buildings (billion US$2017/yr)"]
                            + out[, , "Revenue|Government|Tax|Carbon|+|Demand|Transport (billion US$2017/yr)"]
                            + out[, , "Revenue|Government|Tax|Carbon|+|Demand|Industry (billion US$2017/yr)"]
+                           + out[, , "Revenue|Government|Tax|Carbon|+|non-ES CDR (billion US$2017/yr)"]
                            + out[, , "Revenue|Government|Tax|Carbon|+|Supply (billion US$2017/yr)"],
                                          "Revenue|Government|Tax|Carbon (billion US$2017/yr)")
                   )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **2.0.6**
+R package **remind2**, version **2.0.7**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/remind2)](https://cran.r-project.org/package=remind2) [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Bantje D, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Lécuyer F, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Rüter T, Salzwedel R, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2026). "remind2: The REMIND R package (2nd generation)." Version: 2.0.6, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Bantje D, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Lécuyer F, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Rüter T, Salzwedel R, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2026). "remind2: The REMIND R package (2nd generation)." Version: 2.0.7, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and David Bantje and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Fabrice Lécuyer and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Tonn Rüter and Robert Salzwedel and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann},
-  date = {2026-03-11},
+  date = {2026-03-12},
   year = {2026},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 2.0.6},
+  note = {Version: 2.0.7},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR
This PR adds the expenditure (negative tax revenues) that the regulator would need to spend on DACCS, ERW or OAE. These emissions were previously missing from the revenue calculation and are now accounted for with this new variable (component) Revenue|Government|Tax|Carbon|non-ES CDR.


## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

