### PR TITLE
Climate correction

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4533760'
+ValidationKey: '4555473'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 2.2.0
-date-released: '2026-06-04'
+version: 2.2.1
+date-released: '2026-06-09'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 2.2.0
-Date: 2026-06-04
+Version: 2.2.1
+Date: 2026-06-09
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -589,23 +589,40 @@ reportFE <- function(gdx, regionSubsetList = NULL,
     heatingVarNames <- c("feelrhb", "feelrhcob", "feelhpb", "feheb", "fesob", "fehob", "fegab", "feh2b")
     carrierBuildHeating <- carrierBuild[names(carrierBuild) %in% heatingVarNames]
 
+    # Read climate correction factors and CES offset quantities
+    pm_climateCorrection <- readGDX(gdx, "pm_climateCorrection", react = "silent")[, t, ]
+
+    # Apply climate correction and offset to get actual FE demand
+    # Following equation: vm_demFeSector = vm_cesIO_raw * pm_climateCorrection + offset_quantity
+    # Note: vm_cesIO already has offset added (see lines 552-557), so we need to remove it first
+    vm_cesIO_climateCorrected <- vm_cesIO[,, names(carrierBuild)]
+    if (!is.null(pm_climateCorrection)) {
+      # Apply climate correction factor: (vm_cesIO - offset) * climateCorrection + offset
+      for (c in names(carrierBuild)) {
+        if (c %in% getItems(pm_climateCorrection, 3)) {
+          offsetCarrier <- if (!is.null(offset) && c %in% getItems(offset, 3)) {
+            setNames(offset[,, c], NULL)
+          } else {
+            0
+          }
+
+          # Remove offset, apply correction, add offset back
+          vm_cesIO_climateCorrected[,, c] <- (vm_cesIO[,, c] - offsetCarrier) * pm_climateCorrection[,, c] + offsetCarrier
+        }
+      }
+    }
+
     # FE demand in buildings for each carrier
     # (electricity split: heat pumps, resistive heating, rest)
     for (c in names(carrierBuild)) {
-      out <- mbind(out, setNames(
-        dimSums(vm_cesIO[, , c], dim = 3, na.rm = TRUE),
-        carrierBuild[c]
-      ))
+      out <- mbind(out, setNames(dimSums(vm_cesIO_climateCorrected[,, c], dim = 3, na.rm = TRUE),
+                                 carrierBuild[c]))
     }
 
     # sum of heating FE demand
-    out <- mbind(
-      out,
-      setNames(
-        dimSums(vm_cesIO[, , names(carrierBuildHeating)], dim = 3, na.rm = TRUE),
-        "FE|Buildings|Heating (EJ/yr)"
-      )
-    )
+    out <- mbind(out,
+                 setNames(dimSums(vm_cesIO_climateCorrected[,, names(carrierBuildHeating)], dim = 3, na.rm = TRUE),
+                          "FE|Buildings|Heating (EJ/yr)"))
 
     # UE demand in buildings for each carrier
     # this buildings realisation only works on a FE level but the UE demand is
@@ -617,9 +634,9 @@ reportFE <- function(gdx, regionSubsetList = NULL,
         pm_fedemandBuild[, , names(carrierBuild)]
       feUeEff_build[is.na(feUeEff_build) | is.infinite(feUeEff_build)] <- 1
       # assume efficiency for all gases also for H2
-      feUeEff_build[, , "feh2b"] <- setNames(feUeEff_build[, , "fegab"], "feh2b")
-      # apply efficiency to get UE levels
-      uedemand_build <- vm_cesIO[, , names(carrierBuild)] * feUeEff_build
+      feUeEff_build[,, "feh2b"] <- setNames(feUeEff_build[,, "fegab"], "feh2b")
+      # apply efficiency to get UE levels (using climate-corrected FE demand)
+      uedemand_build <- vm_cesIO_climateCorrected * feUeEff_build
       getItems(uedemand_build, 3) <-
         gsub("^FE", "UE", carrierBuild)[getItems(uedemand_build, 3)]
       out <- mbind(out, uedemand_build)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **2.2.0**
+R package **remind2**, version **2.2.1**
 
    [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -37,8 +37,8 @@ The package comes with vignettes describing the basic functionality of the packa
 
 ```r
 vignette("compareScenariosRemind2") # compareScenarios in remind2
-vignette("remind_summary")          # Adding plots to the REMIND_summary.pdf
 vignette("remind2_reporting")       # remind2 reporting
+vignette("remind_summary")          # Adding plots to the REMIND_summary.pdf
 ```
 
 ## Questions / Problems
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Bantje D, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Lécuyer F, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Rüter T, Salzwedel R, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2026). "remind2: The REMIND R package (2nd generation)." Version: 2.2.0, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Bantje D, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Lécuyer F, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Rüter T, Salzwedel R, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2026). "remind2: The REMIND R package (2nd generation)." Version: 2.2.1, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and David Bantje and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Fabrice Lécuyer and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Tonn Rüter and Robert Salzwedel and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann},
-  date = {2026-06-04},
+  date = {2026-06-09},
   year = {2026},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 2.2.0},
+  note = {Version: 2.2.1},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR

This PR applies climate correction factors to the final energy (FE) and useful energy (UE) demand calculations for buildings in the `reportFE` function. This is specifically necessary if `cm_climateCorrection == on` in REMIND (see PR ...). 

### Changes

- Reads `pm_climateCorrection` parameter from GDX file (exists if `cm_climateCorrection == on`, otherwise returns `NULL`) 
- Applies climate correction to buildings FE demand by:
  - Removing offset quantities from raw CES inputs
  - Multiplying by climate correction factor
  - Re-adding offset quantities
- Uses climate-corrected FE values for calculating UE demand with efficiency factors

### Impact

Buildings FE and UE reporting now properly reflects climate-adjusted energy demand, ensuring that reported values match the actual energy demand calculated in the model (`vm_demFeSector`) which includes climate corrections.

You can find a reporting comparing `SSP2-NPi2025` with and without climate correction here: `/p/tmp/hagento/dev/REMIND/climateCorrection/remind/compScen-climateCorrection-2026-06-09_13.41.26-H12.pdf`

## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

