### PR TITLE
handle module renamings in REMIND

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,4 @@
 pull_request_template.md
 ^_pkgdown\.yml$
 ^\.claude$
+^\.positai$

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '41440490'
+ValidationKey: '41485248'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -17,10 +17,15 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
+      # We fix this to 4.5, as currently, pre-commit hooks do not
+      # work reliably with 4.6 because of Rcpp not building reliably
+      # on 4.6. When this is resolved, the version constraint should
+      # be removed again.
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
           extra-repositories: "https://rse.pik-potsdam.de/r/packages"
+          r-version: 4.5
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tests/testthat/test-convGDX2mif-data
 .Rprofile
 renv
 *.Rproj
+.positai

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: 3b70240796cdccbe1474b0176560281aaded97e6  # frozen: v0.4.3.9003
+    rev: v0.4.3.9021
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 2.0.15
-date-released: '2026-04-23'
+version: 2.0.16
+date-released: '2026-05-05'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 2.0.15
-Date: 2026-04-23
+Version: 2.0.16
+Date: 2026-05-05
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),
@@ -89,6 +89,6 @@ Suggests:
 VignetteBuilder: 
     knitr
 Encoding: UTF-8
-RoxygenNote: 7.3.3
 Config/testthat/parallel: true
 Config/testthat/edition: 3
+Config/roxygen2/version: 8.0.0

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -126,6 +126,11 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
   vm_demPE <- readGDX(gdx, "vm_demPE", field = "l", restore_zeros = FALSE)[, t, ]
   # final energy demand (se2fe emissions factors applied to)
   vm_demFeSector <- readGDX(gdx, "vm_demFeSector", field = "l", restore_zeros = FALSE)[, t, ]
+
+  ## Ensure backwards compatibility for release version 3.6.0 (can be removed with 3.7.0)
+  getNames(vm_demFeSector, dim = 3) <- tolower(getNames(vm_demFeSector, dim = 3))
+  ## End backwards compatibility
+
   # set NA values to 0,
   vm_demFeSector[is.na(vm_demFeSector)] <- 0
   # FE demand per industry subsector
@@ -713,9 +718,14 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
     all_enty1 = getItems(pm_emifac.co2.fe, dim = "all_enty1", full = TRUE)
   ) %>%
     left_join(entyFe2Sector, by = "all_enty1", relationship = "many-to-many") %>%
-    left_join(sector2emiMkt, by = "emi_sectors", relationship = "many-to-many") %>%
-    mutate(name = paste(all_enty, all_enty1, emi_sectors, all_emiMkt, sep = "."))
+    left_join(sector2emiMkt, by = "emi_sectors", relationship = "many-to-many")
 
