### PR TITLE
Mini additions: fossil PE plots; CDR and totals in detailed FE plots; fossil heat reporting

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4388865'
+ValidationKey: '4409684'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 2.1.3
-date-released: '2026-06-01'
+version: 2.1.4
+date-released: '2026-06-02'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 2.1.3
-Date: 2026-06-01
+Version: 2.1.4
+Date: 2026-06-02
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportSE.R
+++ b/R/reportSE.R
@@ -231,19 +231,20 @@ reportSE <- function(gdx, regionSubsetList = NULL, t = c(seq(2005, 2060, 5), seq
 
   ## Heat
   out <- mbind(out,
-    get_prodSE(entyPe, "sehe",                   name = "SE|Heat (EJ/yr)"),
-    get_prodSE( peBio, "sehe",                   name = "SE|Heat|+|Biomass (EJ/yr)"),
-    get_prodSE("pecoal", "sehe",                 name = "SE|Heat|+|Coal (EJ/yr)"),
-    get_prodSE("pegas", "sehe",                  name = "SE|Heat|+|Gas (EJ/yr)"),
-    get_prodSE("pegeo", "sehe",                  name = "SE|Heat|+|Geothermal (EJ/yr)"), # same as SE|Heat|Electricity|Heat Pump
-    get_prodSE("pegeo", "sehe",                  name = "SE|Heat|Electricity|Heat Pump (EJ/yr)"),
-    get_prodSE("pesol", "sehe",                  name = "SE|Heat|+|Solar (EJ/yr)"),
-    get_prodSE( entyPe, "sehe", te = teChp,      name = "SE|Heat|Combined Heat and Power (EJ/yr)"),
-    get_prodSE("pecoal", "sehe", te = "coalchp", name = "SE|Heat|Coal|Combined Heat and Power (EJ/yr)"),
-    get_prodSE("pegas", "sehe", te = "gaschp",   name = "SE|Heat|Gas|Combined Heat and Power (EJ/yr)"),
-    get_prodSE( peBio, "sehe", te = "biochp",    name = "SE|Heat|Biomass|+|Combined Heat and Power (EJ/yr)"),
-    get_prodSE( peBio, "sehe", te = "biohp",     name = "SE|Heat|Biomass|+|Heat (EJ/yr)"),
-    get_prodSE( peBio, "sehe", te = c("biopyrchp", "biopyrhe"),    name = "SE|Heat|Biomass|+|Pyrolysis (EJ/yr)")
+    get_prodSE(entyPe,    "sehe",                 name = "SE|Heat (EJ/yr)"),
+    get_prodSE(peBio,     "sehe",                 name = "SE|Heat|+|Biomass (EJ/yr)"),
+    get_prodSE("pecoal",  "sehe",                 name = "SE|Heat|+|Coal (EJ/yr)"),
+    get_prodSE("pegas",   "sehe",                 name = "SE|Heat|+|Gas (EJ/yr)"),
+    get_prodSE("pegeo",   "sehe",                 name = "SE|Heat|+|Geothermal (EJ/yr)"), # same as SE|Heat|Electricity|Heat Pump
+    get_prodSE("pegeo",   "sehe",                 name = "SE|Heat|Electricity|Heat Pump (EJ/yr)"), # same as SE|Heat|+|Geothermal
+    get_prodSE("pesol",   "sehe",                 name = "SE|Heat|+|Solar (EJ/yr)"),
+    get_prodSE(peFos,     "sehe",                 name = "SE|Heat|Fossil (EJ/yr)"),
+    get_prodSE(entyPe,    "sehe", te = teChp,     name = "SE|Heat|Combined Heat and Power (EJ/yr)"),
+    get_prodSE("pecoal",  "sehe", te = "coalchp", name = "SE|Heat|Coal|Combined Heat and Power (EJ/yr)"),
+    get_prodSE("pegas",   "sehe", te = "gaschp",  name = "SE|Heat|Gas|Combined Heat and Power (EJ/yr)"),
+    get_prodSE(peBio,     "sehe", te = "biochp",  name = "SE|Heat|Biomass|+|Combined Heat and Power (EJ/yr)"),
+    get_prodSE(peBio,     "sehe", te = "biohp",   name = "SE|Heat|Biomass|+|Heat (EJ/yr)"),
+    get_prodSE(peBio,     "sehe", te = c("biopyrchp", "biopyrhe"),    name = "SE|Heat|Biomass|+|Pyrolysis (EJ/yr)")
   )
 
   ## Hydrogen

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **2.1.3**
+R package **remind2**, version **2.1.4**
 
    [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -37,8 +37,8 @@ The package comes with vignettes describing the basic functionality of the packa
 
 ```r
 vignette("compareScenariosRemind2") # compareScenarios in remind2
-vignette("remind_summary")          # Adding plots to the REMIND_summary.pdf
 vignette("remind2_reporting")       # remind2 reporting
+vignette("remind_summary")          # Adding plots to the REMIND_summary.pdf
 ```
 
 ## Questions / Problems
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Bantje D, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Lécuyer F, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Rüter T, Salzwedel R, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2026). "remind2: The REMIND R package (2nd generation)." Version: 2.1.3, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Bantje D, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Lécuyer F, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Rüter T, Salzwedel R, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2026). "remind2: The REMIND R package (2nd generation)." Version: 2.1.4, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and David Bantje and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Fabrice Lécuyer and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Tonn Rüter and Robert Salzwedel and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann},
-  date = {2026-06-01},
+  date = {2026-06-02},
   year = {2026},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 2.1.3},
