### PR TITLE
Adding CO2 price convergence plots to nashConvergenceReport

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4579416'
+ValidationKey: '4747200'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -3,6 +3,9 @@ AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*
 - .*to check if summation groups add up.*
+- 'Warning: package ''.*'' was built under R version'
+- 'Warning: namespace ''.*'' is not available and has been replaced'
+- .*qpdf.* is needed for checks on size reduction of PDFs
 - Warning: package .* was built under R version
 - range error
 AcceptedNotes: Imports includes .* non-default packages.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 2.2.2
-date-released: '2026-06-24'
+version: 2.3.0
+date-released: '2026-07-06'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 2.2.2
-Date: 2026-06-24
+Version: 2.3.0
+Date: 2026-07-06
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,7 +66,6 @@ Imports:
     piamPlotComparison (>= 0.0.10),
     piamutils,
     plotly (>= 4.10.4),
-    qpdf,
     quitte (>= 0.3132.0),
     readr,
     remulator,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,6 +66,7 @@ Imports:
     piamPlotComparison (>= 0.0.10),
     piamutils,
     plotly (>= 4.10.4),
+    qpdf,
     quitte (>= 0.3132.0),
     readr,
     remulator,

--- a/R/nashConvergenceReport.R
+++ b/R/nashConvergenceReport.R
@@ -46,7 +46,8 @@ nashConvergenceReport <- function(gdx = "fulldata.gdx", outputDir = getwd()) {
   # all reports
   reports <- c(
     "infes" = "overview", "surplus" = "trade", "DevPriceAnticip" = "priceAnticipation", "taxconv" = "taxConv", "target" = "emiTarget",
-    "regiTarget" = "regiTarget", "implicitEnergyTarget" = "qttyTarget", "cm_implicitPriceTarget" = "priceTarget", "cm_implicitPePriceTarget" = "pePriceTarget", "damage" = "damage"
+    "regiTarget" = "regiTarget", "implicitEnergyTarget" = "qttyTarget", "cm_implicitPriceTarget" = "priceTarget", "cm_implicitPePriceTarget" = "pePriceTarget", "damage" = "damage",
+    "peakbudget" = "co2price"
   )
 
   # active convergence criteria
@@ -62,7 +63,8 @@ nashConvergenceReport <- function(gdx = "fulldata.gdx", outputDir = getwd()) {
 .createIndexHTML <- function(active_reports, output_dir) {
   titles <- c(
     "overview" = "Overview", "trade" = "Trade Surplus", "priceAnticipation" = "Price Anticipation", "taxConv" = "Tax Convergence", "emiTarget" = "Emission target",
-    "regiTarget" = "Regional target", "qttyTarget" = "Quantity target", "priceTarget" = "Price target", "pePriceTarget" = "PE Price target", "damage" = "Damage"
+    "regiTarget" = "Regional target", "qttyTarget" = "Quantity target", "priceTarget" = "Price target", "pePriceTarget" = "PE Price target", "damage" = "Damage",
+    "co2price" = "CO2 price convergence"
   )
 
   indexHTML <- '<!DOCTYPE html>\n<html>\n<head>\n<meta name="viewport" content="width=device-width, initial-scale=1">'

--- a/R/plotLCOE.R
+++ b/R/plotLCOE.R
@@ -13,8 +13,8 @@
 #' @export
 #' @importFrom magclass read.report mbind
 #' @importFrom lusweave swopen swlatex swfigure swclose
-#' @importFrom ggplot2 ggplot facet_wrap geom_errorbar ggtitle scale_y_continuous
-#' geom_col aes element_text theme_bw sec_axis scale_x_discrete scale_linetype_identity unit
+#' @importFrom ggplot2 ggplot facet_wrap geom_errorbar ggtitle scale_y_continuous geom_col aes element_text theme_bw
+#' @importFrom ggplot2 sec_axis scale_x_discrete scale_linetype_identity unit
 #' @importFrom dplyr left_join
 #' @importFrom quitte order.levels getRegs revalue.levels getScenarios
 #' @importFrom tidyr spread gather

--- a/R/plotNashConvergence.R
+++ b/R/plotNashConvergence.R
@@ -14,9 +14,8 @@
 #' @importFrom quitte as.quitte
 #' @importFrom data.table :=
 #' @importFrom mip plotstyle
-#' @importFrom ggplot2 scale_y_continuous scale_x_continuous scale_y_discrete
-#'              scale_fill_manual scale_color_manual coord_cartesian aes_ geom_rect
-#'              theme geom_point geom_hline
+#' @importFrom ggplot2 scale_y_continuous scale_x_continuous scale_y_discrete scale_fill_manual scale_color_manual
+#' @importFrom ggplot2 coord_cartesian aes_ geom_rect theme geom_point geom_hline
 #' @importFrom plotly ggplotly config hide_legend subplot layout
 #' @importFrom reshape2 dcast
 #'

--- a/R/reportCrossVariables.R
+++ b/R/reportCrossVariables.R
@@ -21,8 +21,7 @@
 #' @export
 #' @importFrom assertr assert not_na
 #' @importFrom gdx readGDX
-#' @importFrom magclass getYears getRegions mbind setNames mselect
-#' new.magpie setYears mcalc
+#' @importFrom magclass getYears getRegions mbind setNames mselect new.magpie setYears mcalc
 #' @importFrom tibble as_tibble
 #' @importFrom data.table :=
 #' @importFrom tidyselect everything

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -19,10 +19,8 @@
 #'
 #' @export
 #' @importFrom gdx readGDX
-#' @importFrom magclass new.magpie mselect getRegions getYears mbind setNames
-#'                      getNames<- as.data.frame as.magpie getSets
-#' @importFrom dplyr %>% filter full_join group_by left_join mutate rename
-#'     select semi_join summarize ungroup
+#' @importFrom magclass new.magpie mselect getRegions getYears mbind setNames getNames<- as.data.frame as.magpie getSets
+#' @importFrom dplyr %>% filter full_join group_by left_join mutate rename select semi_join summarize ungroup
 #' @importFrom quitte inline.data.frame revalue.levels
 #' @importFrom rlang syms
 #' @importFrom tibble as_tibble tibble tribble

--- a/R/reportPrices.R
+++ b/R/reportPrices.R
@@ -26,8 +26,8 @@
 #'
 #' @importFrom dplyr %>% case_when distinct filter inner_join tibble left_join rename
 #' @importFrom gdx readGDX
-#' @importFrom magclass mbind getYears getRegions setNames dimExists new.magpie
-#' lowpass complete_magpie getItems<- getNames unitsplit unitjoin
+#' @importFrom magclass mbind getYears getRegions setNames dimExists new.magpie lowpass
+#' @importFrom magclass complete_magpie getItems<- getNames unitsplit unitjoin
 #' @importFrom quitte df.2.named.vector getColValues
 #' @importFrom readr read_csv
 #' @importFrom madrat toolAggregate

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **2.2.2**
+R package **remind2**, version **2.3.0**
 
    [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Bantje D, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Lécuyer F, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Rüter T, Salzwedel R, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2026). "remind2: The REMIND R package (2nd generation)." Version: 2.2.2, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Bantje D, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Lécuyer F, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Rüter T, Salzwedel R, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2026). "remind2: The REMIND R package (2nd generation)." Version: 2.3.0, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and David Bantje and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Fabrice Lécuyer and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Tonn Rüter and Robert Salzwedel and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann},
-  date = {2026-06-24},
+  date = {2026-07-06},
   year = {2026},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 2.2.2},