+  ## Ensure backwards compatibility for release version 3.6.0 (can be removed with 3.7.0)
+  emi.map.fe[,"emi_sectors"] <- tolower(emi.map.fe[,"emi_sectors"])
+  ## End backwards compatibility
+
+  emi.map.fe <- emi.map.fe %>%
+    mutate(name = paste(all_enty, all_enty1, emi_sectors, all_emiMkt, sep = "."))
 
   # calculate captured CO2 per pe2se technology
   sel_pm_emifac_pe2seCCO2 <- if (getSets(pm_emifac)[[6]] == "emiAll") {
@@ -946,7 +956,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
     ),
     # cdr energy requirement emissions: fe carrier emissions subtracting captured and stored emissions
     setNames(
-      (dimSums(EmiFeCarrier[, , "CDR"], dim = 3)
+      (dimSums(EmiFeCarrier[, , "cdr"], dim = 3)
       - sm_capture_rate_cdrmodule * dimSums(vm_co2emi_cdrFE_beforeCapture, dim = 3) * p_share_CCS)
       * GtC_2_MtCO2,
       "Emi|CO2|Energy|Demand|+|CDR Sector (Mt CO2/yr)"
@@ -1058,11 +1068,11 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
     ),
     # CDR
     setNames(
-      (dimSums(mselect(EmiFeCarrier, all_enty1 = c("fedie"), emi_sectors = "CDR"), dim = 3)) * GtC_2_MtCO2,
+      (dimSums(mselect(EmiFeCarrier, all_enty1 = c("fedie"), emi_sectors = "cdr"), dim = 3)) * GtC_2_MtCO2,
       "Emi|CO2|Energy|Demand|CDR Sector|+|Liquids (Mt CO2/yr)"
     ),
     setNames(
-      (dimSums(mselect(EmiFeCarrier, all_enty1 = c("fegas"), emi_sectors = "CDR"), dim = 3)
+      (dimSums(mselect(EmiFeCarrier, all_enty1 = c("fegas"), emi_sectors = "cdr"), dim = 3)
       - sm_capture_rate_cdrmodule * dimSums(vm_co2emi_cdrFE_beforeCapture, dim = 3) * p_share_CCS) * GtC_2_MtCO2,
       "Emi|CO2|Energy|Demand|CDR Sector|+|Gases (Mt CO2/yr)"
     )
@@ -1780,7 +1790,7 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
   )
 
 
-  vm_demFeSector_CDR <- mselect(mselect(vm_demFeSector_woNonEn, all_enty1 = "fegas"), emi_sectors = "CDR")
+  vm_demFeSector_CDR <- mselect(mselect(vm_demFeSector_woNonEn, all_enty1 = "fegas"), emi_sectors = "cdr")
   vm_demFeSector_CDR_totalfegas <- dimSums(vm_demFeSector_CDR, dim = 3)
   # replace zeros by -1 to avoid division by zero if no fegas is used
   vm_demFeSector_CDR_totalfegas[vm_demFeSector_CDR_totalfegas == 0] <- -1

--- a/R/reportTax.R
+++ b/R/reportTax.R
@@ -14,19 +14,20 @@
 #'
 #' @author Renato Rodrigues, Lavinia Baumstark, Christoph Bertram
 #' @examples
-#'
-#' \dontrun{reportTax(gdx)}
+#' \dontrun{
+#' reportTax(gdx)
+#' }
 #'
 #' @export
 #' @importFrom gdx readGDX
 #' @importFrom magclass mbind getYears getNames setNames setItems
 
-reportTax <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,5),seq(2070,2110,10),2130,2150)){
+reportTax <- function(gdx, output = NULL, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq(2070, 2110, 10), 2130, 2150)) {
   # old tax reporting was deleted, stop if old tax reporting would be needed
-  stopifnot(is.null(readGDX(gdx,name = "pm_tau_fe_tax_bit_st", format = "first_found", react = "silent")))
+  stopifnot(is.null(readGDX(gdx, name = "pm_tau_fe_tax_bit_st", format = "first_found", react = "silent")))
 
   # Cost calculation requires information from other reportings
-  if(is.null(output)){
+  if (is.null(output)) {
     message("reportTax executes reportEmi ", appendLF = FALSE)
     output <- mbind(output, reportEmi(gdx, regionSubsetList = regionSubsetList, t = t))
     message("- reportPrices")
@@ -34,22 +35,29 @@ reportTax <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,5)
   }
 
   # get rid of GLO from output
-  all_regi_wo_GLO <- getItems(output, dim = "all_regi")[! getItems(output, dim = "all_regi") %in% c("GLO", names(regionSubsetList))]
-  output_wo_GLO   <- output[all_regi_wo_GLO, , ]
+  all_regi_wo_GLO <- getItems(output, dim = "all_regi")[!getItems(output, dim = "all_regi") %in% c("GLO", names(regionSubsetList))]
+  output_wo_GLO <- output[all_regi_wo_GLO, , ]
 
   ### conversion factors
-  TWa_2_EJ     <- 31.536
-  tdptwyr2dpgj <- 31.71 #"multipl. factor to convert (TerraDollar per TWyear) to (Dollar per GJoule)"
+  TWa_2_EJ <- 31.536
+  tdptwyr2dpgj <- 31.71 # "multipl. factor to convert (TerraDollar per TWyear) to (Dollar per GJoule)"
 
   ### initialize output
   out <- NULL
 
   ### FE taxes/subsidies per sector
-  fe_tax  <- readGDX(gdx, name=c("p21_tau_fe_tax","pm_tau_fe_tax"), format="first_found", react = "silent")[,t,] * tdptwyr2dpgj
-  fe_sub  <- readGDX(gdx, name=c("p21_tau_fe_sub","pm_tau_fe_sub"), format="first_found", react = "silent")[,t,] * tdptwyr2dpgj
+  fe_tax <- readGDX(gdx, name = c("p21_tau_fe_tax", "pm_tau_fe_tax"), format = "first_found", react = "silent")[, t, ] * tdptwyr2dpgj
+  fe_sub <- readGDX(gdx, name = c("p21_tau_fe_sub", "pm_tau_fe_sub"), format = "first_found", react = "silent")[, t, ] * tdptwyr2dpgj
 
-  vm_demFeSector <- readGDX(gdx,name=c("vm_demFeSector"),field="l",format="first_found",restore_zeros=FALSE)[,t,]*TWa_2_EJ
+  vm_demFeSector <- readGDX(gdx,
+    name = c("vm_demFeSector"), field = "l",
+    format = "first_found", restore_zeros = FALSE
+  )[, t, ] * TWa_2_EJ
   vm_demFeSector[is.na(vm_demFeSector)] <- 0
+
+  ## Ensure backwards compatibility for release version 3.6.0 (can be removed with 3.7.0)
+  getNames(vm_demFeSector, dim = 3) <- tolower(getNames(vm_demFeSector, dim = 3))
+  ## End backwards compatibility
 
   commonFinalEnergyVariables <- c(
     Solids      = "fesos",
@@ -64,13 +72,13 @@ reportTax <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,5)
     Transportation = "trans",
     Buildings      = "build",
     Industry       = "indst",
-    CDR            = "CDR"
+    CDR            = "cdr"
   )
 
   entyFe_map <- list(
-    CDR            = commonFinalEnergyVariables,
-    Buildings      = commonFinalEnergyVariables,
-    Industry       = commonFinalEnergyVariables,
+    CDR = commonFinalEnergyVariables,
+    Buildings = commonFinalEnergyVariables,
+    Industry = commonFinalEnergyVariables,
     Transportation = c(
       "Liquids|LDV"     = "fepet",
       "Liquids|non-LDV" = "fedie",
@@ -80,10 +88,10 @@ reportTax <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,5)
     )
   )
 
