### PR TITLE
Renaming of ERW-related variables

### DIFF
--- a/R/reportCosts.R
+++ b/R/reportCosts.R
@@ -110,7 +110,7 @@ reportCosts <- function(gdx,
   v_costfu <- readGDX(gdx, name = c("v_costFu", "v_costfu"), field = "l", restore_zeros = FALSE, format = "first_found")
   v_costom <- readGDX(gdx, name = c("v_costOM", "v_costom"), field = "l", format = "first_found")
   v_costin <- readGDX(gdx, name = c("v_costInv", "v_costin"), field = "l", format = "first_found")
-  vm_omcosts_cdr <- readGDX(gdx, name = c("vm_omcosts_cdr"), field = "l", format = "first_found")
+  vm_EW_transport_costs <- readGDX(gdx, name = c("vm_omcosts_cdr", "vm_EW_transport_costs"), field = "l", format = "first_found")
   v_investcost <- readGDX(gdx, name = c("vm_costTeCapital", "v_costTeCapital", "v_investcost"), field = "l", format = "first_found")
   vm_cap <- readGDX(gdx, name = c("vm_cap"), field = "l", format = "first_found")
   vm_cap[is.na(vm_cap)] <- 0
@@ -187,7 +187,7 @@ reportCosts <- function(gdx,
   sebal.m <- sebal.m[, y, ]
   febalForUe.m <- febalForUe.m[, y, ]
   balfinen.m <- balfinen.m[, y, ]
-  vm_omcosts_cdr <- vm_omcosts_cdr[, y, ]
+  vm_EW_transport_costs <- vm_EW_transport_costs[, y, ]
   output <- output[, y, ]
   p_eta_conv <- p_eta_conv[, y, ]
 
@@ -601,7 +601,7 @@ reportCosts <- function(gdx,
   tmp <- mbind(tmp, setNames(v_costom * 1000, "OandM costs (billion US$2017/yr)"))
 
   ##### CDR
-  tmp <- mbind(tmp, setNames(vm_omcosts_cdr * 1000, "OandM costs CDR (billion US$2017/yr)"))
+  tmp <- mbind(tmp, setNames(vm_EW_transport_costs * 1000, "OandM transport costs EW (billion US$2017/yr)"))
 
   #####################################
   ########## Operational costs ########

--- a/R/reportLCOE.R
+++ b/R/reportLCOE.R
@@ -515,8 +515,8 @@ reportLCOE <- function(gdx, output.type = "both") {
     if (EW_name %in% teCDR) {
       # The calculation of cost is associated with the spreading of rocks in a time step. However, the removal induced thereby is spread across time steps.
       # Thus, we need to calculate the total removal induced through spreading a given amount of rock as reference value for the cost incurred in that time step.
-      s33_co2_rem_pot <- readGDX(gdx, "s33_co2_rem_pot")
-      EW_induced_in_tCO2 <- dimSums(v33_EW_onfield * s33_co2_rem_pot * s_GtC2tCO2, dim = 3) # here grades do not matter because the overall removal depends on the type of stone and not grade
+      s33_rockRemPot <- readGDX(gdx, c("s33_rockRemPot","s33_co2_rem_pot"), format = "first_found")
+      EW_induced_in_tCO2 <- dimSums(v33_EW_onfield * s33_rockRemPot * s_GtC2tCO2, dim = 3) # here grades do not matter because the overall removal depends on the type of stone and not grade
       # [Gt stone] * [GtC/GtStone] * [tCO2/GtC]
       EW_induced_in_tCO2[EW_induced_in_tCO2 == 0] <- NA # set NA to avoid infinite investment cost for the standing system when regions do not spread EW in time steps after initial investment was taken
       cdrco2_byTech_tCO2[, , EW_name] <- EW_induced_in_tCO2[, ttot_from2005, ]

--- a/R/reportLCOE.R
+++ b/R/reportLCOE.R
@@ -492,7 +492,6 @@ reportLCOE <- function(gdx, output.type = "both") {
       # To allow interpretation of the LC, separate these cost components.
       p33_EW_transport_costs <- readGDX(gdx, c("p33_EW_transport_costs", "p33_transport_costs"), format = "first_found")
 
-      EW_fixed_other_cost <- 10^12 * s33_costs_fix * v33_EW_onfield_sum
       EW_fixed_transport_cost <-  10^12 *  dimSums(p33_EW_transport_costs[, , getNames(v33_EW_onfield)] * v33_EW_onfield)
     }
 
@@ -691,10 +690,10 @@ reportLCOE <- function(gdx, output.type = "both") {
           setNames(EW_fixed_transport_cost / cdrco2_byTech_tCO2[, ttot_from2005, EW_name],
                    paste0("LCOCS|average|", "sco2|", EW_name, "|carbon management", "|OMF transport Cost")),
           # sum for enhanced weathering (incl. special om cost)
-          setNames((te_annual_inv_cost[, ttot_from2005, EW_name] +  te_annual_OMF_cost[, , EW_name] + te_annual_otherFuel_cost[, , EW_name] + EW_fixed_other_cost +
+          setNames((te_annual_inv_cost[, ttot_from2005, EW_name] +  te_annual_OMF_cost[, , EW_name] + te_annual_otherFuel_cost[, , EW_name] +
                       EW_fixed_transport_cost) / cdrco2_byTech_tCO2[, ttot_from2005, EW_name],
                    paste0("LCOCS|average|", "sco2|", EW_name, "|carbon management", "|Total Cost")),
-          setNames((te_annual_inv_cost_wadj[, ttot_from2005, EW_name] + te_annual_otherFuel_cost[, , EW_name] + EW_fixed_other_cost +
+          setNames((te_annual_inv_cost_wadj[, ttot_from2005, EW_name] + te_annual_otherFuel_cost[, , EW_name] +
                       EW_fixed_transport_cost) / cdrco2_byTech_tCO2[, ttot_from2005, EW_name],
                    paste0("LCOCS|average|", "sco2|", EW_name, "|carbon management", "|Total Cost w/ Adj Cost"))
         )

--- a/R/reportLCOE.R
+++ b/R/reportLCOE.R
@@ -488,9 +488,8 @@ reportLCOE <- function(gdx, output.type = "both") {
       v33_EW_onfield <- readGDX(gdx, c("v33_EW_onfield", "v33_grindrock_onfield"), restore_zeros = FALSE, field = "l", format = "first_found")[, ttot_from2005, ]
       v33_EW_onfield_sum <- dimSums(v33_EW_onfield, dim = 3)
 
-      # EW-specific fixed OM cost are given by vm_omcosts_cdr. This cumulates a) completely fixed cost for mining, grinding and spreading; and b) fixed transportation cost that depend on the distance grade.
+      # EW-specific fixed OM cost are given by v33_EW_transport_costs This cumulates a) completely fixed cost for mining, grinding and spreading; and b) fixed transportation cost that depend on the distance grade.
       # To allow interpretation of the LC, separate these cost components.
-      s33_costs_fix <- readGDX(gdx, "s33_costs_fix")
       p33_EW_transport_costs <- readGDX(gdx, c("p33_EW_transport_costs", "p33_transport_costs"), format = "first_found")
 
       EW_fixed_other_cost <- 10^12 * s33_costs_fix * v33_EW_onfield_sum
@@ -689,8 +688,6 @@ reportLCOE <- function(gdx, output.type = "both") {
           setNames(te_annual_OMV_cost[, , te_sco2] / cdrco2_byTech_tCO2[, ttot_from2005, te_sco2],
                    paste0("LCOCS|average|", "sco2|", te_sco2, "|carbon management", "|OMV Cost")),
           # specific to enhanced weathering
-          setNames(EW_fixed_other_cost[, , ] / cdrco2_byTech_tCO2[, ttot_from2005, EW_name],
-                   paste0("LCOCS|average|", "sco2|", EW_name, "|carbon management", "|OMF other Cost")),
           setNames(EW_fixed_transport_cost / cdrco2_byTech_tCO2[, ttot_from2005, EW_name],
                    paste0("LCOCS|average|", "sco2|", EW_name, "|carbon management", "|OMF transport Cost")),
           # sum for enhanced weathering (incl. special om cost)

--- a/R/reportLCOE.R
+++ b/R/reportLCOE.R
@@ -693,7 +693,7 @@ reportLCOE <- function(gdx, output.type = "both") {
           setNames((te_annual_inv_cost[, ttot_from2005, EW_name] +  te_annual_OMF_cost[, , EW_name] + te_annual_otherFuel_cost[, , EW_name] +
                       EW_fixed_transport_cost) / cdrco2_byTech_tCO2[, ttot_from2005, EW_name],
                    paste0("LCOCS|average|", "sco2|", EW_name, "|carbon management", "|Total Cost")),
-          setNames((te_annual_inv_cost_wadj[, ttot_from2005, EW_name] + te_annual_otherFuel_cost[, , EW_name] +
+          setNames((te_annual_inv_cost_wadj[, ttot_from2005, EW_name] + te_annual_OMF_cost[, , EW_name] + te_annual_otherFuel_cost[, , EW_name]  +
                       EW_fixed_transport_cost) / cdrco2_byTech_tCO2[, ttot_from2005, EW_name],
                    paste0("LCOCS|average|", "sco2|", EW_name, "|carbon management", "|Total Cost w/ Adj Cost"))
         )


### PR DESCRIPTION
## Purpose of this PR 
Adjustments in connection to [REMIND-PR 2411](https://github.com/remindmodel/remind/pull/2411)
- Renaming of `s33_co2_rem_pot` to `s33_rockRemPot`
- Deletion of `s33_costs_fix` and renaming of `vm_omcosts_cdr` to `vm_EW_transport_costs `

## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

