### PR TITLE
add "Carbon Management|Storage" to cumulated variables

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '5186162'
+ValidationKey: '5210100'
 AcceptedWarnings:
 - .*following variables are expected in the piamInterfaces.*
 - Summation checks have revealed some gaps.*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'remind2: The REMIND R package (2nd generation)'
-version: 2.5.1
-date-released: '2026-07-28'
+version: 2.5.2
+date-released: '2026-08-10'
 abstract: Contains the REMIND-specific routines for data and model output manipulation.
 authors:
 - family-names: Rodrigues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: remind2
 Title: The REMIND R package (2nd generation)
-Version: 2.5.1
-Date: 2026-07-28
+Version: 2.5.2
+Date: 2026-08-10
 Authors@R: c(
     person("Renato", "Rodrigues", , "renato.rodrigues@pik-potsdam.de", role = c("aut", "cre")),
     person("Lavinia", "Baumstark", role = "aut"),

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -3781,7 +3781,8 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
     vars %>%
       deletePlus() %>% # remove all + from extended variables: summation checks only make sense if all sub-variables are covered
       sub("^Emi\\|CO2", paste0("Emi|CO2|", addedString), .) %>%
-      sub("^Emi\\|GHG", paste0("Emi|GHG|", addedString), .)
+      sub("^Emi\\|GHG", paste0("Emi|GHG|", addedString), .) %>%
+      sub("^Carbon Management\\|Storage", paste0("Carbon Management|Storage|", addedString), .)
   }
 
   # emissions variables with bunkers. Insert 'w/ Bunkers' into variable name
@@ -3838,7 +3839,8 @@ reportEmi <- function(gdx, output = NULL, regionSubsetList = NULL,
     "Emi|CO2|CDR|+|EW (Mt CO2/yr)",
     "Emi|CO2|CDR|+|OAE (Mt CO2/yr)",
     "Emi|CO2|CDR|+|Land-Use Change (Mt CO2/yr)",
-    "Emi|CO2|CDR|+|Materials (Mt CO2/yr)"
+    "Emi|CO2|CDR|+|Materials (Mt CO2/yr)",
+    "Carbon Management|Storage (Mt CO2/yr)"
   ) %>%
     intersect(getNames(out)) # keep only variables that are in out
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package (2nd generation)
 
-R package **remind2**, version **2.5.1**
+R package **remind2**, version **2.5.2**
 
    [![R build status](https://github.com/pik-piam/remind2/workflows/check/badge.svg)](https://github.com/pik-piam/remind2/actions) [![codecov](https://codecov.io/gh/pik-piam/remind2/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/remind2) [![r-universe](https://pik-piam.r-universe.dev/badges/remind2)](https://pik-piam.r-universe.dev/builds)
 
@@ -37,8 +37,8 @@ The package comes with vignettes describing the basic functionality of the packa
 
 ```r
 vignette("compareScenariosRemind2") # compareScenarios in remind2
-vignette("remind_summary")          # Adding plots to the REMIND_summary.pdf
 vignette("remind2_reporting")       # remind2 reporting
+vignette("remind_summary")          # Adding plots to the REMIND_summary.pdf
 ```
 
 ## Questions / Problems
@@ -49,7 +49,7 @@ In case of questions / problems please contact Renato Rodrigues <renato.rodrigue
 
 To cite package **remind2** in publications use:
 
-Rodrigues R, Baumstark L, Benke F, Bantje D, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Lécuyer F, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Odenweller A, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Rüter T, Salzwedel R, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2026). "remind2: The REMIND R package (2nd generation)." Version: 2.5.1, <https://github.com/pik-piam/remind2>.
+Rodrigues R, Baumstark L, Benke F, Bantje D, Dietrich J, Dirnaichner A, Dorndorf T, Duerrwaechter J, Führlich P, Giannousakis A, Hasse R, Hilaire J, Klein D, Koch J, Kowalczyk K, Lécuyer F, Levesque A, Malik A, Merfort A, Merfort L, Morena-Leiva S, Odenweller A, Pehl M, Pietzcker R, Rauner S, Richters O, Rottoli M, Rüter T, Salzwedel R, Schötz C, Schreyer F, Siala K, Sörgel B, Spahr M, Strefler J, Verpoort P, Weigmann P (2026). "remind2: The REMIND R package (2nd generation)." Version: 2.5.2, <https://github.com/pik-piam/remind2>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,9 +57,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {remind2: The REMIND R package (2nd generation)},
   author = {Renato Rodrigues and Lavinia Baumstark and Falk Benke and David Bantje and Jan Philipp Dietrich and Alois Dirnaichner and Tabea Dorndorf and Jakob Duerrwaechter and Pascal Führlich and Anastasis Giannousakis and Robin Hasse and Jérome Hilaire and David Klein and Johannes Koch and Katarzyna Kowalczyk and Fabrice Lécuyer and Antoine Levesque and Aman Malik and Anne Merfort and Leon Merfort and Simón Morena-Leiva and Adrian Odenweller and Michaja Pehl and Robert Pietzcker and Sebastian Rauner and Oliver Richters and Marianna Rottoli and Tonn Rüter and Robert Salzwedel and Christof Schötz and Felix Schreyer and Kais Siala and Björn Sörgel and Mike Spahr and Jessica Strefler and Philipp Verpoort and Pascal Weigmann},
-  date = {2026-07-28},
+  date = {2026-08-10},
   year = {2026},
   url = {https://github.com/pik-piam/remind2},
-  note = {Version: 2.5.1},
+  note = {Version: 2.5.2},
 }
 ```

--- a/man/calc_regionSubset_sums.Rd
+++ b/man/calc_regionSubset_sums.Rd
@@ -7,13 +7,13 @@
 calc_regionSubset_sums(data, regionSubsetList)
 }
 \arguments{
-\item{data}{A \code{\link[magclass:magclass]{MAgPIE}} object.}
+\item{data}{A \code{\link[magclass:magclass-package]{MAgPIE}} object.}
 
 \item{regionSubsetList}{A list of region subsets to calculate of the form
 \verb{list(subset_name = c(region_A, region_B, ...)}}
 }
 \value{
-A \code{\link[magclass:magclass]{MAgPIE}} object.
+A \code{\link[magclass:magclass-package]{MAgPIE}} object.
 }
 \description{
 Sum up values in \code{data} for all sets of regions in \code{regionSubsetList}.


### PR DESCRIPTION
## Purpose of this PR
Add "Carbon Management|Storage" to cumulated emission variables. Had been intended with #773  but was overwritten shortly after.


## Checklist:
I checked the tests when running buildLibrary and made sure that my changes
- [x] do not create new complaints about summation checks.
- [x] do not create new complaints about missing variables that are expected in the piamInterfaces package. (If needed, adjust piamInterfaces mappings based on the [README.md](https://github.com/pik-piam/piamInterfaces/blob/master/README.md#renaming-a-piam_variable). In case of complaints unrelated to your changes that you are unable to fix, please open an issue in piamInterfaces.)

