### PR TITLE
Include only ccsinje* technologies in the calculation of the geological storage potential 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '41542548'
+ValidationKey: '41579286'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,7 +23,7 @@ jobs:
           options(repos = c(pikpiam = 'https://pik-piam.r-universe.dev',
                             CRAN = Sys.getenv('RSPM')))
           pak::pak()
-          
+
       - name: Run pre-commit checks
         shell: bash
         run: |

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 2.0.18
-date-released: '2026-05-13'
+version: 2.0.19
+date-released: '2026-05-21'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -92,3 +92,4 @@ Encoding: UTF-8
 Config/testthat/parallel: true
 Config/testthat/edition: 3
 Config/roxygen2/version: 8.0.0
+RoxygenNote: 7.3.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 2.0.18
-Date: 2026-05-13
+Version: 2.0.19
+Date: 2026-05-21
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -210,7 +210,10 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
 
   # maximum annual CO2 storage potential assumed
   # collapseDim removes 'cco2', 'ico2', and 'rlf' dimensions and keeps only 'ccsinjeon/ccsinjeoff'
-  max_geolStorage <- collapseDim(readGDX(gdx, "vm_co2CCS", field = "up", restore_zeros = FALSE), keepdim = "all_te")
+  # in some cases there are more technologies and more grades. Thus, explicitly pick ccsinje* techs and their only grade '1'
+  max_geolStorage <- readGDX(gdx, "vm_co2CCS", field = "up", restore_zeros = FALSE)
+  max_geolStorage <- max_geolStorage[,,c("ccsinjeon","ccsinjeoff"), pmatch = TRUE][,,"1"]
+  max_geolStorage <- collapseDim(max_geolStorage, keepdim = "all_te")
 
   ## Read CO2 captured per industry subsector ----
   # NOTE: The parameter pm_IndstCO2Captured was calculated without taking into

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -212,7 +212,9 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
   # collapseDim removes 'cco2', 'ico2', and 'rlf' dimensions and keeps only 'ccsinjeon/ccsinjeoff'
   # in some cases there are more technologies and more grades. Thus, explicitly pick ccsinje* techs and their only grade '1'
   max_geolStorage <- readGDX(gdx, "vm_co2CCS", field = "up", restore_zeros = FALSE)
-  max_geolStorage <- max_geolStorage[,,c("ccsinjeon","ccsinjeoff"), pmatch = TRUE][,,"1"]
+  if ("ccsinjeon" %in% getItems(max_geolStorage, dim = "all_te")) {
+    max_geolStorage <- max_geolStorage[,,c("ccsinjeon","ccsinjeoff"), pmatch = TRUE][,,"1"]
+  }
   max_geolStorage <- collapseDim(max_geolStorage, keepdim = "all_te")
 
   ## Read CO2 captured per industry subsector ----

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **2.0.18**
+R package **remind2**, version **2.0.19**
 
    [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -21,13 +21,13 @@ The additional repository can be made available permanently by adding the line a
 
 After that the most recent version of the package can be installed using `install.packages`:
 
-```r 
+```r
 install.packages("remind2")
 ```
 
 Package updates can be installed using `update.packages` (make sure that the additional repository has been added before running that command):
 
-```r 
+```r
 update.packages()
 ```
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Bantje D, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Lécuyer F, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Rüter T, Salzwedel R, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2026). "remind2: The REMIND R package (2nd generation)." Version: 2.0.18, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Bantje D, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Lécuyer F, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Rüter T, Salzwedel R, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2026). "remind2: The REMIND R package (2nd generation)." Version: 2.0.19, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and David Bantje and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Fabrice Lécuyer and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Tonn Rüter and Robert Salzwedel and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann},
-  date = {2026-05-13},
+  date = {2026-05-21},
   year = {2026},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 2.0.18},
+  note = {Version: 2.0.19},
 }
 ```

--- a/man/calc_regionSubset_sums.Rd
+++ b/man/calc_regionSubset_sums.Rd
@@ -7,13 +7,13 @@
 calc_regionSubset_sums(data, regionSubsetList)
 }
 \arguments{
-\item{data}{A \code{\link[magclass:magclass]{MAgPIE}} object.}
+\item{data}{A \code{\link[magclass:magclass-package]{MAgPIE}} object.}
 
 \item{regionSubsetList}{A list of region subsets to calculate of the form
 \verb{list(subset_name = c(region_A, region_B, ...)}}
 }
 \value{
-A \code{\link[magclass:magclass]{MAgPIE}} object.
+A \code{\link[magclass:magclass-package]{MAgPIE}} object.
 }
 \description{
 Sum up values in \code{data} for all sets of regions in \code{regionSubsetList}.

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -12,8 +12,8 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{piamPlotComparison}{\code{\link[piamPlotComparison:getCs2Profiles]{getCs2Profiles()}}}
+  \item{piamPlotComparison}{\code{\link[piamPlotComparison]{getCs2Profiles}}}
 
-  \item{piamutils}{\code{\link[piamutils:deletePlus]{deletePlus()}}}
+  \item{piamutils}{\code{\link[piamutils]{deletePlus}}}
 }}
 

--- a/man/remind2-package.Rd
+++ b/man/remind2-package.Rd
@@ -20,7 +20,6 @@ Useful links:
 
 Authors:
 \itemize{
-  \item Renato Rodrigues \email{renato.rodrigues@pik-potsdam.de}
   \item Lavinia Baumstark
   \item Falk Benke
   \item David Bantje

--- a/man/test_ranges.Rd
+++ b/man/test_ranges.Rd
@@ -12,19 +12,17 @@ test_ranges(
 )
 }
 \arguments{
-\item{data}{A \code{\link[magclass:magclass]{magpie}} object to test.}
+\item{data}{A \code{\link[magclass:magclass-package]{magpie}} object to test.}
 
 \item{tests}{A list of tests to perform, where each tests consists of:
-\itemize{
-\item A regular expression to match variables names in \code{data} (mandatory
+- A regular expression to match variables names in \code{data} (mandatory
 first item).
-\item A named entry \code{low} to test the lower bound.  Can be set to \code{NULL} or
+- A named entry \code{low} to test the lower bound.  Can be set to \code{NULL} or
 omitted.
-\item A named entry \code{up} to test the upper bound.  Can be set to \code{NULL} or
+- A named entry \code{up} to test the upper bound.  Can be set to \code{NULL} or
 omitted.
-\item An optional entry \code{ignore.case} which can be set to \code{FALSE} if the
-regular expression should be matched case-sensitive.
-}}
+- An optional entry \code{ignore.case} which can be set to \code{FALSE} if the
+regular expression should be matched case-sensitive.}
 
 \item{reaction}{A character string, either \code{'message'} or \code{'stop'}, to either
 warn or throw an error if variables exceed the ranges.}


### PR DESCRIPTION
## Purpose of this PR

Adjust `reportEmi()` to not include irrelevant technologies in the calculation of the geological storage potential by explicitly selecting CCS injection technologies and a specific grade in `max_geolStorage`. In a few cases, the upper bound of `vm_co2ccs` contains values not only for ccsinje but also for other technologies, which can be ignored.

## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

