### PR TITLE
exclude climate trace from cs plots

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4555694'
+ValidationKey: '4579416'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 2.2.1
-date-released: '2026-06-10'
+version: 2.2.2
+date-released: '2026-06-24'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 2.2.1
-Date: 2026-06-10
+Version: 2.2.2
+Date: 2026-06-24
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **2.2.1**
+R package **remind2**, version **2.2.2**
 
    [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Bantje D, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Lécuyer F, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Rüter T, Salzwedel R, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2026). "remind2: The REMIND R package (2nd generation)." Version: 2.2.1, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Bantje D, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Lécuyer F, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Rüter T, Salzwedel R, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2026). "remind2: The REMIND R package (2nd generation)." Version: 2.2.2, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and David Bantje and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Fabrice Lécuyer and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Tonn Rüter and Robert Salzwedel and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann},
-  date = {2026-06-10},
+  date = {2026-06-24},
   year = {2026},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 2.2.1},
+  note = {Version: 2.2.2},
 }
 ```

--- a/inst/compareScenarios/cs_03_emissions.Rmd
+++ b/inst/compareScenarios/cs_03_emissions.Rmd
@@ -73,12 +73,14 @@ showLinePlots(data, "Emi|GHG|Industrial Processes")
 
 ### GHG Agriculture
 ```{r GHG Agriculture}
-showLinePlots(data, "Emi|GHG|Agriculture")
+showLinePlots(data, "Emi|GHG|Agriculture",
+              histModelsExclude = "ClimateTrace")
 ```
 
 ### GHG Waste
 ```{r GHG Waste}
-showLinePlots(data, "Emi|GHG|Waste")
+showLinePlots(data, "Emi|GHG|Waste",
+              histModelsExclude = "ClimateTrace")
 ```
 
 
@@ -141,7 +143,8 @@ showAreaAndBarPlots(data, items, tot, scales = "fixed")
 ```{r Energy and Industrial Processes w/o bunkers - Net (incl BECCS)}
 showLinePlots(
   data, 
-  vars = "Emi|CO2|w/o Bunkers|Energy and Industrial Processes"
+  vars = "Emi|CO2|w/o Bunkers|Energy and Industrial Processes",
+  histModelsExclude = "ClimateTrace"
 )
 ```
 
@@ -149,7 +152,8 @@ showLinePlots(
 ```{r Energy and Industrial Processes w/ bunkers - Net (incl BECCS)}
 showLinePlots(
   data, 
-  vars = "Emi|CO2|w/ Bunkers|Energy and Industrial Processes"
+  vars = "Emi|CO2|w/ Bunkers|Energy and Industrial Processes",
+  histModelsExclude = "ClimateTrace"
 )
 ```
 
@@ -179,7 +183,8 @@ showLinePlots(data, "Emi|CO2|w/ Bunkers|Energy")
 showLinePlots(
   data, 
   vars = "Emi|CO2|Energy|Supply", 
-  histVars = c("Emi|CO2|Energy|Supply", "Emi|CO2|Fossil Fuels and Industry|Energy Supply")
+  histVars = c("Emi|CO2|Energy|Supply", "Emi|CO2|Fossil Fuels and Industry|Energy Supply"),
+  histModelsExclude = "ClimateTrace"
 )
 ```
 
@@ -189,14 +194,17 @@ showLinePlots(
 showLinePlots(
   data, 
   vars = "Emi|CO2|Energy|Supply|Electricity w/ couple prod", 
-  histVars = c("Emi|CO2|Energy|Supply|Electricity w/ couple prod", "Emi|CO2|Energy|Supply|Electricity")
+  histVars = c("Emi|CO2|Energy|Supply|Electricity w/ couple prod", "Emi|CO2|Energy|Supply|Electricity"),
+  histModelsExclude = "ClimateTrace"
 )
 ```
 
 
 ### Electricity and Heat
 ```{r CO2 Electricity and Heat}
-showLinePlots(data, vars = "Emi|CO2|Energy|Supply|Electricity and Heat")
+showLinePlots(data, 
+              vars = "Emi|CO2|Energy|Supply|Electricity and Heat",
+              histModelsExclude = "ClimateTrace")
 ```
 
 
@@ -205,7 +213,8 @@ showLinePlots(data, vars = "Emi|CO2|Energy|Supply|Electricity and Heat")
 showLinePlots(
   data, 
   vars = "Emi|CO2|Energy|Demand|Buildings", 
-  histVars = c("Emi|CO2|Energy|Demand|Buildings", "Emi|CO2|Buildings|Direct")
+  histVars = c("Emi|CO2|Energy|Demand|Buildings", "Emi|CO2|Buildings|Direct"),
+  histModelsExclude = "ClimateTrace"
 )
 ```
 
@@ -230,7 +239,9 @@ showLinePlots(
 
 ### Industry with Industrial Processes
 ```{r CO2 Industry with Industrial Processes}
-showLinePlots(data, "Emi|CO2|Industry")
+showLinePlots(data, 
+              vars = "Emi|CO2|Industry",
+              histModelsExclude = "ClimateTrace")
 ```
 
 ### Industry Subsector Emissions
@@ -247,17 +258,20 @@ walk(items, showLinePlots, data = data)
 
 ### Transport without bunkers
 ```{r CO2 Transport}
-showLinePlots(data, "Emi|CO2|w/o Bunkers|Energy|Demand|Transport")
+showLinePlots(data, "Emi|CO2|w/o Bunkers|Energy|Demand|Transport",
+              histModelsExclude = "ClimateTrace")
 ```
 
 ### Transport with bunkers
 ```{r CO2 Transport}
-showLinePlots(data, "Emi|CO2|w/ Bunkers|Energy|Demand|Transport")
+showLinePlots(data, "Emi|CO2|w/ Bunkers|Energy|Demand|Transport",
+              histModelsExclude = "ClimateTrace")
 ```
 
 ### International Bunkers
 ```{r CO2 Bunkers}
-showLinePlots(data, "Emi|CO2|Energy|Demand|Transport|International Bunkers")
+showLinePlots(data, "Emi|CO2|Energy|Demand|Transport|International Bunkers",
+              histModelsExclude = "ClimateTrace")
 ```
 
 


### PR DESCRIPTION
## Purpose of this PR

Remove Climate Trace from cs plots as it can not be considered a reliable data source without further analysis.

## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