-  #filter entyFe_map to remove uncontrolled sets (e.g. fegat is not present in transport complex, solids are not used in CDR)
-  for(sector in names(sector_map)){
-    for(FinalEnergy in names(entyFe_map[[sector]])){
-      if(!(entyFe_map[[sector]][FinalEnergy] %in% getNames(vm_demFeSector[,,sector_map[sector]],dim=2))){
+  # filter entyFe_map to remove uncontrolled sets (e.g. fegat is not present in transport complex, solids are not used in CDR)
+  for (sector in names(sector_map)) {
+    for (FinalEnergy in names(entyFe_map[[sector]])) {
+      if (!(entyFe_map[[sector]][FinalEnergy] %in% getNames(vm_demFeSector[, , sector_map[sector]], dim = 2))) {
         entyFe_map[[sector]] <- entyFe_map[[sector]][names(entyFe_map[[sector]]) != FinalEnergy]
       }
     }
@@ -95,200 +103,258 @@ reportTax <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,5)
       "mbind",
       lapply(
         names(sector_map),
-        function(sector){
+        function(sector) {
           do.call(
             "mbind",
             lapply(
               names(entyFe_map[[sector]]),
-              function(FinalEnergy){
+              function(FinalEnergy) {
                 mbind(
-                  setNames(dimSums(mselect(fe_tax,emi_sectors = sector_map[sector],
-                                           all_enty = entyFe_map[[sector]][[FinalEnergy]]),
-                                   dim = 3, na.rm = TRUE),
-                           paste0("Tax rate|Final Energy|", sector, "|", FinalEnergy, " (US$2017/GJ)")),
-                  setNames(dimSums(mselect(fe_sub,emi_sectors = sector_map[sector],
-                                           all_enty = entyFe_map[[sector]][[FinalEnergy]]),
-                                   dim = 3, na.rm = TRUE),
-                           paste0("Subsidy Rate|Final Energy|", sector, "|", FinalEnergy, " (US$2017/GJ)")),
-                  setNames(dimSums(mselect(fe_tax,emi_sectors = sector_map[sector],
-                                           all_enty = entyFe_map[[sector]][[FinalEnergy]]),
-                                   dim = 3, na.rm = TRUE) *
-                             dimSums(mselect(vm_demFeSector, all_enty1 = entyFe_map[[sector]][FinalEnergy],
-                                             emi_sectors = sector_map[sector]),
-                                     dim = 3, na.rm = TRUE),
-                           paste0("Taxes|Final Energy|", sector, "|", FinalEnergy, " (billion US$2017/yr)")),
-                  setNames(dimSums(mselect(fe_sub, emi_sectors = sector_map[sector],
-                                           all_enty = entyFe_map[[sector]][[FinalEnergy]]),
-                                   dim = 3, na.rm = TRUE) *
-                             dimSums(mselect(vm_demFeSector, all_enty1 = entyFe_map[[sector]][FinalEnergy],
-                                             emi_sectors = sector_map[sector]),
-                                     dim = 3, na.rm = TRUE),
-                           paste0("Subsidies|Final Energy|", sector, "|", FinalEnergy, " (billion US$2017/yr)"))
+                  setNames(
+                    dimSums(
+                      mselect(fe_tax,
+                        emi_sectors = sector_map[sector],
+                        all_enty = entyFe_map[[sector]][[FinalEnergy]]
+                      ),
+                      dim = 3, na.rm = TRUE
+                    ),
+                    paste0("Tax rate|Final Energy|", sector, "|", FinalEnergy, " (US$2017/GJ)")
+                  ),
+                  setNames(
+                    dimSums(
+                      mselect(fe_sub,
+                        emi_sectors = sector_map[sector],
+                        all_enty = entyFe_map[[sector]][[FinalEnergy]]
+                      ),
+                      dim = 3, na.rm = TRUE
+                    ),
+                    paste0("Subsidy Rate|Final Energy|", sector, "|", FinalEnergy, " (US$2017/GJ)")
+                  ),
+                  setNames(
+                    dimSums(
+                      mselect(fe_tax,
+                        emi_sectors = sector_map[sector],
+                        all_enty = entyFe_map[[sector]][[FinalEnergy]]
+                      ),
+                      dim = 3, na.rm = TRUE
+                    ) *
+                      dimSums(
+                        mselect(vm_demFeSector,
+                          all_enty1 = entyFe_map[[sector]][FinalEnergy],
+                          emi_sectors = sector_map[sector]
+                        ),
+                        dim = 3, na.rm = TRUE
+                      ),
+                    paste0("Taxes|Final Energy|", sector, "|", FinalEnergy, " (billion US$2017/yr)")
+                  ),
+                  setNames(
+                    dimSums(
+                      mselect(fe_sub,
+                        emi_sectors = sector_map[sector],
+                        all_enty = entyFe_map[[sector]][[FinalEnergy]]
+                      ),
+                      dim = 3, na.rm = TRUE
+                    ) *
+                      dimSums(
+                        mselect(vm_demFeSector,
+                          all_enty1 = entyFe_map[[sector]][FinalEnergy],
+                          emi_sectors = sector_map[sector]
+                        ),
+                        dim = 3, na.rm = TRUE
+                      ),
+                    paste0("Subsidies|Final Energy|", sector, "|", FinalEnergy, " (billion US$2017/yr)")
+                  )
                 )
-              })
+              }
+            )
           )
-        })
+        }
+      )
     )
   )
 