+  note = {Version: 2.1.4},
 }
 ```

--- a/inst/compareScenarios/cs_01_summary.Rmd
+++ b/inst/compareScenarios/cs_01_summary.Rmd
@@ -114,7 +114,7 @@ items <- c(
   "FE|Transport",
   "FE|Buildings",
   "FE|Industry")
-showAreaAndBarPlots(data, items, scales = "fixed")
+showAreaAndBarPlots(data, items, tot = "FE", scales = "fixed")
 ```
 
 ### FE per capita - area plot, time domain
@@ -169,13 +169,14 @@ items <- c(
   "FE|Solids",
   NULL)
 
-showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
+showAreaAndBarPlots(data, items, tot = "FE", orderVars = "user", scales = "fixed")
 ```
 
 ### FE by carrier (detailed)
 
 ```{r FE by carrier (detailed)}
 items <- c(
+  "FE|CDR",
   "FE|Transport|Electricity",
   "FE|Buildings|Electricity",
   "FE|Industry|Electricity",
@@ -194,7 +195,7 @@ items <- c(
   "FE|Industry|Solids",
   NULL)
 
-showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
+showAreaAndBarPlots(data, items, tot = "FE", orderVars = "user", scales = "fixed")
 ```
 
 ### FE Industry by carrier (incl. non-energy use)
@@ -209,7 +210,7 @@ items <- c(
   "FE|Industry|Solids",
   NULL)
 
-showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
+showAreaAndBarPlots(data, items, tot = "FE|Industry", orderVars = "user", scales = "fixed")
 ```
 
 ### FE Buildings by carrier
@@ -224,10 +225,10 @@ items <- c(
   "FE|Buildings|Solids",
   NULL)
 
-showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
+showAreaAndBarPlots(data, items, tot = "FE|Buildings", orderVars = "user", scales = "fixed")
 ```
 
-### FE Transport by carrier
+### FE Transport by carrier (incl. bunkers)
 
 ```{r FE Transport by carrier}
 items <- c(
@@ -237,7 +238,7 @@ items <- c(
   "FE|Transport|Liquids",
   NULL)
 
-showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
+showAreaAndBarPlots(data, items, tot = "FE|Transport", orderVars = "user", scales = "fixed")
 ```
 
 ### FE CDR by carrier
@@ -251,7 +252,7 @@ items <- c(
   "FE|CDR|Liquids",
   NULL)
 
-showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
+showAreaAndBarPlots(data, items, tot = "FE|CDR", orderVars = "user", scales = "fixed")
 ```
 
 
@@ -262,15 +263,12 @@ items <- c(
   "FE|Non-energy Use|Industry|Gases",
   "FE|Non-energy Use|Industry|Liquids",
   "FE|Non-energy Use|Industry|Solids")
-showAreaAndBarPlots(data, items, orderVars = "user")
+showAreaAndBarPlots(data, items, tot = "FE|Non-energy Use", orderVars = "user")
 ```
 
 ## SE Electricity by carrier
 
 ```{r SE Electricity by carrier}
-
-tot <- "SE|Electricity"
-
 items <- c(
   "SE|Electricity|Net Imports",
   "SE|Electricity|Hydrogen",
@@ -290,7 +288,7 @@ items <- c(
   "SE|Electricity|Coal|w/o CC",
   NULL)
 
-showAreaAndBarPlots(data, items, orderVars = "user", tot, scales = "fixed")
+showAreaAndBarPlots(data, items, tot = "SE|Electricity", orderVars = "user", scales = "fixed")
 ```
 
 
@@ -310,7 +308,7 @@ items <- c(
   "PE|Coal",
   NULL)
 
-showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
+showAreaAndBarPlots(data, items, tot = "PE", orderVars = "user", scales = "fixed")
 ```
 
 

--- a/inst/compareScenarios/cs_04_energy_supply.Rmd
+++ b/inst/compareScenarios/cs_04_energy_supply.Rmd
@@ -281,6 +281,40 @@ Note: multiply EJ by 7.16 to obtain kt of Uranium
 
 
 ## PE Consumption (after trade)
+### PE Fossil
+```{r PE Fossil}
+tot <- "PE|Fossil"
+showLinePlots(data, tot)
+showRegiLinePlots(data, tot)
+
+items <- c(
+  "PE|Gas|Electricity",
+  "PE|Gas|Gases",
+  "PE|Gas|Liquids",
+  "PE|Gas|Heat",
+  "PE|Gas|Hydrogen",
+  "PE|Oil|Electricity",
+  "PE|Oil|Liquids",
+  "PE|Coal|Electricity",
+  "PE|Coal|Gases",
+  "PE|Coal|Liquids",
+  "PE|Coal|Hydrogen",
+  "PE|Coal|Heat",
+  "PE|Coal|Solids",
+  NULL)
+showAreaAndBarPlots(data, items, tot = tot, orderVars = "user", scales = "fixed")
+
+items <- c(
+  "PE|Gas|w/ CC",
+  "PE|Gas|w/o CC",
+  "PE|Oil|w/ CC",
+  "PE|Oil|w/o CC",
+  "PE|Coal|w/ CC",
+  "PE|Coal|w/o CC",
+  NULL)
+showAreaAndBarPlots(data, items, tot = tot, orderVars = "user", scales = "fixed")
+```
+
 ### PE Coal
 ```{r PE Coal}
 tot <- "PE|Coal"

--- a/inst/compareScenarios/cs_05_energy_demand.Rmd
+++ b/inst/compareScenarios/cs_05_energy_demand.Rmd
@@ -51,6 +51,7 @@ showAreaAndBarPlots(data, items, orderVars = "user", scales = "fixed")
 ```{r Final Energy Detail}
 tot <- "FE"
 items <- c(
+  "FE|CDR",
   "FE|Transport|Electricity",
   "FE|Buildings|Electricity",
   "FE|Industry|Electricity",
@@ -76,7 +77,7 @@ items <- c(
 showAreaAndBarPlots(data, items, tot, orderVars = "user", scales = "fixed")
 ```
 
-### FE Demand Detail - Carrier and Sector - carrier share - Bar 
+### FE Demand Detail - Carrier and Sector share - Bar 
 ```{r FE all sectors - carrier share - Bar  }
 showAreaAndBarPlots(data, items, tot, orderVars = "user", fill = TRUE)
 ```

--- a/man/calc_regionSubset_sums.Rd
+++ b/man/calc_regionSubset_sums.Rd
@@ -7,13 +7,13 @@
 calc_regionSubset_sums(data, regionSubsetList)
 }
 \arguments{
-\item{data}{A \code{\link[magclass:magclass]{MAgPIE}} object.}
+\item{data}{A \code{\link[magclass:magclass-package]{MAgPIE}} object.}
 
 \item{regionSubsetList}{A list of region subsets to calculate of the form
 \verb{list(subset_name = c(region_A, region_B, ...)}}
 }
 \value{
-A \code{\link[magclass:magclass]{MAgPIE}} object.
+A \code{\link[magclass:magclass-package]{MAgPIE}} object.
 }
 \description{
 Sum up values in \code{data} for all sets of regions in \code{regionSubsetList}.

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -12,8 +12,8 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{piamPlotComparison}{\code{\link[piamPlotComparison:getCs2Profiles]{getCs2Profiles()}}}
+  \item{piamPlotComparison}{\code{\link[piamPlotComparison]{getCs2Profiles}}}
 
-  \item{piamutils}{\code{\link[piamutils:deletePlus]{deletePlus()}}}
+  \item{piamutils}{\code{\link[piamutils]{deletePlus}}}
 }}
 

--- a/man/remind2-package.Rd
+++ b/man/remind2-package.Rd
@@ -20,7 +20,6 @@ Useful links:
 
 Authors:
 \itemize{
-  \item Renato Rodrigues \email{renato.rodrigues@pik-potsdam.de}
   \item Lavinia Baumstark
   \item Falk Benke
   \item David Bantje

--- a/man/test_ranges.Rd
+++ b/man/test_ranges.Rd
@@ -12,19 +12,17 @@ test_ranges(
 )
 }
 \arguments{
-\item{data}{A \code{\link[magclass:magclass]{magpie}} object to test.}
+\item{data}{A \code{\link[magclass:magclass-package]{magpie}} object to test.}
 
 \item{tests}{A list of tests to perform, where each tests consists of:
-\itemize{
-\item A regular expression to match variables names in \code{data} (mandatory
+- A regular expression to match variables names in \code{data} (mandatory
 first item).
-\item A named entry \code{low} to test the lower bound.  Can be set to \code{NULL} or
+- A named entry \code{low} to test the lower bound.  Can be set to \code{NULL} or
 omitted.
-\item A named entry \code{up} to test the upper bound.  Can be set to \code{NULL} or
+- A named entry \code{up} to test the upper bound.  Can be set to \code{NULL} or
 omitted.
-\item An optional entry \code{ignore.case} which can be set to \code{FALSE} if the
-regular expression should be matched case-sensitive.
-}}
+- An optional entry \code{ignore.case} which can be set to \code{FALSE} if the
+regular expression should be matched case-sensitive.}
 
 \item{reaction}{A character string, either \code{'message'} or \code{'stop'}, to either
 warn or throw an error if variables exceed the ranges.}


### PR DESCRIPTION
## Purpose of this PR
Patchwork of minor additions:
1. **add fossil PE plots**. In many projects, we want to check the phase-out of fossil fuels as a whole. It is not convenient to look at coal, oil, gas separately. This PR adds a short section for PE fossil, with global and regional lineplots, PE x SE bars, and PE x capture bars.
2.  **update detailed FE plots**. Neither the total FE nor the `FE|CDR` sector were displayed, which I found misleading. This PR adds the total on various plots, and the CDR sectors where missing.
3. **add fossil heat reporting**. All other SE carriers had there `|Fossil` detail. This PR adds it for heat too.


## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