+  note = {Version: 2.3.0},
 }
 ```

--- a/inst/markdown/nashConvergence-co2price.Rmd
+++ b/inst/markdown/nashConvergence-co2price.Rmd
@@ -1,0 +1,313 @@
+---
+title: "CO2 price convergence"
+output:
+  html_document:
+    toc: true
+    toc_float: true
+    code_folding: hide
+params:
+  gdx: "fulldata.gdx"
+  warning: false
+  message: false
+  figWidth: 8
+---
+
+<style>
+  .main-container {
+    max-width: 95% !important;
+  }
+  .toc-content {
+    padding-left: 0px !important;
+  }
+  .svg-container {
+    margin: auto !important;
+  }
+
+</style>
+
+```{r loading_libraries, include=FALSE}
+
+library(dplyr)
+library(gdx)
+library(ggplot2)
+library(magclass)
+library(mip)
+library(plotly)
+library(remind2)
+
+knitr::opts_chunk$set(
+  echo = FALSE,
+  error = TRUE,
+  fig.width = params$figWidth,
+  message = params$message,
+  warning = params$warning
+)
+
+```
+
+
+```{r setup, echo=FALSE, include=FALSE}
+
+# Value column returned by mip::getPlotData is named after the variable, while
+# the set dimensions keep their gdx names ("iteration" and "ttot" here). The
+# helpers below abstract the read-and-plot step per dimensionality so each
+# variable section stays a one-liner.
+
+# placeholder shown when a variable is absent/empty in this gdx (ggplotly()
+# errors on a zero-row data frame, so we substitute an annotated blank plot).
+# Also dumps str() of the raw data for debugging why it came back empty.
+emptyPlot <- function(var, df = NULL) {
+  cat(paste0("str() of raw data for '", var, "':\n"))
+  str(df)
+  p <- ggplot() +
+    annotate("text", x = 0, y = 0, label = paste0("no data for '", var, "' in this gdx")) +
+    theme_void()
+  ggplotly(p)
+}
+
+# only an iteration dimension -> static line/point over iterations
+plotOverIterations <- function(var, gdx = params$gdx) {
+  df <- mip::getPlotData(var, gdx) %>%
+    mutate("iteration" := as.numeric(as.character(.data$iteration)))
+
+  if (nrow(df) == 0) return(emptyPlot(var, df))
+
+  p <- ggplot(df, aes(x = .data$iteration, y = .data[[var]])) +
+    geom_line(alpha = 0.6) +
+    geom_point(size = 1) +
+    theme_bw() +
+    labs(x = "iteration", y = var)
+
+  ggplotly(p)
+}
+
+# combine several iteration-indexed flags into one strip plot: iteration on x,
+# one row per variable on y, discrete colour (blue = 0, red = nonzero). Missing
+# iterations are filled with 0 so every variable spans the full iteration axis
+# (cf. "Max. Trade Surplus" in plotNashConvergence.R).
+plotFlipflopStrip <- function(vars, gdx = params$gdx) {
+  lastIteration <- readGDX(gdx, "o_iterationNumber", react = "error")[[1]]
+  iterations <- data.frame(iteration = seq_len(lastIteration))
+
+  df <- lapply(vars, function(v) {
+    d <- mip::getPlotData(v, gdx)
+    have <- if (nrow(d) == 0) {
+      data.frame(iteration = numeric(0), value = numeric(0))
+    } else {
+      data.frame(iteration = as.numeric(as.character(d$iteration)), value = d[[v]])
+    }
+    full <- left_join(iterations, have, by = "iteration")
+    full$value[is.na(full$value)] <- 0
+    full$variable <- v
+    full
+  }) %>% bind_rows()
+
+  df$variable <- factor(df$variable, levels = rev(vars))
+  df$state <- factor(ifelse(df$value == 0, "0", "1"), levels = c("0", "1"))
+
+  p <- suppressWarnings(ggplot(df, aes(
+    x = .data$iteration, y = .data$variable,
+    color = .data$state, text = paste0("value: ", .data$value)
+  )) +
+    geom_point(size = 2, alpha = 0.6) +
+    scale_color_manual(values = c("0" = "blue", "1" = "red"), drop = FALSE) +
+    scale_y_discrete(drop = FALSE) +
+    theme_minimal() +
+    labs(x = NULL, y = NULL, color = "value"))
+
+  pl <- ggplotly(p, tooltip = c("x", "y", "text"), height = 120 + 70 * length(vars)) %>%
+    hide_legend() %>%
+    config(displayModeBar = FALSE, displaylogo = FALSE)
+
+  htmltools::tagList(pl)
+}
+
+# only a period dimension -> static line/point over periods
+plotOverPeriod <- function(var, gdx = params$gdx) {
+  df <- mip::getPlotData(var, gdx) %>%
+    mutate("ttot" := as.numeric(as.character(.data$ttot)))
+
+  if (nrow(df) == 0) return(emptyPlot(var, df))
+
+  p <- ggplot(df, aes(x = .data$ttot, y = .data[[var]])) +
+    geom_line(alpha = 0.6) +
+    geom_point(size = 1) +
+    theme_bw() +
+    labs(x = "period", y = var)
+
+  ggplotly(p)
+}
+
+# used by the animated period-vs-iteration plots below
+adjustSliderAnimation <- function(p) {
+  return(list(p[[1]] %>% plotly::animation_opts(frame = 1)))
+}
+
+# period x iteration -> animated, period on x with a slider over iterations.
+# Returns a tagList so the calling chunk can render it directly.
+plotOverPeriodBySlider <- function(var, gdx = params$gdx) {
+  df <- mip::getPlotData(var, gdx) %>%
+    mutate("ttot" := as.numeric(as.character(.data$ttot)))
+
+  if (nrow(df) == 0) return(htmltools::tagList(emptyPlot(var, df)))
+
+  p <- mip::mipIterations(
+    plotData = df,
+    xAxis = "ttot",
+    facets = NULL,
+    color = NULL,
+    slider = "iteration"
+  ) %>% adjustSliderAnimation()
+
+  htmltools::tagList(p)
+}
+
+```
+
+
+## Model configuration
+
+Initial scalar configuration read from the gdx (missing entries show as `NA`).
+
+```{r config_read}
+configVars <- c(
+  "cm_budgetCO2from2020", "carbonprice", "cm_taxCO2_functionalForm", "cm_taxCO2_peakBudgYr",
+  "cm_peakBudgYr", "cm_taxCO2_IncAfterPeakBudgYr", "cm_nash_autoconverge", "cm_budgetCO2_absDevTol",
+  "sm_peakbudget_diff_tolerance", "cm_iterative_target_adj"
+)
+
+readScalar <- function(v) {
+  x <- suppressWarnings(gdx::readGDX(params$gdx, v, react = "silent"))
+  if (is.null(x)) return(NA_character_)
+  paste(as.character(as.vector(x)), collapse = ", ")
+}
+
+configTable <- data.frame(variable = configVars, value = vapply(configVars, readScalar, character(1)))
+```
+
+```{r config_table}
+knitr::kable(configTable, row.names = FALSE)
+```
+
+
+## Actual peak emissions year
+
+peak budget year calculated based on maximum of cumulative CO2 emissions, used to check adjustment algorithm [year]
+
+```{r peak_year, results = "asis"}
+p45_peakBudgYr_check <- readGDX(params$gdx, "p45_peakBudgYr_check")
+allperiods <- getYears(p45_peakBudgYr_check, as.integer = TRUE)
+actualPeakBudgYr <- allperiods[p45_peakBudgYr_check == 1]
+cat(actualPeakBudgYr)
+```
+
+
+## CO2 tax anchor
+
+### p45_taxCO2eq_anchor_iter
+
+save p45_taxCO2eq_anchor in each iteration (before entering functionalForm/postsolve.gms) for debugging
+
+<!-- animated: x: period, slider: iteration -->
+
+```{r results = "asis"}
+plotOverPeriodBySlider("p45_taxCO2eq_anchor_iter")
+```
+
+### o45_taxCO2eq_anchor_iterDiff_Itr
+
+track pm_taxCO2eq_anchor_iterationdiff in 2100 over iterations
+
+```{r}
+plotOverIterations("o45_taxCO2eq_anchor_iterDiff_Itr")
+```
+
+### p45_taxCO2eq_anchor_iterationdiff_tmp
+
+help parameter for iterative adjustment of taxes
+
+```{r results = "asis"}
+plotOverPeriodBySlider("p45_taxCO2eq_anchor_iterationdiff_tmp")
+```
+
+
+## CO2 budget and peak budget year
+
+### o45_diff_to_Budg
+
+Difference between actual CO2 budget and target CO2 budget
+
+```{r}
+plotOverIterations("o45_diff_to_Budg")
+```
+
+### o45_totCO2emi_peakBudgYr
+
+Total CO2 emissions in the peakBudgYr
+
+```{r}
+plotOverIterations("o45_totCO2emi_peakBudgYr")
+```
+
+### o45_peakBudgYr_Itr
+
+Year in which the CO2 budget is supposed to peak. Is changed in iterative_target_adjust = 9
+
+```{r}
+plotOverIterations("o45_peakBudgYr_Itr")
+```
+
+### o45_totCO2emi_allYrs
+
+Global CO2 emissions over time and iterations. Needed to check the procedure to find the peakBudgYr
+
+<!-- animated: x: period, slider: iteration -->
+
+```{r results = "asis"}
+plotOverPeriodBySlider("o45_totCO2emi_allYrs")
+```
+
+### o45_change_totCO2emi_peakBudgYr
+
+Measure for how much the CO2 emissions change around the peakBudgYr
+
+```{r}
+plotOverIterations("o45_change_totCO2emi_peakBudgYr")
+```
+
+## CO2 price rescaling
+
+### p45_factorRescale_taxCO2
+
+Multiplicative factor for rescaling the CO2 price to reach the target
+
+```{r}
+plotOverIterations("p45_factorRescale_taxCO2")
+```
+
+### p45_factorRescale_taxCO2_Funneled
+
+Multiplicative factor for rescaling the CO2 price to reach the target - limited by an iteration-dependent funnel
+
+```{r}
+plotOverIterations("p45_factorRescale_taxCO2_Funneled")
+```
+
+
+## Flip-flop tracking
+
+Iteration on the x-axis, one row per variable; blue = 0, red = nonzero. Missing iterations are filled with 0 (hover for the actual value).
+
+- o45_pkBudgYr_flipflop: Counter that tracks if flipfloping of cm_peakBudgYr occured in the last iterations
+- o45_delay_increase_peakBudgYear: Counter that tracks if flip-flopping of peakBudgYr happened. Starts an inner loop to try and overcome this
+- o45_reached_until2150pricepath: Counter that tracks if the inner loop of increasing the CO2 price AFTER peakBudgYr goes beyond the initial trajectory
+- o45_factorRescale_taxCO2_afterPeakBudgYr: Multiplicative factor for rescaling the CO2 price in the year after peakBudgYr - only needed if flip-flopping of peakBudgYr occurs
+
+```{r results = "asis"}
+plotFlipflopStrip(c(
+  "o45_pkBudgYr_flipflop",
+  "o45_delay_increase_peakBudgYear",
+  "o45_reached_until2150pricepath",
+  "o45_factorRescale_taxCO2_afterPeakBudgYr"
+))
+```


### PR DESCRIPTION
## Purpose of this PR
Adds a new template to `nashConvergenceReport`, with basic information about the CO2 price convergence algorithm when `carbonprice = functionalForm`. 


## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