-  #sector totals
+  # sector totals
   out <- mbind(
     out,
-    do.call("mbind",
-            lapply(names(sector_map), function(sector){
-              mbind(
-                setNames(dimSums(out[,,paste0("Taxes|Final Energy|", sector, "|", names(entyFe_map[[sector]]),
-                                              " (billion US$2017/yr)")],dim=3,na.rm=T),
-                         paste0("Taxes|Final Energy|", sector, " (billion US$2017/yr)")),
-                setNames(dimSums(out[,,paste0("Subsidies|Final Energy|", sector, "|", names(entyFe_map[[sector]]),
-                                              " (billion US$2017/yr)")],dim=3,na.rm=T),
-                         paste0("Subsidies|Final Energy|", sector, " (billion US$2017/yr)"))
-              )
-            })
+    do.call(
+      "mbind",
+      lapply(names(sector_map), function(sector) {
+        mbind(
+          setNames(
+            dimSums(out[, , paste0(
+              "Taxes|Final Energy|", sector, "|", names(entyFe_map[[sector]]),
+              " (billion US$2017/yr)"
+            )], dim = 3, na.rm = T),
+            paste0("Taxes|Final Energy|", sector, " (billion US$2017/yr)")
+          ),
+          setNames(
+            dimSums(out[, , paste0(
+              "Subsidies|Final Energy|", sector, "|", names(entyFe_map[[sector]]),
+              " (billion US$2017/yr)"
+            )], dim = 3, na.rm = T),
+            paste0("Subsidies|Final Energy|", sector, " (billion US$2017/yr)")
+          )
+        )
+      })
     )
   )
 
   # transportation liquids aggregations
   out <- mbind(
     out,
-    setNames(out[,,"Taxes|Final Energy|Transportation|Liquids|LDV (billion US$2017/yr)"]     + out[,,"Taxes|Final Energy|Transportation|Liquids|non-LDV (billion US$2017/yr)"]    , "Taxes|Final Energy|Transportation|Liquids (billion US$2017/yr)"),
-    setNames(out[,,"Subsidies|Final Energy|Transportation|Liquids|LDV (billion US$2017/yr)"] + out[,,"Subsidies|Final Energy|Transportation|Liquids|non-LDV (billion US$2017/yr)"], "Subsidies|Final Energy|Transportation|Liquids (billion US$2017/yr)"),
-    setNames((out[,,"Tax rate|Final Energy|Transportation|Liquids|LDV (US$2017/GJ)"]*out[,,"Taxes|Final Energy|Transportation|Liquids|LDV (billion US$2017/yr)"] + out[,,"Tax rate|Final Energy|Transportation|Liquids|non-LDV (US$2017/GJ)"]*out[,,"Taxes|Final Energy|Transportation|Liquids|non-LDV (billion US$2017/yr)"])/
-               (out[,,"Taxes|Final Energy|Transportation|Liquids|LDV (billion US$2017/yr)"]     + out[,,"Taxes|Final Energy|Transportation|Liquids|non-LDV (billion US$2017/yr)"]) , "Tax rate|Final Energy|Transportation|Liquids (US$2017/GJ)"),
-    setNames((out[,,"Subsidy Rate|Final Energy|Transportation|Liquids|LDV (US$2017/GJ)"]*out[,,"Subsidies|Final Energy|Transportation|Liquids|LDV (billion US$2017/yr)"] + out[,,"Subsidy Rate|Final Energy|Transportation|Liquids|non-LDV (US$2017/GJ)"]*out[,,"Subsidies|Final Energy|Transportation|Liquids|non-LDV (billion US$2017/yr)"])/
-               (out[,,"Subsidies|Final Energy|Transportation|Liquids|LDV (billion US$2017/yr)"]     + out[,,"Subsidies|Final Energy|Transportation|Liquids|non-LDV (billion US$2017/yr)"]) , "Subsidy Rate|Final Energy|Transportation|Liquids (US$2017/GJ)")
+    setNames(out[, , "Taxes|Final Energy|Transportation|Liquids|LDV (billion US$2017/yr)"] + out[, , "Taxes|Final Energy|Transportation|Liquids|non-LDV (billion US$2017/yr)"], "Taxes|Final Energy|Transportation|Liquids (billion US$2017/yr)"),
+    setNames(out[, , "Subsidies|Final Energy|Transportation|Liquids|LDV (billion US$2017/yr)"] + out[, , "Subsidies|Final Energy|Transportation|Liquids|non-LDV (billion US$2017/yr)"], "Subsidies|Final Energy|Transportation|Liquids (billion US$2017/yr)"),
+    setNames((out[, , "Tax rate|Final Energy|Transportation|Liquids|LDV (US$2017/GJ)"] * out[, , "Taxes|Final Energy|Transportation|Liquids|LDV (billion US$2017/yr)"] + out[, , "Tax rate|Final Energy|Transportation|Liquids|non-LDV (US$2017/GJ)"] * out[, , "Taxes|Final Energy|Transportation|Liquids|non-LDV (billion US$2017/yr)"]) /
+      (out[, , "Taxes|Final Energy|Transportation|Liquids|LDV (billion US$2017/yr)"] + out[, , "Taxes|Final Energy|Transportation|Liquids|non-LDV (billion US$2017/yr)"]), "Tax rate|Final Energy|Transportation|Liquids (US$2017/GJ)"),
+    setNames((out[, , "Subsidy Rate|Final Energy|Transportation|Liquids|LDV (US$2017/GJ)"] * out[, , "Subsidies|Final Energy|Transportation|Liquids|LDV (billion US$2017/yr)"] + out[, , "Subsidy Rate|Final Energy|Transportation|Liquids|non-LDV (US$2017/GJ)"] * out[, , "Subsidies|Final Energy|Transportation|Liquids|non-LDV (billion US$2017/yr)"]) /
+      (out[, , "Subsidies|Final Energy|Transportation|Liquids|LDV (billion US$2017/yr)"] + out[, , "Subsidies|Final Energy|Transportation|Liquids|non-LDV (billion US$2017/yr)"]), "Subsidy Rate|Final Energy|Transportation|Liquids (US$2017/GJ)")
   )
 
   # total taxes/subsidies final energy
   out <- mbind(
     out,
-    setNames(dimSums(out[,,paste0("Taxes|Final Energy|", names(sector_map), " (billion US$2017/yr)")],dim=3,na.rm=T),     "Taxes|Final Energy (billion US$2017/yr)"),
-    setNames(dimSums(out[,,paste0("Subsidies|Final Energy|", names(sector_map), " (billion US$2017/yr)")],dim=3,na.rm=T), "Subsidies|Final Energy (billion US$2017/yr)")
+    setNames(dimSums(out[, , paste0("Taxes|Final Energy|", names(sector_map), " (billion US$2017/yr)")], dim = 3, na.rm = T), "Taxes|Final Energy (billion US$2017/yr)"),
+    setNames(dimSums(out[, , paste0("Subsidies|Final Energy|", names(sector_map), " (billion US$2017/yr)")], dim = 3, na.rm = T), "Subsidies|Final Energy (billion US$2017/yr)")
   )
 
 
   ### Primary energy resources subsidies
 
-  fuEx_sub <- readGDX(gdx, name='p21_tau_fuEx_sub', format="first_found",react="silent")[,t,c("pecoal","peoil","pegas")] * tdptwyr2dpgj
+  fuEx_sub <- readGDX(gdx, name = "p21_tau_fuEx_sub", format = "first_found", react = "silent")[, t, c("pecoal", "peoil", "pegas")] * tdptwyr2dpgj
   fuEx_sub[is.na(fuEx_sub)] <- 0
-  fuExtr <- readGDX(gdx, c("vm_fuExtr"),field="l", format="first_found",restore_zeros=FALSE,react="silent")[,t,]*TWa_2_EJ
+  fuExtr <- readGDX(gdx, c("vm_fuExtr"), field = "l", format = "first_found", restore_zeros = FALSE, react = "silent")[, t, ] * TWa_2_EJ
 
   out <- mbind(
     out,
-    setNames(fuEx_sub[,,"pecoal"],"Subsidy Rate|Fuel Extraction|Coal (US$2017/GJ)"),
-    setNames(fuEx_sub[,,"peoil"],"Subsidy Rate|Fuel Extraction|Oil (US$2017/GJ)"),
-    setNames(fuEx_sub[,,"pegas"],"Subsidy Rate|Fuel Extraction|Natural Gas (US$2017/GJ)"),
-    setNames(fuEx_sub[,,"pecoal"]* dimSums(fuExtr[,,"pecoal"],dim=3, na.rm=T),"Subsidies|Fuel Extraction|Coal (billion US$2017/yr)"),
-    setNames(fuEx_sub[,,"peoil"]*  dimSums(fuExtr[,,"peoil"] ,dim=3, na.rm=T),"Subsidies|Fuel Extraction|Oil (billion US$2017/yr)"),
-    setNames(fuEx_sub[,,"pegas"]*  dimSums(fuExtr[,,"pegas"] ,dim=3, na.rm=T),"Subsidies|Fuel Extraction|Natural Gas (billion US$2017/yr)")
+    setNames(fuEx_sub[, , "pecoal"], "Subsidy Rate|Fuel Extraction|Coal (US$2017/GJ)"),
+    setNames(fuEx_sub[, , "peoil"], "Subsidy Rate|Fuel Extraction|Oil (US$2017/GJ)"),
+    setNames(fuEx_sub[, , "pegas"], "Subsidy Rate|Fuel Extraction|Natural Gas (US$2017/GJ)"),
+    setNames(fuEx_sub[, , "pecoal"] * dimSums(fuExtr[, , "pecoal"], dim = 3, na.rm = T), "Subsidies|Fuel Extraction|Coal (billion US$2017/yr)"),
+    setNames(fuEx_sub[, , "peoil"] * dimSums(fuExtr[, , "peoil"], dim = 3, na.rm = T), "Subsidies|Fuel Extraction|Oil (billion US$2017/yr)"),
+    setNames(fuEx_sub[, , "pegas"] * dimSums(fuExtr[, , "pegas"], dim = 3, na.rm = T), "Subsidies|Fuel Extraction|Natural Gas (billion US$2017/yr)")
   )
 
-  out <- mbind(out,setNames(out[,,"Subsidies|Fuel Extraction|Coal (billion US$2017/yr)"] + out[,,"Subsidies|Fuel Extraction|Oil (billion US$2017/yr)"]  + out[,,"Subsidies|Fuel Extraction|Natural Gas (billion US$2017/yr)"] ,"Subsidies|Fuel Extraction (billion US$2017/yr)"))
+  out <- mbind(out, setNames(out[, , "Subsidies|Fuel Extraction|Coal (billion US$2017/yr)"] + out[, , "Subsidies|Fuel Extraction|Oil (billion US$2017/yr)"] + out[, , "Subsidies|Fuel Extraction|Natural Gas (billion US$2017/yr)"], "Subsidies|Fuel Extraction (billion US$2017/yr)"))
 
   # total subsidies - it only includes final energy and fuel extraction subsidies, it misses other subsidies like technology specific ones (BEV and FCEV for example).
-  out <- mbind(out,setNames(out[,,"Subsidies|Final Energy (billion US$2017/yr)"] + (out[,,"Subsidies|Fuel Extraction|Coal (billion US$2017/yr)"] + out[,,"Subsidies|Fuel Extraction|Oil (billion US$2017/yr)"]  + out[,,"Subsidies|Fuel Extraction|Natural Gas (billion US$2017/yr)"]),"Subsidies (billion US$2017/yr)"))
+  out <- mbind(out, setNames(out[, , "Subsidies|Final Energy (billion US$2017/yr)"] + (out[, , "Subsidies|Fuel Extraction|Coal (billion US$2017/yr)"] + out[, , "Subsidies|Fuel Extraction|Oil (billion US$2017/yr)"] + out[, , "Subsidies|Fuel Extraction|Natural Gas (billion US$2017/yr)"]), "Subsidies (billion US$2017/yr)"))
 
   ### Other Taxes (net taxes = tax - subsidies)
 
   # GHG emission tax
-  p21_taxrevGHG0 <- readGDX(gdx, name=c("pm_taxrevGHG0","p21_taxrevGHG0"), format= "first_found")[,t,]*1000
+  p21_taxrevGHG0 <- readGDX(gdx, name = c("pm_taxrevGHG0", "p21_taxrevGHG0"), format = "first_found")[, t, ] * 1000
   out <- mbind(out, setNames(p21_taxrevGHG0, "Net Taxes|GHG emissions|w/o CO2 LUC (billion US$2017/yr)"))
 
   # co2luc emission tax
-  p21_taxrevCO2luc0 <- readGDX(gdx, name=c("pm_taxrevCO2LUC0","p21_taxrevCO2luc0"), format= "first_found")[,t,]*1000
+  p21_taxrevCO2luc0 <- readGDX(gdx, name = c("pm_taxrevCO2LUC0", "p21_taxrevCO2luc0"), format = "first_found")[, t, ] * 1000
   out <- mbind(out, setNames(p21_taxrevCO2luc0, "Net Taxes|GHG emissions|CO2 LUC (billion US$2017/yr)"))
 
-  out <- mbind(out, setNames((p21_taxrevGHG0+p21_taxrevCO2luc0),"Net Taxes|GHG emissions (billion US$2017/yr)"))
+  out <- mbind(out, setNames((p21_taxrevGHG0 + p21_taxrevCO2luc0), "Net Taxes|GHG emissions (billion US$2017/yr)"))
 
   # CCS tax
-  p21_taxrevCCS0 <- readGDX(gdx, name=c("p21_taxrevCCS0"), format= "first_found")[,t,]*1000
-  out <- mbind(out, setNames(p21_taxrevCCS0,"Net Taxes|CCS (billion US$2017/yr)"))
+  p21_taxrevCCS0 <- readGDX(gdx, name = c("p21_taxrevCCS0"), format = "first_found")[, t, ] * 1000
+  out <- mbind(out, setNames(p21_taxrevCCS0, "Net Taxes|CCS (billion US$2017/yr)"))
 
   # net-negative emissions tax
-  p21_taxrevNetNegEmi0 <- readGDX(gdx, name=c("pm_taxrevNetNegEmi0","p21_taxrevNetNegEmi0"), format= "first_found")[,t,]*1000
-  out <- mbind(out, setNames(p21_taxrevNetNegEmi0,"Net Taxes|Net-negative emissions (billion US$2017/yr)"))
+  p21_taxrevNetNegEmi0 <- readGDX(gdx, name = c("pm_taxrevNetNegEmi0", "p21_taxrevNetNegEmi0"), format = "first_found")[, t, ] * 1000
+  out <- mbind(out, setNames(p21_taxrevNetNegEmi0, "Net Taxes|Net-negative emissions (billion US$2017/yr)"))
 
   # negative CO2 emissions for taxes
-  p21_emiALLco2neg0 <- readGDX(gdx, name=c("p21_emiALLco2neg0", "p21_emiAllco2neg0"), format= "first_found")[,t,]*1000
-  out <- mbind(out, setNames(p21_emiALLco2neg0,"Net Taxes|Negative emissions (billion US$2017/yr)"))
+  p21_emiALLco2neg0 <- readGDX(gdx, name = c("p21_emiALLco2neg0", "p21_emiAllco2neg0"), format = "first_found")[, t, ] * 1000
+  out <- mbind(out, setNames(p21_emiALLco2neg0, "Net Taxes|Negative emissions (billion US$2017/yr)"))
 
   # final energy tax
-  p21_taxrevFE0 <- readGDX(gdx, name=c("p21_taxrevFE0"), format= "first_found")[,t,]*1000
-  out <- mbind(out, setNames(p21_taxrevFE0,"Net Taxes|Final Energy (billion US$2017/yr)"))
+  p21_taxrevFE0 <- readGDX(gdx, name = c("p21_taxrevFE0"), format = "first_found")[, t, ] * 1000
+  out <- mbind(out, setNames(p21_taxrevFE0, "Net Taxes|Final Energy (billion US$2017/yr)"))
 
   # resource extraction tax
-  p21_taxrevResEx0 <- readGDX(gdx, name=c("p21_taxrevResEx0"), format= "first_found")[,t,]*1000
-  out <- mbind(out, setNames(p21_taxrevResEx0,"Net Taxes|Fuel Extraction|Fossils (billion US$2017/yr)"))
+  p21_taxrevResEx0 <- readGDX(gdx, name = c("p21_taxrevResEx0"), format = "first_found")[, t, ] * 1000
+  out <- mbind(out, setNames(p21_taxrevResEx0, "Net Taxes|Fuel Extraction|Fossils (billion US$2017/yr)"))
 
   # pe2se technologies tax
-  p21_taxrevPE2SE0 <- readGDX(gdx, name=c("p21_taxrevPE2SE0"), format= "first_found")[,t,]*1000
-  out <- mbind(out, setNames(p21_taxrevPE2SE0,"Net Taxes|PE2SE Technologies (billion US$2017/yr)"))
+  p21_taxrevPE2SE0 <- readGDX(gdx, name = c("p21_taxrevPE2SE0"), format = "first_found")[, t, ] * 1000
+  out <- mbind(out, setNames(p21_taxrevPE2SE0, "Net Taxes|PE2SE Technologies (billion US$2017/yr)"))
 
   # SO2 tax
-  p21_taxrevSO20 <- readGDX(gdx, name=c("p21_taxrevSO20"), format= "first_found")[,t,]*1000
-  out <- mbind(out, setNames(p21_taxrevSO20,"Net Taxes|SO2 (billion US$2017/yr)"))
+  p21_taxrevSO20 <- readGDX(gdx, name = c("p21_taxrevSO20"), format = "first_found")[, t, ] * 1000
+  out <- mbind(out, setNames(p21_taxrevSO20, "Net Taxes|SO2 (billion US$2017/yr)"))
 
   # bioenergy tax
-  p21_taxrevBio0 <- readGDX(gdx, name=c("p21_taxrevBio0"), format= "first_found")[,t,]*1000
-  out <- mbind(out, setNames(p21_taxrevBio0,"Net Taxes|Bioenergy (billion US$2017/yr)"))
+  p21_taxrevBio0 <- readGDX(gdx, name = c("p21_taxrevBio0"), format = "first_found")[, t, ] * 1000
+  out <- mbind(out, setNames(p21_taxrevBio0, "Net Taxes|Bioenergy (billion US$2017/yr)"))
 
   # co2 emission taxes per emission market
-  p21_taxemiMkt0 <- readGDX(gdx, name=c("p21_taxemiMkt0"), format= "first_found")[,t,]*1000
-  out <- mbind(out,
-               setNames(p21_taxemiMkt0[,,"ES"]   ,"Net Taxes|CO2 market|ESR (billion US$2017/yr)"),
-               setNames(p21_taxemiMkt0[,,"ETS"]  ,"Net Taxes|CO2 market|ETS (billion US$2017/yr)"),
-               setNames(p21_taxemiMkt0[,,"other"],"Net Taxes|CO2 market|other (billion US$2017/yr)"))
+  p21_taxemiMkt0 <- readGDX(gdx, name = c("p21_taxemiMkt0"), format = "first_found")[, t, ] * 1000
+  out <- mbind(
+    out,
+    setNames(p21_taxemiMkt0[, , "ES"], "Net Taxes|CO2 market|ESR (billion US$2017/yr)"),
+    setNames(p21_taxemiMkt0[, , "ETS"], "Net Taxes|CO2 market|ETS (billion US$2017/yr)"),
+    setNames(p21_taxemiMkt0[, , "other"], "Net Taxes|CO2 market|other (billion US$2017/yr)")
+  )
 
   # flexibility tax
-  p21_taxrevFlex0 <- readGDX(gdx, name=c("p21_taxrevFlex0"), format= "first_found")[,t,]*1000
-  out <- mbind(out, setNames(p21_taxrevFlex0,"Net Taxes|electricity flexibility (billion US$2017/yr)"))
+  p21_taxrevFlex0 <- readGDX(gdx, name = c("p21_taxrevFlex0"), format = "first_found")[, t, ] * 1000
+  out <- mbind(out, setNames(p21_taxrevFlex0, "Net Taxes|electricity flexibility (billion US$2017/yr)"))
 
   # import tax
-  p21_taxrevImport0 <- readGDX(gdx, name=c("p21_taxrevImport0","p21_taxrevBioImport0"), format= "first_found")[,t,]*1000
-  out <- mbind(out, setNames(dimSums(p21_taxrevImport0,dim=3),"Net Taxes|Primary energy import (billion US$2017/yr)"))
+  p21_taxrevImport0 <- readGDX(gdx, name = c("p21_taxrevImport0", "p21_taxrevBioImport0"), format = "first_found")[, t, ] * 1000
+  out <- mbind(out, setNames(dimSums(p21_taxrevImport0, dim = 3), "Net Taxes|Primary energy import (billion US$2017/yr)"))
 
   # report GHG tax revenues
-  out <- mbind(out,
-               setNames(output_wo_GLO[, , "Price|Carbon|Demand|Buildings (US$2017/t CO2)"] * output_wo_GLO[, , "Emi|GHG|Energy|Demand|+|Buildings (Mt CO2eq/yr)"] / 1000,
-                          "Revenue|Government|Tax|Carbon|+|Demand|Buildings (billion US$2017/yr)"),
-               setNames(output_wo_GLO[, , "Price|Carbon|Demand|Transport (US$2017/t CO2)"] * output_wo_GLO[, , "Emi|GHG|Energy|Demand|+|Transport (Mt CO2eq/yr)"] / 1000,
-                          "Revenue|Government|Tax|Carbon|+|Demand|Transport (billion US$2017/yr)"),
-               setNames(output_wo_GLO[, , "Price|Carbon|Demand|Industry (US$2017/t CO2)"]  * output_wo_GLO[, , "Emi|GHG|Industry (Mt CO2eq/yr)"] / 1000,
-                          "Revenue|Government|Tax|Carbon|+|Demand|Industry (billion US$2017/yr)"),
-               # AM: novel CDR (excluding biochar and BECCS), i.e. DACCS, ERW ad OAE (BECCS and biochar are accounted under energy supply)
-               # For now no separate price for removals, identical to Energy supply CO2 price. 
-               setNames(output_wo_GLO[, , "Price|Carbon|Supply (US$2017/t CO2)"]  * output_wo_GLO[, , "Emi|GHG|+++|non-ES CDR (Mt CO2eq/yr)"] / 1000,
-                        "Revenue|Government|Tax|Carbon|+|non-ES CDR (billion US$2017/yr)"),
-               setNames(output_wo_GLO[, , "Price|Carbon|Supply (US$2017/t CO2)"]           * output_wo_GLO[, , "Emi|GHG|Energy|+|Supply (Mt CO2eq/yr)"] / 1000,
-                          "Revenue|Government|Tax|Carbon|+|Supply (billion US$2017/yr)")
-               )
-  out <- mbind(out, setNames(out[, , "Revenue|Government|Tax|Carbon|+|Demand|Buildings (billion US$2017/yr)"]
-                           + out[, , "Revenue|Government|Tax|Carbon|+|Demand|Transport (billion US$2017/yr)"]
-                           + out[, , "Revenue|Government|Tax|Carbon|+|Demand|Industry (billion US$2017/yr)"]
-                           + out[, , "Revenue|Government|Tax|Carbon|+|non-ES CDR (billion US$2017/yr)"]
-                           + out[, , "Revenue|Government|Tax|Carbon|+|Supply (billion US$2017/yr)"],
-                                         "Revenue|Government|Tax|Carbon (billion US$2017/yr)")
-                  )
+  out <- mbind(
+    out,
+    setNames(
+      output_wo_GLO[, , "Price|Carbon|Demand|Buildings (US$2017/t CO2)"] * output_wo_GLO[, , "Emi|GHG|Energy|Demand|+|Buildings (Mt CO2eq/yr)"] / 1000,
+      "Revenue|Government|Tax|Carbon|+|Demand|Buildings (billion US$2017/yr)"
+    ),
+    setNames(
+      output_wo_GLO[, , "Price|Carbon|Demand|Transport (US$2017/t CO2)"] * output_wo_GLO[, , "Emi|GHG|Energy|Demand|+|Transport (Mt CO2eq/yr)"] / 1000,
+      "Revenue|Government|Tax|Carbon|+|Demand|Transport (billion US$2017/yr)"
+    ),
+    setNames(
+      output_wo_GLO[, , "Price|Carbon|Demand|Industry (US$2017/t CO2)"] * output_wo_GLO[, , "Emi|GHG|Industry (Mt CO2eq/yr)"] / 1000,
+      "Revenue|Government|Tax|Carbon|+|Demand|Industry (billion US$2017/yr)"
+    ),
+    # AM: novel CDR (excluding biochar and BECCS), i.e. DACCS, ERW ad OAE (BECCS and biochar are accounted under energy supply)
+    # For now no separate price for removals, identical to Energy supply CO2 price.
+    setNames(
+      output_wo_GLO[, , "Price|Carbon|Supply (US$2017/t CO2)"] * output_wo_GLO[, , "Emi|GHG|+++|non-ES CDR (Mt CO2eq/yr)"] / 1000,
+      "Revenue|Government|Tax|Carbon|+|non-ES CDR (billion US$2017/yr)"
+    ),
+    setNames(
+      output_wo_GLO[, , "Price|Carbon|Supply (US$2017/t CO2)"] * output_wo_GLO[, , "Emi|GHG|Energy|+|Supply (Mt CO2eq/yr)"] / 1000,
+      "Revenue|Government|Tax|Carbon|+|Supply (billion US$2017/yr)"
+    )
+  )
+  out <- mbind(out, setNames(
+    out[, , "Revenue|Government|Tax|Carbon|+|Demand|Buildings (billion US$2017/yr)"]
+    + out[, , "Revenue|Government|Tax|Carbon|+|Demand|Transport (billion US$2017/yr)"]
+      + out[, , "Revenue|Government|Tax|Carbon|+|Demand|Industry (billion US$2017/yr)"]
+      + out[, , "Revenue|Government|Tax|Carbon|+|non-ES CDR (billion US$2017/yr)"]
+      + out[, , "Revenue|Government|Tax|Carbon|+|Supply (billion US$2017/yr)"],
+    "Revenue|Government|Tax|Carbon (billion US$2017/yr)"
+  ))
 
   # reporting subsidy or tax rate necessary to reach implicit set energy bounds
-  p47_implEnergyBoundTax <- readGDX(gdx, "p47_implEnergyBoundTax", format= "first_found", react = "silent")
-  if ((!(is.null(p47_implEnergyBoundTax)) && ("FE_wo_b" %in% unique(getNames(p47_implEnergyBoundTax, dim=1))))) {
-    p47_implEnergyBoundTax <- p47_implEnergyBoundTax[,t,] * tdptwyr2dpgj
-    energyCarrierLevel = c(
-        "PE"="PE",
-        "SE"="SE",
-        "FE"="FE",
-        "FE_wo_b"="FE",
-        "FE_wo_n_e"="FE",
-        "FE_wo_b_wo_n_e"="FE"
+  p47_implEnergyBoundTax <- readGDX(gdx, "p47_implEnergyBoundTax", format = "first_found", react = "silent")
+  if ((!(is.null(p47_implEnergyBoundTax)) && ("FE_wo_b" %in% unique(getNames(p47_implEnergyBoundTax, dim = 1))))) {
+    p47_implEnergyBoundTax <- p47_implEnergyBoundTax[, t, ] * tdptwyr2dpgj
+    energyCarrierLevel <- c(
+      "PE" = "PE",
+      "SE" = "SE",
+      "FE" = "FE",
+      "FE_wo_b" = "FE",
+      "FE_wo_n_e" = "FE",
+      "FE_wo_b_wo_n_e" = "FE"
     )
-    for (carrier in names(energyCarrierLevel)){
-      for (energyType in getNames(p47_implEnergyBoundTax,dim=2)){
-        if(!(all(p47_implEnergyBoundTax[,,carrier][,,energyType]==0))){
-          if(all(p47_implEnergyBoundTax[,,carrier][,,energyType]>=0))
-            out <- mbind(out, setNames(p47_implEnergyBoundTax[,,carrier][,,energyType],paste0("Tax Rate|Implicit Energy Bounds|",energyCarrierLevel[carrier],"|",energyType, " (US$2017/GJ)")))
-          else
-            out <- mbind(out, setNames(p47_implEnergyBoundTax[,,carrier][,,energyType],paste0("Subsidy Rate|Implicit Energy Bounds|",energyCarrierLevel[carrier],"|",energyType, " (US$2017/GJ)")))
+    for (carrier in names(energyCarrierLevel)) {
+      for (energyType in getNames(p47_implEnergyBoundTax, dim = 2)) {
+        if (!(all(p47_implEnergyBoundTax[, , carrier][, , energyType] == 0))) {
+          if (all(p47_implEnergyBoundTax[, , carrier][, , energyType] >= 0)) {
+            out <- mbind(out, setNames(p47_implEnergyBoundTax[, , carrier][, , energyType], paste0("Tax Rate|Implicit Energy Bounds|", energyCarrierLevel[carrier], "|", energyType, " (US$2017/GJ)")))
+          } else {
+            out <- mbind(out, setNames(p47_implEnergyBoundTax[, , carrier][, , energyType], paste0("Subsidy Rate|Implicit Energy Bounds|", energyCarrierLevel[carrier], "|", energyType, " (US$2017/GJ)")))
+          }
         }
       }
     }
@@ -297,12 +363,13 @@ reportTax <- function(gdx,output=NULL,regionSubsetList=NULL,t=c(seq(2005,2060,5)
   # add global values
   out <- mbind(out, setItems(dimSums(out, dim = 1), dim = 1, "GLO"))
   # add other region aggregations
-  if (!is.null(regionSubsetList))
+  if (!is.null(regionSubsetList)) {
     out <- mbind(out, calc_regionSubset_sums(out, regionSubsetList))
+  }
 
   # select variables that cannot be aggregated by simply sums and set their values to NA
   vars <- grep("[Rr]ate", getNames(out), value = TRUE)
-  out[c("GLO", names(regionSubsetList)),,vars] <- NA
+  out[c("GLO", names(regionSubsetList)), , vars] <- NA
 
   getSets(out)[3] <- "variable"
   return(out)

--- a/R/reportTechnology.R
+++ b/R/reportTechnology.R
@@ -41,9 +41,14 @@ reportTechnology <- function(gdx, output = NULL, regionSubsetList = NULL,
   module2realisation <- readGDX(gdx, "module2realisation", react = "silent")
   tran_mod <- module2realisation[module2realisation$modules == "transport", 2]
 
-  CDR_mod <- module2realisation[module2realisation$modules == "CDR", 2]
+  ## Ensure backwards compatibility for release version 3.6.0 (can be removed with 3.7.0)
+  if ("CDR" %in% module2realisation$modules) {
+    CDR_mod <- module2realisation[module2realisation$modules == "CDR", 2]
+  } else {
+    CDR_mod <- module2realisation[module2realisation$modules == "carbonRemoval", 2]
+  }
 
-  sety       <- readGDX(gdx, c("entySe", "sety"), format = "first_found")
+  sety <- readGDX(gdx, c("entySe", "sety"), format = "first_found")
   te <- readGDX(gdx, "te")
 
   # calculate maximal temporal resolution ----

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **2.0.15**
+R package **remind2**, version **2.0.16**
 
    [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Bantje D, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Lécuyer F, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Rüter T, Salzwedel R, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2026). "remind2: The REMIND R package (2nd generation)." Version: 2.0.15, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Bantje D, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Lécuyer F, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Rüter T, Salzwedel R, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2026). "remind2: The REMIND R package (2nd generation)." Version: 2.0.16, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and David Bantje and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Fabrice Lécuyer and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Tonn Rüter and Robert Salzwedel and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann},
-  date = {2026-04-23},
+  date = {2026-05-05},
   year = {2026},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 2.0.15},
+  note = {Version: 2.0.16},
 }
 ```

--- a/man/calc_regionSubset_sums.Rd
+++ b/man/calc_regionSubset_sums.Rd
@@ -7,13 +7,13 @@
 calc_regionSubset_sums(data, regionSubsetList)
 }
 \arguments{
-\item{data}{A \code{\link[magclass:magclass-package]{MAgPIE}} object.}
+\item{data}{A \code{\link[magclass:magclass]{MAgPIE}} object.}
 
 \item{regionSubsetList}{A list of region subsets to calculate of the form
 \verb{list(subset_name = c(region_A, region_B, ...)}}
 }
 \value{
-A \code{\link[magclass:magclass-package]{MAgPIE}} object.
+A \code{\link[magclass:magclass]{MAgPIE}} object.
 }
 \description{
 Sum up values in \code{data} for all sets of regions in \code{regionSubsetList}.

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -12,8 +12,8 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{piamPlotComparison}{\code{\link[piamPlotComparison]{getCs2Profiles}}}
+  \item{piamPlotComparison}{\code{\link[piamPlotComparison:getCs2Profiles]{getCs2Profiles()}}}
 
-  \item{piamutils}{\code{\link[piamutils]{deletePlus}}}
+  \item{piamutils}{\code{\link[piamutils:deletePlus]{deletePlus()}}}
 }}
 

--- a/man/remind2-package.Rd
+++ b/man/remind2-package.Rd
@@ -20,6 +20,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Renato Rodrigues \email{renato.rodrigues@pik-potsdam.de}
   \item Lavinia Baumstark
   \item Falk Benke
   \item David Bantje

--- a/man/reportTax.Rd
+++ b/man/reportTax.Rd
@@ -28,8 +28,9 @@ Read in tax information from GDX file, information used in convGDX2MIF.R for
 the reporting
 }
 \examples{
-
-\dontrun{reportTax(gdx)}
+\dontrun{
+reportTax(gdx)
+}
 
 }
 \author{

--- a/man/test_ranges.Rd
+++ b/man/test_ranges.Rd
@@ -12,17 +12,19 @@ test_ranges(
 )
 }
 \arguments{
-\item{data}{A \code{\link[magclass:magclass-package]{magpie}} object to test.}
+\item{data}{A \code{\link[magclass:magclass]{magpie}} object to test.}
 
 \item{tests}{A list of tests to perform, where each tests consists of:
-- A regular expression to match variables names in \code{data} (mandatory
+\itemize{
+\item A regular expression to match variables names in \code{data} (mandatory
 first item).
-- A named entry \code{low} to test the lower bound.  Can be set to \code{NULL} or
+\item A named entry \code{low} to test the lower bound.  Can be set to \code{NULL} or
 omitted.
-- A named entry \code{up} to test the upper bound.  Can be set to \code{NULL} or
+\item A named entry \code{up} to test the upper bound.  Can be set to \code{NULL} or
 omitted.
-- An optional entry \code{ignore.case} which can be set to \code{FALSE} if the
-regular expression should be matched case-sensitive.}
+\item An optional entry \code{ignore.case} which can be set to \code{FALSE} if the
+regular expression should be matched case-sensitive.
+}}
 
 \item{reaction}{A character string, either \code{'message'} or \code{'stop'}, to either
 warn or throw an error if variables exceed the ranges.}


### PR DESCRIPTION
## Purpose of this PR

After module renamings the set item "cdr" now can referenced as intended in REMIND (not via "CDR", which was the conflicting module name before).


## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

